### PR TITLE
fix: allowed reconciliation tables

### DIFF
--- a/api/upstream.go
+++ b/api/upstream.go
@@ -7,9 +7,15 @@ import (
 	"github.com/flanksource/duty/upstream"
 )
 
-var TablesToReconcile = []string{
+// List of tables that a mission-control UPSTREAM should allow reconciliation
+// from other agents.
+var AllowedReconciliationTables = []string{
 	"topologies",
 	"components",
+	"config_scrapers",
+	"config_items",
+	"canaries",
+	"checks",
 }
 
 var UpstreamConf upstream.UpstreamConfig

--- a/jobs/upstream.go
+++ b/jobs/upstream.go
@@ -30,13 +30,15 @@ var SyncWithUpstream = &job.Job{
 	Fn: func(ctx job.JobRuntime) error {
 		ctx.History.ResourceType = job.ResourceTypeUpstream
 		ctx.History.ResourceID = api.UpstreamConf.Host
-		for _, table := range api.TablesToReconcile {
+		tablesToReconcile := []string{"topologies", "components"}
+		for _, table := range tablesToReconcile {
 			if count, err := reconcileTable(ctx.Context, table); err != nil {
 				ctx.History.AddError(err.Error())
 			} else {
 				ctx.History.SuccessCount += count
 			}
 		}
+
 		return nil
 	},
 }

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -28,8 +28,8 @@ func RegisterRoutes(e *echo.Echo) {
 	upstreamGroup.GET("/ping", upstream.PingHandler(agentIDCache))
 	upstreamGroup.POST("/push", upstream.PushHandler(agentIDCache))
 	upstreamGroup.DELETE("/push", upstream.DeleteHandler(agentIDCache))
-	upstreamGroup.GET("/pull/:agent_name", upstream.PullHandler(api.TablesToReconcile))
-	upstreamGroup.GET("/status/:agent_name", upstream.StatusHandler(api.TablesToReconcile))
+	upstreamGroup.GET("/pull/:agent_name", upstream.PullHandler(api.AllowedReconciliationTables))
+	upstreamGroup.GET("/status/:agent_name", upstream.StatusHandler(api.AllowedReconciliationTables))
 	upstreamGroup.GET("/canary/pull/:agent_name", PullCanaries)
 	upstreamGroup.GET("/scrapeconfig/pull/:agent_name", PullScrapeConfigs)
 


### PR DESCRIPTION
Distinguishes between the tables a mc agent should reconcile and the tables a mc upstream should allow reconciliation.


Fixes
![image](https://github.com/flanksource/mission-control/assets/13419481/85039554-292b-49a8-9445-baee43f9fdc9)
