### PR TITLE
fix: set batchsize and consumer count in async event queue handler

### DIFF
--- a/upstream/events.go
+++ b/upstream/events.go
@@ -13,5 +13,5 @@ func init() {
 
 func RegisterEvents(ctx context.Context) {
 	deleteConsumer := upstream.NewDeleteFromUpstreamConsumer(api.UpstreamConf)
-	events.RegisterAsyncHandler(deleteConsumer, 50, 5, upstream.EventPushQueueDelete)
+	events.RegisterAsyncHandler(deleteConsumer, 100, 10, upstream.EventPushQueueDelete)
 }


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/897

the batch size and num of consumers that were set when registering an async handler were ignored.