### PR TITLE
chore: bump duty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.25.0 // indirect
 	github.com/flanksource/commons v1.22.1
-	github.com/flanksource/duty v1.0.432
+	github.com/flanksource/duty v1.0.433
 	github.com/flanksource/gomplate/v3 v3.24.7
 	github.com/flanksource/kopper v1.0.8
 	github.com/flanksource/postq v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -855,8 +855,8 @@ github.com/flanksource/artifacts v1.0.3 h1:Ci26mDhVFyxPefX96tgPGTe5fR0wfntXotSxa
 github.com/flanksource/artifacts v1.0.3/go.mod h1:KfDDG7B4wsiGqJYOamcRU19u5hBvpYjlru3GfcORvko=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.432 h1:ygwyxAXWgisSzpKEAtDm7AyY8+Be21BTGTrTaLisRDw=
-github.com/flanksource/duty v1.0.432/go.mod h1:GNckeTl2cnxQepuHJAH0b8xEaLsAnx9kQZs+VIPDnXc=
+github.com/flanksource/duty v1.0.433 h1:Mhbt/yc3Cv8Af/YN697eMuDeWoZKZZ0QkuvNxzzMOTU=
+github.com/flanksource/duty v1.0.433/go.mod h1:GNckeTl2cnxQepuHJAH0b8xEaLsAnx9kQZs+VIPDnXc=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.7 h1:XVIwcOTIR9l95D+jaerHcqRFN2Mo6MNEMttxsEsZ9aY=
 github.com/flanksource/gomplate/v3 v3.24.7/go.mod h1:7SJHGdFITvw3I8qf/ppF1BXbL2/ENyI5vpQkWt8MHtU=

--- a/hack/generate-schemas/go.mod
+++ b/hack/generate-schemas/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/exaring/otelpgx v0.5.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flanksource/duty v1.0.432 // indirect
+	github.com/flanksource/duty v1.0.433 // indirect
 	github.com/flanksource/gomplate/v3 v3.24.7 // indirect
 	github.com/flanksource/is-healthy v1.0.4 // indirect
 	github.com/flanksource/kommons v0.31.4 // indirect

--- a/hack/generate-schemas/go.sum
+++ b/hack/generate-schemas/go.sum
@@ -736,8 +736,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flanksource/commons v1.22.1 h1:Ycg8r26bx537UTdAEFgngDW1r2j5bX6Lr3NGxLICpiw=
 github.com/flanksource/commons v1.22.1/go.mod h1:GD5+yGvmYFPIW3WMNN+y1JkeDMJY74e05pQAsRbrvwY=
-github.com/flanksource/duty v1.0.432 h1:ygwyxAXWgisSzpKEAtDm7AyY8+Be21BTGTrTaLisRDw=
-github.com/flanksource/duty v1.0.432/go.mod h1:GNckeTl2cnxQepuHJAH0b8xEaLsAnx9kQZs+VIPDnXc=
+github.com/flanksource/duty v1.0.433 h1:Mhbt/yc3Cv8Af/YN697eMuDeWoZKZZ0QkuvNxzzMOTU=
+github.com/flanksource/duty v1.0.433/go.mod h1:GNckeTl2cnxQepuHJAH0b8xEaLsAnx9kQZs+VIPDnXc=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.7 h1:XVIwcOTIR9l95D+jaerHcqRFN2Mo6MNEMttxsEsZ9aY=
 github.com/flanksource/gomplate/v3 v3.24.7/go.mod h1:7SJHGdFITvw3I8qf/ppF1BXbL2/ENyI5vpQkWt8MHtU=


### PR DESCRIPTION
fixes: `config_detail` view. Returns health and ready.