### PR TITLE
feat: public url

### DIFF
--- a/api/global.go
+++ b/api/global.go
@@ -17,7 +17,10 @@ var (
 	Namespace         string
 
 	// Full URL of the mission control web UI.
-	PublicWebURL string
+	FrontendURL string
+
+	// Full URL of the mission contorl backend.
+	PublicURL string
 
 	// DefaultArtifactConnection is the connection that's used to save all playbook artifacts.
 	DefaultArtifactConnection string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,12 +85,13 @@ var (
 )
 
 func ServerFlags(flags *pflag.FlagSet) {
-	flags.IntVar(&httpPort, "httpPort", 8080, "Port to expose a health dashboard")
+	flags.IntVar(&httpPort, "httpPort", 8080, "Server port")
 	flags.StringVar(&api.Namespace, "namespace", utils.Coalesce(os.Getenv("NAMESPACE"), "default"), "Namespace to use for config/secret lookups")
 	flags.IntVar(&devGuiPort, "devGuiPort", 3004, "Port used by a local npm server in development mode")
 	flags.IntVar(&metricsPort, "metricsPort", 8081, "Port to expose a health dashboard ")
 	flags.BoolVar(&dev, "dev", false, "Run in development mode")
-	flags.StringVar(&api.PublicWebURL, "public-endpoint", "http://localhost:3000", "Public endpoint this instance is exposed under")
+	flags.StringVar(&api.FrontendURL, "frontend-url", "http://localhost:3000", "URL of the frontend")
+	flags.StringVar(&api.PublicURL, "public-endpoint", "http://localhost:8080", "Public endpoint this instance is exposed under")
 	flags.StringVar(&api.ApmHubPath, "apm-hub", "http://apm-hub:8080", "APM Hub URL")
 	flags.StringVar(&api.ConfigDB, "config-db", "http://config-db:8080", "Config DB URL")
 	flags.StringVar(&auth.KratosAPI, "kratos-api", "http://kratos-public:80", "Kratos API service")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -86,7 +86,7 @@ var Serve = &cobra.Command{
 	PreRun: PreRun,
 	Run: func(cmd *cobra.Command, args []string) {
 		// PostgREST needs to know how it is exposed to create the correct links
-		db.HttpEndpoint = api.PublicWebURL + "/db"
+		db.HttpEndpoint = api.PublicURL + "/db"
 
 		ctx := context.NewContext(gocontext.Background(), commonsCtx.WithTracer(otel.GetTracerProvider().Tracer("mission-control"))).
 			WithDB(db.Gorm, db.Pool).

--- a/echo/kube_config_download.go
+++ b/echo/kube_config_download.go
@@ -39,7 +39,7 @@ type kubeConfigData struct {
 }
 
 func DownloadKubeConfig(c echo.Context) error {
-	parsed, err := url.Parse(api.PublicWebURL)
+	parsed, err := url.Parse(api.PublicURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse public web url")
 	}

--- a/notification/events.go
+++ b/notification/events.go
@@ -240,7 +240,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		env["status"] = checkStatus.AsMap()
 		env["canary"] = canary.AsMap("spec")
 		env["check"] = check.AsMap("spec")
-		env["permalink"] = fmt.Sprintf("%s/health?layout=table&checkId=%s&timeRange=1h", api.PublicWebURL, check.ID)
+		env["permalink"] = fmt.Sprintf("%s/health?layout=table&checkId=%s&timeRange=1h", api.FrontendURL, check.ID)
 	}
 
 	if event.Name == "incident.created" || strings.HasPrefix(event.Name, "incident.status.") {
@@ -254,7 +254,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		}
 
 		env["incident"] = incident.AsMap()
-		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.PublicWebURL, incident.ID)
+		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.FrontendURL, incident.ID)
 	}
 
 	if strings.HasPrefix(event.Name, "incident.responder.") {
@@ -275,7 +275,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 
 		env["incident"] = incident.AsMap()
 		env["responder"] = responder.AsMap()
-		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.PublicWebURL, incident.ID)
+		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.FrontendURL, incident.ID)
 	}
 
 	if strings.HasPrefix(event.Name, "incident.comment.") {
@@ -303,7 +303,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		env["incident"] = incident.AsMap()
 		env["comment"] = comment.AsMap()
 		env["author"] = author.AsMap()
-		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.PublicWebURL, incident.ID)
+		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.FrontendURL, incident.ID)
 	}
 
 	if strings.HasPrefix(event.Name, "incident.dod.") {
@@ -327,7 +327,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		env["evidence"] = evidence.AsMap()
 		env["hypotheses"] = hypotheses.AsMap()
 		env["incident"] = incident.AsMap()
-		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.PublicWebURL, incident.ID)
+		env["permalink"] = fmt.Sprintf("%s/incidents/%s", api.FrontendURL, incident.ID)
 	}
 
 	if strings.HasPrefix(event.Name, "component.") {
@@ -353,7 +353,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		component.Status = types.ComponentStatus(event.Properties["status"])
 
 		env["component"] = component.AsMap("checks", "incidents", "analysis", "components", "order", "relationship_id", "children", "parents")
-		env["permalink"] = fmt.Sprintf("%s/topology/%s", api.PublicWebURL, componentID)
+		env["permalink"] = fmt.Sprintf("%s/topology/%s", api.FrontendURL, componentID)
 	}
 
 	if strings.HasPrefix(event.Name, "config.") {
@@ -379,7 +379,7 @@ func getEnvForEvent(ctx context.Context, event postq.Event, properties map[strin
 		config.Status = lo.ToPtr(event.Properties["status"])
 
 		env["config"] = config.AsMap("last_scraped_time", "path", "parent_id")
-		env["permalink"] = fmt.Sprintf("%s/catalog/%s", api.PublicWebURL, configID)
+		env["permalink"] = fmt.Sprintf("%s/catalog/%s", api.FrontendURL, configID)
 	}
 
 	return env, nil


### PR DESCRIPTION
We need URL of the frontend and the backend.

Frontend is used to form links in the notifications.
Backend is used to as server url when forming kubeconfig.