### PR TITLE
fix: kubeproxy & kubeconfig

### DIFF
--- a/echo/kube_config_download.go
+++ b/echo/kube_config_download.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 
 	dutyAPI "github.com/flanksource/duty/api"
@@ -46,7 +47,7 @@ func DownloadKubeConfig(c echo.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse public web url")
 	}
-	parsed.Path = "/kubeproxy"
+	parsed.Path = path.Join(parsed.Path, "kubeproxy")
 
 	kcd := kubeConfigData{
 		Server:      parsed.String(),


### PR DESCRIPTION
* when reading token `\n` was appended and Auth header value would be invalid
* in the kubeconfig set user instead of token so kubectl doesn't ask for basic auth