### PR TITLE
fix: override action if default is unset

### DIFF
--- a/rbac/middleware.go
+++ b/rbac/middleware.go
@@ -68,7 +68,10 @@ func Authorization(object, action string) MiddlewareFunc {
 				return next(c)
 			}
 
-			action = GetActionFromHttpMethod(c.Request().Method)
+			// If action is unset, extract from HTTP Method
+			if action == "" {
+				action = GetActionFromHttpMethod(c.Request().Method)
+			}
 
 			ctx := c.Request().Context().(context.Context)
 			u := ctx.User()


### PR DESCRIPTION
Queries like POST catalog/summary are failing as they are marked as read but we are overriding it always by extracting from Method