### PR TITLE
feat: use new Slack module to send slack notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ docker-push:
 tidy:
 	go mod tidy
 	git add go.mod go.sum
-	cd hack/generate-schemas && go mod tidy && 	git add go.mod go.sum
 
 .PHONY: compress
 compress: .bin/upx

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/samber/lo v1.47.0
 	github.com/samber/oops v1.13.1
 	github.com/samber/slog-echo v1.14.4
+	github.com/slack-go/slack v0.14.0
 	github.com/tg123/go-htpasswd v1.2.2
 	github.com/timberio/go-datemath v0.1.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.44.0
@@ -155,6 +156,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
@@ -1136,6 +1136,7 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosimple/slug v1.13.1 h1:bQ+kpX9Qa6tHRaK+fZR0A0M2Kd7Pa5eHPPsb1JpHD+Q=
 github.com/gosimple/slug v1.13.1/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
@@ -1516,6 +1517,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
+github.com/slack-go/slack v0.14.0 h1:6c0UTfbRnvRssZUsZ2qe0Iu07VAMPjRqOa6oX8ewF4k=
+github.com/slack-go/slack v0.14.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=

--- a/notification/events.go
+++ b/notification/events.go
@@ -240,7 +240,7 @@ func sendNotifications(ctx context.Context, events models.Events) models.Events 
 			e.SetError(err.Error())
 			failedEvents = append(failedEvents, e)
 			notificationContext.WithError(err.Error())
-		} else if err := SendNotification(notificationContext, payload, celEnv); err != nil {
+		} else if err := PrepareAndSendEventNotification(notificationContext, payload, celEnv); err != nil {
 			e.SetError(err.Error())
 			failedEvents = append(failedEvents, e)
 			notificationContext.WithError(err.Error())

--- a/notification/send.go
+++ b/notification/send.go
@@ -158,7 +158,7 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, celEnv m
 		// We know we are sending to slack.
 		// Send the notification with slack-api and don't go through Shoutrrr.
 		celEnv["outgoing_channel"] = "slack"
-		templater := ctx.NewStructTemplater(celEnv, "", nil)
+		templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
 		if err := templater.Walk(&data); err != nil {
 			return "", fmt.Errorf("error templating notification: %w", err)
 		}
@@ -186,11 +186,11 @@ func defaultTitleAndBody(event string) (title string, body string) {
 	switch event {
 	case api.EventCheckPassed:
 		title = `{{ if ne outgoing_channel "slack"}}Check {{.check.name}} has passed{{end}}`
-		body = fmt.Sprintf(string(content), labelsTemplate(".check.labels"))
+		body = string(content)
 
 	case api.EventCheckFailed:
 		title = `{{ if ne outgoing_channel "slack"}}Check {{.check.name}} has failed{{end}}`
-		body = fmt.Sprintf(string(content), labelsTemplate(".check.labels"))
+		body = string(content)
 
 	case api.EventConfigHealthy, api.EventConfigUnhealthy, api.EventConfigWarning, api.EventConfigUnknown:
 		title = "{{.config.type}} {{.config.name}} is {{.config.health}}"

--- a/notification/send.go
+++ b/notification/send.go
@@ -157,7 +157,7 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, celEnv m
 	if connection != nil && connection.Type == models.ConnectionTypeSlack {
 		// We know we are sending to slack.
 		// Send the notification with slack-api and don't go through Shoutrrr.
-		celEnv["outgoing_channel"] = "slack"
+		celEnv["channel"] = "slack"
 		templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
 		if err := templater.Walk(&data); err != nil {
 			return "", fmt.Errorf("error templating notification: %w", err)
@@ -165,7 +165,7 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, celEnv m
 		return "slack", SlackSend(ctx, connection.Password, connection.Username, data)
 	}
 
-	service, err := shoutrrrSend(ctx, nil, shoutrrrURL, data)
+	service, err := shoutrrrSend(ctx, celEnv, shoutrrrURL, data)
 	if err != nil {
 		return "", fmt.Errorf("failed to send message with Shoutrrr: %w", err)
 	}
@@ -185,11 +185,11 @@ func defaultTitleAndBody(event string) (title string, body string) {
 
 	switch event {
 	case api.EventCheckPassed:
-		title = `{{ if ne outgoing_channel "slack"}}Check {{.check.name}} has passed{{end}}`
+		title = `{{ if ne channel "slack"}}Check {{.check.name}} has passed{{end}}`
 		body = string(content)
 
 	case api.EventCheckFailed:
-		title = `{{ if ne outgoing_channel "slack"}}Check {{.check.name}} has failed{{end}}`
+		title = `{{ if ne channel "slack"}}Check {{.check.name}} has failed{{end}}`
 		body = string(content)
 
 	case api.EventConfigHealthy, api.EventConfigUnhealthy, api.EventConfigWarning, api.EventConfigUnknown:

--- a/notification/shoutrrr.go
+++ b/notification/shoutrrr.go
@@ -76,7 +76,7 @@ func shoutrrrSend(ctx *Context, celEnv map[string]any, shoutrrrURL string, data 
 		data.Message = stripmd.StripOptions(data.Message, stripmd.Options{KeepURL: true})
 	}
 
-	celEnv["outgoing_channel"] = service
+	celEnv["channel"] = service
 	templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
 	if err := templater.Walk(&data); err != nil {
 		return "", fmt.Errorf("error templating notification: %w", err)

--- a/notification/shoutrrr.go
+++ b/notification/shoutrrr.go
@@ -77,7 +77,7 @@ func shoutrrrSend(ctx *Context, celEnv map[string]any, shoutrrrURL string, data 
 	}
 
 	celEnv["outgoing_channel"] = service
-	templater := ctx.NewStructTemplater(celEnv, "", nil)
+	templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
 	if err := templater.Walk(&data); err != nil {
 		return "", fmt.Errorf("error templating notification: %w", err)
 	}

--- a/notification/slack.go
+++ b/notification/slack.go
@@ -1,0 +1,9 @@
+package notification
+
+import "github.com/slack-go/slack"
+
+func SlackSend(ctx *Context, apiToken, channel string, msg NotificationTemplate) error {
+	api := slack.New(apiToken)
+	_, _, err := api.PostMessage(channel, slack.MsgOptionText(msg.Message, false))
+	return err
+}

--- a/notification/slack.go
+++ b/notification/slack.go
@@ -1,9 +1,37 @@
 package notification
 
-import "github.com/slack-go/slack"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+type SlackMsgTemplate struct {
+	Blocks slack.Blocks `json:"blocks"`
+}
 
 func SlackSend(ctx *Context, apiToken, channel string, msg NotificationTemplate) error {
 	api := slack.New(apiToken)
-	_, _, err := api.PostMessage(channel, slack.MsgOptionText(msg.Message, false))
+
+	var opts []slack.MsgOption
+	if msg.Title != "" {
+		opts = append(opts, slack.MsgOptionText(msg.Title, false))
+	}
+
+	if msg.Message != "" {
+		if strings.Contains(msg.Message, `"blocks"`) {
+			var slackMsg SlackMsgTemplate
+			if err := json.Unmarshal([]byte(msg.Message), &slackMsg); err != nil {
+				return err
+			}
+
+			opts = append(opts, slack.MsgOptionBlocks(slackMsg.Blocks.BlockSet...))
+		} else {
+			opts = append(opts, slack.MsgOptionText(msg.Message, false))
+		}
+	}
+
+	_, _, err := api.PostMessage(channel, opts...)
 	return err
 }

--- a/notification/template.go
+++ b/notification/template.go
@@ -1,21 +1,48 @@
 package notification
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
 var templateFuncs = map[string]any{
-	"labelsFormat": func(field map[string]any) string {
-		if len(field) == 0 {
+	"labelsFormat": func(labels map[string]any) string {
+		if len(labels) == 0 {
 			return ""
 		}
 
 		output := "### Labels:\n"
-		for k, v := range field {
+		for k, v := range labels {
 			output += fmt.Sprintf("**%s**: %s \n", k, v)
 		}
 
 		return output
+	},
+	"slackSectionLabels": func(labels map[string]any) string {
+		if len(labels) == 0 {
+			return ""
+		}
+
+		var fields []any
+		for k, v := range labels {
+			fields = append(fields, map[string]any{
+				"type":     "mrkdwn",
+				"text":     fmt.Sprintf("*%s*: %s", k, v),
+				"verbatim": true,
+			})
+		}
+
+		var m = map[string]any{
+			"type":   "section",
+			"fields": fields,
+			"text": map[string]any{
+				"type": "mrkdwn",
+				"text": "*Labels*",
+			},
+		}
+
+		out, _ := json.Marshal(m)
+		return string(out)
 	},
 	"slackSectionTextFieldMD": func(text string) string {
 		return fmt.Sprintf(`{
@@ -40,5 +67,22 @@ var templateFuncs = map[string]any{
 				"text": %q
 			}
 		}`, text)
+	},
+	"slackURLAction": func(name, url string) string {
+		return fmt.Sprintf(`{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "%s",
+						"emoji": true
+					},
+					"url": "%s",
+					"action_id": "%s"
+				}
+			]
+		}`, name, url, name)
 	},
 }

--- a/notification/template.go
+++ b/notification/template.go
@@ -1,0 +1,44 @@
+package notification
+
+import (
+	"fmt"
+)
+
+var templateFuncs = map[string]any{
+	"labelsFormat": func(field map[string]any) string {
+		if len(field) == 0 {
+			return ""
+		}
+
+		output := "### Labels:\n"
+		for k, v := range field {
+			output += fmt.Sprintf("**%s**: %s \n", k, v)
+		}
+
+		return output
+	},
+	"slackSectionTextFieldMD": func(text string) string {
+		return fmt.Sprintf(`{
+			"type": "mrkdwn",
+			"text": %q
+		}`, text)
+	},
+	"slackSectionTextMD": func(text string) string {
+		return fmt.Sprintf(`{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": %q
+			}
+		}`, text)
+	},
+	"slackSectionTextPlain": func(text string) string {
+		return fmt.Sprintf(`{
+			"type": "section",
+			"text": {
+				"type": "plain_text",
+				"text": %q
+			}
+		}`, text)
+	},
+}

--- a/notification/templates/check.failed
+++ b/notification/templates/check.failed
@@ -1,0 +1,56 @@
+{{ if eq outgoing_channel "slack"}}
+{
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": ":red_circle: *{{.check.name}}* is _unhealthy_"
+			}
+		},
+		{{ if .status.message}}{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "{{.status.message}}"
+			}
+		},{{end}}
+		{
+			"type": "section",
+			"fields": [
+				{
+					"type": "mrkdwn",
+					"text": "*Canary*: {{.canary.name }}"
+				}{{ if .status.message}},
+				{
+					"type": "mrkdwn",
+					"text": "*Agent*: {{.agent.name}}",
+					"verbatim": true
+				}{{end}}
+			]
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "View Health Check",
+						"emoji": true
+					},
+					"url": "{{.permalink}}",
+					"action_id": "health_check_button"
+				}
+			]
+		}
+	]
+}
+{{ else }}
+Canary: {{.canary.name}}
+{{if .agent}}Agent: {{.agent.name}}{{end}}
+Error: {{.status.error}}
+%s
+
+[Reference]({{.permalink}})
+{{end}}

--- a/notification/templates/check.failed
+++ b/notification/templates/check.failed
@@ -1,32 +1,16 @@
 {{ if eq outgoing_channel "slack"}}
 {
 	"blocks": [
-		{
-			"type": "section",
-			"text": {
-				"type": "mrkdwn",
-				"text": ":red_circle: *{{.check.name}}* is _unhealthy_"
-			}
-		},
-		{{ if .status.message}}{
-			"type": "section",
-			"text": {
-				"type": "mrkdwn",
-				"text": "{{.status.message}}"
-			}
-		},{{end}}
+		{{slackSectionTextMD (printf `:red_circle: *%s* is _unhealthy_` .check.name)}},
+		{{ if .status.message}}{{slackSectionTextMD status.message}},{{end}}
 		{
 			"type": "section",
 			"fields": [
-				{
-					"type": "mrkdwn",
-					"text": "*Canary*: {{.canary.name }}"
-				}{{ if .status.message}},
-				{
-					"type": "mrkdwn",
-					"text": "*Agent*: {{.agent.name}}",
-					"verbatim": true
-				}{{end}}
+				{{slackSectionTextFieldMD (printf `*Canary*: %s` .canary.name) }},
+				{{slackSectionTextFieldMD (printf `*Namespace*: %s` .canary.namespace) }}
+				{{ if .agent.name}}
+					,{{slackSectionTextFieldMD (printf `*Agent*: %s` .agent.name) }}
+				{{end}}
 			]
 		},
 		{
@@ -50,7 +34,7 @@
 Canary: {{.canary.name}}
 {{if .agent}}Agent: {{.agent.name}}{{end}}
 Error: {{.status.error}}
-%s
+{{labelsFormat .check.labels}}
 
 [Reference]({{.permalink}})
 {{end}}

--- a/notification/templates/check.failed
+++ b/notification/templates/check.failed
@@ -1,8 +1,9 @@
-{{ if eq outgoing_channel "slack"}}
+{{ if eq channel "slack"}}
 {
 	"blocks": [
 		{{slackSectionTextMD (printf `:red_circle: *%s* is _unhealthy_` .check.name)}},
-		{{ if .status.message}}{{slackSectionTextMD status.message}},{{end}}
+    {"type": "divider"},
+		{{ if .status.error}}{{slackSectionTextMD status.error}},{{end}}
 		{
 			"type": "section",
 			"fields": [
@@ -13,21 +14,8 @@
 				{{end}}
 			]
 		},
-		{
-			"type": "actions",
-			"elements": [
-				{
-					"type": "button",
-					"text": {
-						"type": "plain_text",
-						"text": "View Health Check",
-						"emoji": true
-					},
-					"url": "{{.permalink}}",
-					"action_id": "health_check_button"
-				}
-			]
-		}
+		{{ if .check.labels}}{{slackSectionLabels .check.labels}},{{end}}
+		{{ slackURLAction "View Health Check" .permalink}}
 	]
 }
 {{ else }}

--- a/notification/templates/check.passed
+++ b/notification/templates/check.passed
@@ -1,0 +1,56 @@
+{{ if eq outgoing_channel "slack"}}
+{
+	"blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": ":large_green_circle: *{{.check.name}}* is _healthy_"
+      }
+    },
+    {{ if .status.message}}{
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "{{.status.message}}"
+      }
+    },{{end}}
+    {
+      "type": "section",
+      "fields": [
+        {
+          "type": "mrkdwn",
+          "text": "*Canary*: {{.canary.name }}"
+        }{{ if .status.message}},
+        {
+          "type": "mrkdwn",
+          "text": "*Agent*: {{.agent.name}}",
+          "verbatim": true
+        }{{end}}
+      ]
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "View Health Check",
+            "emoji": true
+          },
+          "url": "{{.permalink}}",
+          "action_id": "health_check_button"
+        }
+      ]
+    }
+  ]
+}
+{{ else }}
+Canary: {{.canary.name}}
+{{if .agent}}Agent: {{.agent.name}}{{end}}
+{{if .status.message}}Message: {{.status.message}} {{end}}
+%s
+
+[Reference]({{.permalink}})
+{{end}}

--- a/notification/templates/check.passed
+++ b/notification/templates/check.passed
@@ -1,34 +1,18 @@
-{{ if eq outgoing_channel "slack"}}
+{{ if eq .outgoing_channel "slack"}}
 {
 	"blocks": [
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": ":large_green_circle: *{{.check.name}}* is _healthy_"
-      }
-    },
-    {{ if .status.message}}{
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "{{.status.message}}"
-      }
-    },{{end}}
-    {
-      "type": "section",
-      "fields": [
-        {
-          "type": "mrkdwn",
-          "text": "*Canary*: {{.canary.name }}"
-        }{{ if .status.message}},
-        {
-          "type": "mrkdwn",
-          "text": "*Agent*: {{.agent.name}}",
-          "verbatim": true
-        }{{end}}
-      ]
-    },
+    {{slackSectionTextMD (printf `:large_green_circle: *%s* is _healthy_` .canary.name)}},
+    {{ if .status.message}}{{slackSectionTextMD status.message}},{{end}}
+		{
+			"type": "section",
+			"fields": [
+				{{slackSectionTextFieldMD (printf `*Canary*: %s` .canary.name) }},
+				{{slackSectionTextFieldMD (printf `*Namespace*: %s` .canary.namespace) }}
+				{{ if .agent.name}}
+					,{{slackSectionTextFieldMD (printf `*Agent*: %s` .agent.name) }}
+				{{end}}
+			]
+		},
     {
       "type": "actions",
       "elements": [
@@ -50,7 +34,7 @@
 Canary: {{.canary.name}}
 {{if .agent}}Agent: {{.agent.name}}{{end}}
 {{if .status.message}}Message: {{.status.message}} {{end}}
-%s
+{{labelsFormat .check.labels}}
 
 [Reference]({{.permalink}})
 {{end}}

--- a/notification/templates/check.passed
+++ b/notification/templates/check.passed
@@ -1,7 +1,8 @@
-{{ if eq .outgoing_channel "slack"}}
+{{ if eq .channel "slack"}}
 {
 	"blocks": [
     {{slackSectionTextMD (printf `:large_green_circle: *%s* is _healthy_` .canary.name)}},
+    {"type": "divider"},
     {{ if .status.message}}{{slackSectionTextMD status.message}},{{end}}
 		{
 			"type": "section",
@@ -13,21 +14,8 @@
 				{{end}}
 			]
 		},
-    {
-      "type": "actions",
-      "elements": [
-        {
-          "type": "button",
-          "text": {
-            "type": "plain_text",
-            "text": "View Health Check",
-            "emoji": true
-          },
-          "url": "{{.permalink}}",
-          "action_id": "health_check_button"
-        }
-      ]
-    }
+    {{ if .check.labels}}{{slackSectionLabels .check.labels}},{{end}}
+    {{ slackURLAction "View Health Check" .permalink}}
   ]
 }
 {{ else }}

--- a/playbook/actions/notification.go
+++ b/playbook/actions/notification.go
@@ -14,5 +14,6 @@ type Notification struct {
 
 func (t *Notification) Run(ctx context.Context, action v1.NotificationAction) error {
 	notifContext := notification.NewContext(ctx, uuid.Nil)
-	return notification.Send(notifContext, action.Connection, action.URL, action.Title, action.Message, action.Properties)
+	_, err := notification.SendNotification(notifContext, action.Connection, action.URL, nil, notification.NotificationTemplate{Title: action.Title, Message: action.Message, Properties: action.Properties})
+	return err
 }


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/923

- needed quite a bit of refactoring because the templating of the notification title & body needs to be pushed to the very end of the pipeline instead of the very beginning. This is because now we need to template the message only after we've figured out the shoutrrr service we're sending to.