### PR TITLE
feat: save unsent notification using the new postgresql function

### DIFF
--- a/db/notifications.go
+++ b/db/notifications.go
@@ -165,3 +165,13 @@ func GetMatchingNotificationSilencesCount(ctx context.Context, resources models.
 
 	return count, nil
 }
+
+func SaveUnsentNotificationToHistory(ctx context.Context, sendHistory models.NotificationSendHistory, window time.Duration) error {
+	return ctx.DB().Exec("SELECT * FROM insert_unsent_notification_to_history(?, ?, ?, ?, ?)",
+		sendHistory.NotificationID,
+		sendHistory.SourceEvent,
+		sendHistory.ResourceID,
+		sendHistory.Status,
+		window,
+	).Error
+}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.25.0 // indirect
 	github.com/flanksource/commons v1.29.10
-	github.com/flanksource/duty v1.0.646
+	github.com/flanksource/duty v1.0.647
 	github.com/flanksource/gomplate/v3 v3.24.30
 	github.com/flanksource/kopper v1.0.10
 	github.com/gomarkdown/markdown v0.0.0-20240419095408-642f0ee99ae2

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ github.com/flanksource/artifacts v1.0.14 h1:Vv70bccsae0MwGaf/uSPp34J5V1/PyKfct9z
 github.com/flanksource/artifacts v1.0.14/go.mod h1:qHVCnQu5k50aWNJ5UhpcAKEl7pAzqUrFFKGSm147G70=
 github.com/flanksource/commons v1.29.10 h1:T/S95Pl8kASEFvQjQ7fJjTUqeVdhxQXg1vfkULTYFJQ=
 github.com/flanksource/commons v1.29.10/go.mod h1:iTbrXOSp3Spv570Nly97D/U9cQjLZoVlmWCXqWzsvRU=
-github.com/flanksource/duty v1.0.646 h1:5fXml/jsp1kxNyu4GxNXujExxg+bgxqLZhMQNglWLcE=
-github.com/flanksource/duty v1.0.646/go.mod h1:Oj9zIX94CR2U+nmnt97gNLMrsBWILyIhIBeJynIIgqE=
+github.com/flanksource/duty v1.0.647 h1:fc2x8TjmYTOztMVZd0H9TmU7XqRkpVT1ynkvU7atTNo=
+github.com/flanksource/duty v1.0.647/go.mod h1:Oj9zIX94CR2U+nmnt97gNLMrsBWILyIhIBeJynIIgqE=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.30 h1:6Y25KnAMX4iCuEXe1C8d1kB2PdV+zD1ZulZrv6DV14Q=
 github.com/flanksource/gomplate/v3 v3.24.30/go.mod h1:/lAM7+fkcCCfghCAjzdCqwgWxN5Ow8Sk6nkdFPjejCE=

--- a/notification/context.go
+++ b/notification/context.go
@@ -38,7 +38,7 @@ func (t *Context) EndLog() error {
 }
 
 func (t *Context) WithMessage(message string) {
-	t.log.Body = message
+	t.log.Body = &message
 }
 
 func (t *Context) WithRecipientType(recipientType RecipientType) {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -205,7 +205,10 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, func() {
 
 			// Check send history
 			var sentHistoryCount int64
-			err = DefaultContext.DB().Model(&models.NotificationSendHistory{}).Where("notification_id = ?", n.ID).Count(&sentHistoryCount).Error
+			err = DefaultContext.DB().Model(&models.NotificationSendHistory{}).
+				Where("notification_id = ?", n.ID).
+				Where("status = ?", models.NotificationStatusRepeatInterval).
+				Count(&sentHistoryCount).Error
 			Expect(err).To(BeNil())
 			Expect(sentHistoryCount).To(Equal(int64(1)))
 		})


### PR DESCRIPTION
* check silences -> repeat interval -> rate limits
* new metrics
  * `notification_silenced`
  * `notification_skipped_by_repeat_interval`
  
resolves: https://github.com/flanksource/mission-control/issues/1387