### PR TITLE
fix: playbook parameters rendering

### DIFF
--- a/playbook/controllers.go
+++ b/playbook/controllers.go
@@ -104,6 +104,7 @@ func HandleGetPlaybookParams(c echo.Context) error {
 
 	dummyRun := models.PlaybookRun{
 		PlaybookID: playbook.ID,
+		Spec:       playbook.Spec,
 		CreatedBy:  lo.ToPtr(ctx.User().ID),
 	}
 	if req.ComponentID != nil {


### PR DESCRIPTION
`CreateTemplateEnv` uses the spec from the run

resolves: https://github.com/flanksource/mission-control/issues/1441