### PR TITLE
fix: templating of notifications for SMTP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.25.0 // indirect
 	github.com/flanksource/commons v1.29.10
-	github.com/flanksource/duty v1.0.684
+	github.com/flanksource/duty v1.0.685
 	github.com/flanksource/gomplate/v3 v3.24.34
 	github.com/flanksource/kopper v1.0.10
 	github.com/gomarkdown/markdown v0.0.0-20240419095408-642f0ee99ae2

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ github.com/flanksource/artifacts v1.0.14 h1:Vv70bccsae0MwGaf/uSPp34J5V1/PyKfct9z
 github.com/flanksource/artifacts v1.0.14/go.mod h1:qHVCnQu5k50aWNJ5UhpcAKEl7pAzqUrFFKGSm147G70=
 github.com/flanksource/commons v1.29.10 h1:T/S95Pl8kASEFvQjQ7fJjTUqeVdhxQXg1vfkULTYFJQ=
 github.com/flanksource/commons v1.29.10/go.mod h1:iTbrXOSp3Spv570Nly97D/U9cQjLZoVlmWCXqWzsvRU=
-github.com/flanksource/duty v1.0.684 h1:wezpwqfsZzyBOivGKyn9g4+TSEx9TNQlTNwpwIddK6Y=
-github.com/flanksource/duty v1.0.684/go.mod h1:XM1Y1FfW0TB4HvuP/GjwS3ZDvJKYM5o1wobgRIyqkuA=
+github.com/flanksource/duty v1.0.685 h1:Nsq2Stsa7DndBg+ksKWyYmPeaOHVS8pmn5ldhHpCZWs=
+github.com/flanksource/duty v1.0.685/go.mod h1:XM1Y1FfW0TB4HvuP/GjwS3ZDvJKYM5o1wobgRIyqkuA=
 github.com/flanksource/gomplate/v3 v3.20.4/go.mod h1:27BNWhzzSjDed1z8YShO6W+z6G9oZXuxfNFGd/iGSdc=
 github.com/flanksource/gomplate/v3 v3.24.34 h1:KeA7bim1OzUqBXTftumgdacMlb3fGX95Y0kOtBduYGQ=
 github.com/flanksource/gomplate/v3 v3.24.34/go.mod h1:FdQHxnyrBSmT5zNJTDq08oXxD+eOqti4ERanSoDmQAU=

--- a/notification/cel.go
+++ b/notification/cel.go
@@ -10,7 +10,8 @@ import (
 )
 
 type celVariables struct {
-	Agent *models.Agent
+	Agent   *models.Agent
+	Channel string
 
 	ConfigItem  *models.ConfigItem
 	Component   *models.Component
@@ -68,13 +69,14 @@ func (t *celVariables) AsMap() map[string]any {
 	output := map[string]any{
 		"permalink":  t.Permalink,
 		"silenceURL": t.SilenceURL,
+		"channel":    t.Channel,
 
 		"agent":     lo.FromPtr(t.Agent).AsMap(),
 		"status":    lo.FromPtr(t.CheckStatus).AsMap(),
 		"check":     lo.FromPtr(t.Check).AsMap("spec"),
+		"config":    lo.FromPtr(t.ConfigItem).AsMap("spec"),
 		"canary":    lo.FromPtr(t.Canary).AsMap("spec"),
 		"component": lo.ToPtr(lo.FromPtr(t.Component)).AsMap("checks", "incidents", "analysis", "components", "order", "relationship_id", "children", "parents"),
-		"config":    lo.FromPtr(t.ConfigItem).AsMap("last_scraped_time", "path", "parent_id"),
 
 		"evidence":   lo.FromPtr(t.Evidence).AsMap(),
 		"hypothesis": lo.FromPtr(t.Hypothesis).AsMap(),

--- a/notification/send.go
+++ b/notification/send.go
@@ -121,7 +121,7 @@ func sendEventNotificationWithMetrics(ctx *Context, celEnv map[string]any, conne
 }
 
 func sendEventNotification(ctx *Context, celEnv map[string]any, connectionName, shoutrrrURL, eventName string, notification *NotificationWithSpec, customProperties map[string]string) (string, error) {
-	defaultTitle, defaultBody := defaultTitleAndBody(eventName)
+	defaultTitle, defaultBody := DefaultTitleAndBody(eventName)
 	customProperties = collections.MergeMap(notification.Properties, customProperties)
 	data := NotificationTemplate{
 		Title:      utils.Coalesce(notification.Title, defaultTitle),
@@ -155,7 +155,7 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, celEnv m
 		// We know we are sending to slack.
 		// Send the notification with slack-api and don't go through Shoutrrr.
 		celEnv["channel"] = "slack"
-		templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
+		templater := ctx.NewStructTemplater(celEnv, "", TemplateFuncs)
 		if err := templater.Walk(&data); err != nil {
 			return "", fmt.Errorf("error templating notification: %w", err)
 		}
@@ -175,9 +175,9 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, celEnv m
 	return service, nil
 }
 
-// defaultTitleAndBody returns the default title and body for notification
+// DefaultTitleAndBody returns the default title and body for notification
 // based on the given event.
-func defaultTitleAndBody(event string) (title string, body string) {
+func DefaultTitleAndBody(event string) (title string, body string) {
 	switch event {
 	case api.EventCheckPassed:
 		title = `{{ if ne channel "slack"}}Check {{.check.name}} has passed{{end}}`

--- a/notification/shoutrrr.go
+++ b/notification/shoutrrr.go
@@ -69,7 +69,7 @@ func PrepareShoutrrr(ctx *Context, celEnv map[string]any, shoutrrrURL string, da
 	}
 
 	celEnv["channel"] = service
-	templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
+	templater := ctx.NewStructTemplater(celEnv, "", TemplateFuncs)
 	if err := templater.Walk(data); err != nil {
 		return "", "", nil, fmt.Errorf("error templating notification: %w", err)
 	}

--- a/notification/shoutrrr.go
+++ b/notification/shoutrrr.go
@@ -64,6 +64,12 @@ func shoutrrrSend(ctx *Context, celEnv map[string]any, shoutrrrURL string, data 
 		return "", fmt.Errorf("failed to extract service name: %w", err)
 	}
 
+	celEnv["channel"] = service
+	templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
+	if err := templater.Walk(&data); err != nil {
+		return "", fmt.Errorf("error templating notification: %w", err)
+	}
+
 	switch service {
 	case "smtp":
 		data.Message = icUtils.MarkdownToHTML(data.Message)
@@ -74,12 +80,6 @@ func shoutrrrSend(ctx *Context, celEnv map[string]any, shoutrrrURL string, data 
 
 	default:
 		data.Message = stripmd.StripOptions(data.Message, stripmd.Options{KeepURL: true})
-	}
-
-	celEnv["channel"] = service
-	templater := ctx.NewStructTemplater(celEnv, "", templateFuncs)
-	if err := templater.Walk(&data); err != nil {
-		return "", fmt.Errorf("error templating notification: %w", err)
 	}
 
 	ctx.WithMessage(data.Message)

--- a/notification/shoutrrr_test.go
+++ b/notification/shoutrrr_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 
 	"github.com/flanksource/incident-commander/notification"
+	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe("Notification properties", func() {
@@ -57,4 +59,24 @@ var _ = ginkgo.Describe("Notification properties", func() {
 			}
 		})
 	}
+})
+
+var _ = ginkgo.Describe("Shoutrrr", func() {
+	ginkgo.It("should template smtp", func() {
+		env := map[string]any{
+			"config": map[string]any{
+				"name": "My Test Config",
+			},
+		}
+
+		ctx := notification.NewContext(DefaultContext, uuid.Nil)
+		data := notification.NotificationTemplate{
+			Message: `{{if .config.name}}{{.config.name}}{{else}}DefaultConfig{{end}}`,
+		}
+		url := "smtp://username:password@host:25/?from=test@flanksource.com&to=receiver@flanksource.com"
+
+		_, _, _, err := notification.PrepareShoutrrr(ctx, env, url, &data)
+		Expect(err).To(BeNil())
+		Expect(data.Message).To(Equal("<p>My Test Config</p>\n"))
+	})
 })

--- a/notification/suite_test.go
+++ b/notification/suite_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 var _ = ginkgo.BeforeSuite(func() {
-	DefaultContext = setup.BeforeSuiteFn(setup.WithoutDummyData)
+	DefaultContext = setup.BeforeSuiteFn()
 	_ = context.UpdateProperty(DefaultContext, api.PropertyIncidentsDisabled, "true")
 	_ = context.UpdateProperty(DefaultContext, "notification.send.trace", "true")
 	events.StartConsumers(DefaultContext)

--- a/notification/template.go
+++ b/notification/template.go
@@ -10,7 +10,7 @@ import (
 	"github.com/samber/lo"
 )
 
-var templateFuncs = map[string]any{
+var TemplateFuncs = map[string]any{
 	"labelsFormat": func(labels map[string]any) string {
 		if len(labels) == 0 {
 			return ""

--- a/playbook/actions/actions.go
+++ b/playbook/actions/actions.go
@@ -94,8 +94,7 @@ func (t *TemplateEnv) AsMap() map[string]any {
 		m["component"] = t.Component.AsMap()
 	}
 	if t.Config != nil {
-		configEnv, _ := t.Config.TemplateEnv()
-		m["config"] = configEnv
+		m["config"] = t.Config.AsMap()
 	}
 
 	return m


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/1446

This happend for SMTP notifications.

We need to first template and then convert the markdown to HTML.

Else the `markdown -> HTML` conversion will break all the go templating logic.