### PR TITLE
fix: playbook run loop

### DIFF
--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -458,7 +458,7 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, func() {
 
 		ginkgo.It("it should eventually consume the event", func() {
 			Eventually(func() bool {
-				DefaultContext.Logger.V(0).Infof("checking if the delayed notificaiton.send event has been consumed")
+				DefaultContext.Logger.V(0).Infof("checking if the delayed notification.send event has been consumed")
 				events.ConsumeAll(DefaultContext)
 
 				var count int64

--- a/playbook/runner/runner.go
+++ b/playbook/runner/runner.go
@@ -208,7 +208,7 @@ func ScheduleRun(ctx context.Context, run models.PlaybookRun) error {
 	if err != nil {
 		return ctx.Oops("db").Wrap(err)
 	} else if agent == nil {
-		return ctx.Oops("db").Wrapf(err, "failed to find any agent (%s)", strings.Join(eligibleAgents, ","))
+		return ctx.Oops().Errorf("failed to find any agent (%s)", strings.Join(eligibleAgents, ","))
 	}
 
 	if agent.Name == Main {

--- a/rbac/middleware.go
+++ b/rbac/middleware.go
@@ -54,8 +54,13 @@ func DbMiddleware() MiddlewareFunc {
 			}
 
 			ctx := c.Request().Context().(context.Context)
+			user := ctx.User()
 
 			if !CheckContext(ctx, object, action) {
+				c.Response().Header().Add("X-Rbac-Subject", user.ID.String())
+				c.Response().Header().Add("X-Rbac-Object", object)
+				c.Response().Header().Add("X-Rbac-Action", action)
+
 				return c.String(http.StatusForbidden, ErrAccessDenied.Error())
 			}
 


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/1463

when the agent wasn't found, we were wrapping a `nil` error.
The consumer would then exit without progressing and get stuck in a loop.