### PR TITLE
feat(kratos): use one-time code for account recovery instead of magic links

### DIFF
--- a/auth/controllers.go
+++ b/auth/controllers.go
@@ -64,12 +64,12 @@ func (k *KratosHandler) InviteUser(c echo.Context) error {
 		}
 	}
 
-	link, err := k.createRecoveryLink(ctx, identity.Id)
+	recoveryCode, recoveryLink, err := k.createRecoveryLink(ctx, identity.Id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, dutyAPI.HTTPError{Err: err.Error(), Message: "error creating recovery link"})
 	}
 
-	body := fmt.Sprintf(inviteUserTemplate, reqData.FirstName, link)
+	body := fmt.Sprintf(inviteUserTemplate, reqData.FirstName, recoveryLink, recoveryCode)
 	inviteMail := mail.New(reqData.Email, "User Invite", body, "text/html")
 	if err = inviteMail.Send(); err != nil {
 		return c.JSON(http.StatusInternalServerError, dutyAPI.HTTPError{
@@ -78,8 +78,10 @@ func (k *KratosHandler) InviteUser(c echo.Context) error {
 		})
 	}
 
-	respJSON := []byte(fmt.Sprintf(`{"link": "%s"}`, link))
-	return c.JSONBlob(http.StatusOK, respJSON)
+	return c.JSON(http.StatusOK, map[string]string{
+		"link": recoveryLink,
+		"code": recoveryCode,
+	})
 }
 
 func UpdateAccountState(c echo.Context) error {

--- a/auth/kratos_client.go
+++ b/auth/kratos_client.go
@@ -55,17 +55,20 @@ func (k *KratosHandler) createUser(ctx gocontext.Context, firstName, lastName, e
 	return createdIdentity, err
 }
 
-func (k *KratosHandler) createRecoveryLink(ctx gocontext.Context, id string) (string, error) {
-	adminCreateSelfServiceRecoveryLinkBody := client.NewCreateRecoveryLinkForIdentityBody(id)
-	resp, _, err := k.adminClient.IdentityApi.CreateRecoveryLinkForIdentity(ctx).CreateRecoveryLinkForIdentityBody(*adminCreateSelfServiceRecoveryLinkBody).Execute()
+func (k *KratosHandler) createRecoveryLink(ctx gocontext.Context, id string) (string, string, error) {
+	createRecoveryCodeForIdentityBody := client.NewCreateRecoveryCodeForIdentityBody(id)
+	resp, _, err := k.adminClient.IdentityApi.
+		CreateRecoveryCodeForIdentity(ctx).
+		CreateRecoveryCodeForIdentityBody(*createRecoveryCodeForIdentityBody).
+		Execute()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return resp.GetRecoveryLink(), nil
+
+	return resp.GetRecoveryCode(), resp.GetRecoveryLink(), nil
 }
 
 func (k *KratosHandler) createAdminIdentity(ctx gocontext.Context) (string, error) {
-
 	config := *client.NewIdentityWithCredentialsPasswordConfig()
 	config.SetPassword(getDefaultAdminPassword())
 

--- a/auth/templates.go
+++ b/auth/templates.go
@@ -3,4 +3,6 @@ package auth
 const inviteUserTemplate = `
 <b>Welcome to Mission Control</b>
 <br><br>
-Hello %s, use this link for signing up: %s`
+Hello %s,
+
+please visit <a href="%s">this link</a> to complete registration and use the code: <code>%s</code>`


### PR DESCRIPTION
one-time codes are the recommended strategy.
https://www.ory.sh/docs/kratos/self-service/flows/account-recovery-password-reset#comparison

"Some email virus scanners open links in emails to scan them. This invalidates the link and may prevent users from completing the flow even if they have the access to the defined address."