### PR TITLE
fix: use a single job instance for pull playbook actions this is to maintain retention

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -34,8 +34,10 @@ var agentJobs = []*job.Job{
 }
 
 func RunPullPlaybookActionsJob(ctx context.Context) {
+	// use a single job instance to maintain retention
+	job := PullPlaybookActions(ctx)
+
 	for {
-		job := PullPlaybookActions(ctx)
 		backoff := retry.WithMaxRetries(10, retry.NewExponential(time.Second))
 		_ = retry.Do(ctx, backoff, func(_ctx gocontext.Context) error {
 			job.Run()


### PR DESCRIPTION
resolves: https://github.com/flanksource/duty/issues/1200