### PR TITLE
fix: dedup window for unsent notifications

### DIFF
--- a/db/notifications.go
+++ b/db/notifications.go
@@ -179,7 +179,9 @@ func GetMatchingNotificationSilences(ctx context.Context, resources models.Notif
 	return silences, nil
 }
 
-func SaveUnsentNotificationToHistory(ctx context.Context, sendHistory models.NotificationSendHistory, window time.Duration) error {
+func SaveUnsentNotificationToHistory(ctx context.Context, sendHistory models.NotificationSendHistory) error {
+	window := ctx.Properties().Duration("notifications.dedup.window", time.Hour*24)
+
 	return ctx.DB().Exec("SELECT * FROM insert_unsent_notification_to_history(?, ?, ?, ?, ?)",
 		sendHistory.NotificationID,
 		sendHistory.SourceEvent,

--- a/notification/events.go
+++ b/notification/events.go
@@ -202,7 +202,7 @@ func addNotificationEvent(ctx context.Context, id string, celEnv map[string]any,
 				SourceEvent:    event.Name,
 				Status:         models.NotificationStatusSilenced,
 			}
-			if err := db.SaveUnsentNotificationToHistory(ctx, history, ctx.Properties().Duration("notifications.dedup.window", time.Hour*24)); err != nil {
+			if err := db.SaveUnsentNotificationToHistory(ctx, history); err != nil {
 				return fmt.Errorf("failed to save silenced notification history: %w", err)
 			}
 
@@ -220,7 +220,7 @@ func addNotificationEvent(ctx context.Context, id string, celEnv map[string]any,
 				SourceEvent:    event.Name,
 				Status:         models.NotificationStatusRepeatInterval,
 			}
-			if err := db.SaveUnsentNotificationToHistory(ctx, history, time.Minute); err != nil {
+			if err := db.SaveUnsentNotificationToHistory(ctx, history); err != nil {
 				return fmt.Errorf("failed to save silenced notification history: %w", err)
 			}
 


### PR DESCRIPTION
the dedup window of 24hrs was only applied when saving silenced notifications.
for repeated notifications, we were still using 1m