### PR TITLE
fix: prevent panic when reconciler isn't initialized

### DIFF
--- a/notification/job.go
+++ b/notification/job.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -71,6 +72,10 @@ func SyncCRDStatusJob(ctx context.Context) *job.Job {
 }
 
 func SyncCRDStatus(ctx context.Context, ids ...string) error {
+	if v1.NotificationReconciler.Client == nil {
+		return errors.New("notification reconciler is not initialized")
+	}
+
 	var summary []struct {
 		Name      string
 		Namespace string


### PR DESCRIPTION
This would happen on rare ocassions where the `SyncCRDstatus` job would run before kopper initialization completed.

resolves: https://github.com/flanksource/mission-control/issues/1738