### PR TITLE
fix: add RLS enforcement indicator to the context.

### DIFF
--- a/echo/serve.go
+++ b/echo/serve.go
@@ -340,6 +340,9 @@ func RLSMiddleware(next echov4.HandlerFunc) echov4.HandlerFunc {
 				return err
 			}
 
+			// We attach this value to indicate that RLS is enforced.
+			txCtx = txCtx.WithValue("rls-enabled", "true")
+
 			// set the context with the tx
 			c.SetRequest(c.Request().WithContext(txCtx))
 


### PR DESCRIPTION
Duty uses it to handling caching of resource selectors

resolves: https://github.com/flanksource/mission-control/issues/1750