### PR TITLE
fix: soft delete on CRD delete

### DIFF
--- a/db/connections.go
+++ b/db/connections.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/flanksource/commons/collections"
+	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	v1 "github.com/flanksource/incident-commander/api/v1"
@@ -364,7 +365,5 @@ func PersistConnectionFromCRD(ctx context.Context, obj *v1.Connection) error {
 }
 
 func DeleteConnection(ctx context.Context, id string) error {
-	return ctx.DB().Table("connections").
-		Delete(&models.Connection{}, "id = ?", id).
-		Error
+	return ctx.DB().Model(&models.Connection{}).Where("id = ?", id).Update("deleted_at", duty.Now()).Error
 }

--- a/db/incidents.go
+++ b/db/incidents.go
@@ -3,6 +3,7 @@ package db
 import (
 	"time"
 
+	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/incident-commander/api"
@@ -52,7 +53,5 @@ func PersistIncidentRuleFromCRD(ctx context.Context, obj *v1.IncidentRule) error
 }
 
 func DeleteIncidentRule(ctx context.Context, id string) error {
-	return ctx.DB().Table("incident_rules").
-		Delete(&api.IncidentRule{}, "id = ?", id).
-		Error
+	return ctx.DB().Table("incident_rules").Where("id = ?", id).Update("deleted_at", duty.Now()).Error
 }

--- a/db/notifications.go
+++ b/db/notifications.go
@@ -10,6 +10,7 @@ import (
 	extraClausePlugin "github.com/WinterYukky/gorm-extra-clause-plugin"
 	"github.com/WinterYukky/gorm-extra-clause-plugin/exclause"
 	"github.com/flanksource/commons/text"
+	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
@@ -20,7 +21,7 @@ import (
 )
 
 func DeleteNotificationSilence(ctx context.Context, id string) error {
-	return ctx.DB().Delete(&models.NotificationSilence{}, "id = ?", id).Error
+	return ctx.DB().Model(&models.NotificationSilence{}).Where("id = ?", id).Update("deleted_at", duty.Now()).Error
 }
 
 func PersistNotificationFromCRD(ctx context.Context, obj *v1.Notification) error {
@@ -133,7 +134,7 @@ func PersistNotificationFromCRD(ctx context.Context, obj *v1.Notification) error
 }
 
 func DeleteNotification(ctx context.Context, id string) error {
-	return ctx.DB().Delete(&models.Notification{}, "id = ?", id).Error
+	return ctx.DB().Model(&models.Notification{}).Where("id = ?", id).Update("deleted_at", duty.Now()).Error
 }
 
 func UpdateNotificationError(ctx context.Context, id string, err string) error {


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/1789

ran into this when deleting a notification crd got stuck.
notification_send_history had foreign key to playbook_runs.