### PR TITLE
fix: panic on pr creation

### DIFF
--- a/pkg/clients/git/connectors/git_access_token.go
+++ b/pkg/clients/git/connectors/git_access_token.go
@@ -110,10 +110,11 @@ func (g *GitAccessTokenClient) OpenPullRequest(ctx context.Context, spec PullReq
 		Head:  spec.Branch,
 		Base:  spec.Base,
 	})
-	ctx = ctx.WithLoggingValues("pr", pr.Number)
 	if err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to create pr repo=%s title=%s, head=%s base=%s", g.repository, spec.Title, spec.Branch, spec.Base)
 	}
+
+	ctx = ctx.WithLoggingValues("pr", pr.Number)
 
 	if len(spec.Reviewers) > 0 {
 		ctx.Tracef("Requesting review from %v for PR #%d", spec.Reviewers, pr.Number)


### PR DESCRIPTION
```
ERROR 2025-02-10T08:42:13.582446236Z [resource.labels.containerName: mission-control] panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3b31815] goroutine 200 [running]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1() /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:398 +0x25 go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0026104e0, {0x0, 0x0, 0xc001370380?}) /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:436 +0xa62 panic({0x62232e0?, 0xc02b240?}) /usr/local/go/src/runtime/panic.go:785 +0x132 github.com/flanksource/incident-commander/pkg/clients/git/connectors.(*GitAccessTokenClient).OpenPullRequest(0xc00075d1f0, {{{0x8271a10, 0xc0044fe720}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {{0x0, ...}, ...}) /app/pkg/clients/git/connectors/git_access_token.go:113 +0x515 github.com/flanksource/incident-commander/pkg/clients/git.OpenPR({{{0x8271a10, 0xc004330990}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {0x8273638, 0xc00075d1f0}, ...) /app/pkg/clients/git/git.go:43 +0x123 github.com/flanksource/incident-commander/playbook/actions.(*GitOps).createPR(...) /app/playbook/actions/gitops.go:368 github.com/flanksource/incident-commander/playbook/actions.(*GitOps).Run(_, {{{_, _}, {_, _}, _, _, {_, _}}}, {{{0xc000f40f00, ...}, ...}, ...}) /app/playbook/actions/gitops.go:95 +0x7cf github.com/flanksource/incident-commander/playbook/runner.executeAction({{{_, _}, {_, _}, _, _, {_, _}}}, {0x72388e0, 0xc0011b1200}, ...) /app/playbook/runner/exec.go:97 +0xdac github.com/flanksource/incident-commander/playbook/runner.ExecuteAndSaveAction({{{0x8271a10, 0xc001161b30}, {_, _}, _, _, {_, _}}}, {0x72388e0, 0xc0011b1200}, ...) /app/playbook/runner/runner.go:237 +0x345 github.com/flanksource/incident-commander/playbook/runner.TemplateAndExecuteAction({{{_, _}, {_, _}, _, _, {_, _}}}, {{0xc00430a7d4, 0x4}, ...}, ...) /app/playbook/runner/runner.go:332 +0xa35 github.com/flanksource/incident-commander/playbook/runner.RunAction({{{0x8271a10, 0xc001161860}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, 0xc001a22a80, 0xc000bac408) /app/playbook/runner/runner.go:280 +0x4f2 github.com/flanksource/incident-commander/playbook.ActionConsumer.func1({{{0x8271a10, 0xc001422420}, {0x82aea40, 0xc00131d5c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {0x8293b30, 0xc00176e000}) /app/playbook/run_consumer.go:274 +0x2f4…
  {
    "textPayload": "\tpanic: runtime error: invalid memory address or nil pointer dereference\n[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3b31815]\n\ngoroutine 200 [running]:\ngo.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()\n\t/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:398 +0x25\ngo.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0026104e0, {0x0, 0x0, 0xc001370380?})\n\t/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:436 +0xa62\npanic({0x62232e0?, 0xc02b240?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\ngithub.com/flanksource/incident-commander/pkg/clients/git/connectors.(*GitAccessTokenClient).OpenPullRequest(0xc00075d1f0, {{{0x8271a10, 0xc0044fe720}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {{0x0, ...}, ...})\n\t/app/pkg/clients/git/connectors/git_access_token.go:113 +0x515\ngithub.com/flanksource/incident-commander/pkg/clients/git.OpenPR({{{0x8271a10, 0xc004330990}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {0x8273638, 0xc00075d1f0}, ...)\n\t/app/pkg/clients/git/git.go:43 +0x123\ngithub.com/flanksource/incident-commander/playbook/actions.(*GitOps).createPR(...)\n\t/app/playbook/actions/gitops.go:368\ngithub.com/flanksource/incident-commander/playbook/actions.(*GitOps).Run(_, {{{_, _}, {_, _}, _, _, {_, _}}}, {{{0xc000f40f00, ...}, ...}, ...})\n\t/app/playbook/actions/gitops.go:95 +0x7cf\ngithub.com/flanksource/incident-commander/playbook/runner.executeAction({{{_, _}, {_, _}, _, _, {_, _}}}, {0x72388e0, 0xc0011b1200}, ...)\n\t/app/playbook/runner/exec.go:97 +0xdac\ngithub.com/flanksource/incident-commander/playbook/runner.ExecuteAndSaveAction({{{0x8271a10, 0xc001161b30}, {_, _}, _, _, {_, _}}}, {0x72388e0, 0xc0011b1200}, ...)\n\t/app/playbook/runner/runner.go:237 +0x345\ngithub.com/flanksource/incident-commander/playbook/runner.TemplateAndExecuteAction({{{_, _}, {_, _}, _, _, {_, _}}}, {{0xc00430a7d4, 0x4}, ...}, ...)\n\t/app/playbook/runner/runner.go:332 +0xa35\ngithub.com/flanksource/incident-commander/playbook/runner.RunAction({{{0x8271a10, 0xc001161860}, {0x82ae990, 0xc0011618c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, 0xc001a22a80, 0xc000bac408)\n\t/app/playbook/runner/runner.go:280 +0x4f2\ngithub.com/flanksource/incident-commander/playbook.ActionConsumer.func1({{{0x8271a10, 0xc001422420}, {0x82aea40, 0xc00131d5c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, {0x8293b30, 0xc00176e000})\n\t/app/playbook/run_consumer.go:274 +0x2f4\ngithub.com/flanksource/duty/context.Context.Transaction.func1(0xc00131d860)\n\t/go/pkg/mod/github.com/flanksource/duty@v1.0.838/context/context.go:320 +0x41a\ngorm.io/gorm.(*DB).Transaction(0xc00131d650, 0xc000fc68c0, {0x0?, 0xc00131d5c0?, 0x7b06148?})\n\t/go/pkg/mod/gorm.io/gorm@v1.25.12/finisher_api.go:651 +0x262\ngithub.com/flanksource/duty/context.Context.Transaction({{{0x8271a10, 0xc001253a40}, {0x82aea40, 0xc00131d5c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}}, 0x7b063f0, {0x0, ...})\n\t/go/pkg/mod/github.com/flanksource/duty@v1.0.838/context/context.go:310 +0x159\ngithub.com/flanksource/incident-commander/playbook.ActionConsumer({{{0x8271a10, 0xc001253a40}, {0x82aea40, 0xc00131d5c0}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}})\n\t/app/playbook/run_consumer.go:257 +0x139\ngithub.com/flanksource/duty/postq.(*PGConsumer).ConsumeUntilEmpty(0xc0009e5d00, {{{0x8271a10, 0xc001253a40}, {0x82ae990, 0xc000a8e300}, 0x7b06148, 0x7b06150, {0x822f468, 0xc000c4b8b0}}})\n\t/go/pkg/mod/github.com/flanksource/duty@v1.0.838/postq/pg_consumer.go:76 +0x99\ngithub.com/flanksource/duty/postq.(*PGConsumer).Listen.func1()\n\t/go/pkg/mod/github.com/flanksource/duty@v1.0.838/postq/pg_consumer.go:97 +0xbc\ncreated by github.com/flanksource/duty/postq.(*PGConsumer).Listen in goroutine 178\n\t/go/pkg/mod/github.com/flanksource/duty@v1.0.838/postq/pg_consumer.go:90 +0x85",
```