### PR TITLE
chore: shutdown and exit in fatal scenarios

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/flanksource/duty"
 	dutyApi "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/secret"
+	"github.com/flanksource/duty/shutdown"
 	"github.com/flanksource/duty/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -38,6 +40,7 @@ func PreRun(cmd *cobra.Command, args []string) {
 		content, err := os.ReadFile(path)
 		if err != nil {
 			logger.Fatalf("failed to read identity role mapper script file(%s): %v", path, err)
+			shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to read identity role mapper script file(%s): %v", path, err))
 		}
 
 		auth.IdentityRoleMapper = string(content)
@@ -94,7 +97,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	var upstreamPageSizeDefault = 500
 	if val, exists := os.LookupEnv("UPSTREAM_PAGE_SIZE"); exists {
 		if parsed, err := strconv.Atoi(val); err != nil {
-			logger.Fatalf("invalid value=%s for UPSTREAM_PAGE_SIZE: %v", val, err)
+			shutdown.ShutdownAndExit(1, fmt.Sprintf("invalid value=%s for UPSTREAM_PAGE_SIZE: %v", val, err))
 		} else {
 			upstreamPageSizeDefault = parsed
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -129,7 +129,7 @@ var Serve = &cobra.Command{
 
 		ctx, stop, err := duty.Start("mission-control", dutyArgs...)
 		if err != nil {
-			logger.Fatalf(err.Error())
+			shutdown.ShutdownAndExit(1, fmt.Sprintf("error setting up db connection: %v", err))
 		}
 
 		e := echo.New(ctx)
@@ -158,7 +158,7 @@ var Serve = &cobra.Command{
 		listenAddr := fmt.Sprintf(":%d", httpPort)
 		logger.Infof("Listening on %s", listenAddr)
 		if err := e.Start(listenAddr); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Fatalf("Failed to start server: %v", err)
+			shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to start server: %v", err))
 		}
 	},
 }

--- a/echo/serve.go
+++ b/echo/serve.go
@@ -21,6 +21,7 @@ import (
 	dutyEcho "github.com/flanksource/duty/echo"
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/flanksource/duty/schema/openapi"
+	"github.com/flanksource/duty/shutdown"
 	"github.com/flanksource/duty/telemetry"
 	"github.com/flanksource/incident-commander/agent"
 	"github.com/flanksource/incident-commander/api"
@@ -141,7 +142,7 @@ func New(ctx context.Context) *echov4.Echo {
 
 	if vars.AuthMode != "" {
 		if err := auth.Middleware(ctx, e); err != nil {
-			logger.Fatalf(err.Error())
+			shutdown.ShutdownAndExit(1, fmt.Sprintf("error setting up auth middleware: %v", err))
 		}
 	}
 
@@ -306,7 +307,7 @@ func Start(e *echov4.Echo, httpPort int) {
 	listenAddr := fmt.Sprintf(":%d", httpPort)
 	logger.Infof("Listening on %s", listenAddr)
 	if err := e.Start(listenAddr); err != nil {
-		logger.Fatalf("Failed to start server: %v", err)
+		shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to start server: %v", err))
 	}
 }
 


### PR DESCRIPTION
@moshloop @adityathebe Should be put the shutdown and exit in logger.Fatalf ? or keep it the way it is right now ?