### PR TITLE
fix: use waitForGroup in CRD

### DIFF
--- a/api/v1/notification_types.go
+++ b/api/v1/notification_types.go
@@ -77,9 +77,9 @@ type NotificationSpec struct {
 	// Kubernetes config health. Format: "5m", "1h"
 	WaitForEvalPeriod *string `json:"waitForEvalPeriod,omitempty" yaml:"waitForEvalPeriod,omitempty"`
 
-	// WaitForGroup allows notifications in waiting status to be grouped together
+	// GroupBy allows notifications in waiting status to be grouped together
 	// based on certain set of keys.
-	WaitForGroup []string `json:"waitForGroup,omitempty"`
+	GroupBy []string `json:"groupBy,omitempty"`
 }
 
 var NotificationReconciler kopper.Reconciler[Notification, *Notification]

--- a/api/v1/notification_types.go
+++ b/api/v1/notification_types.go
@@ -58,7 +58,7 @@ type NotificationSpec struct {
 
 	// RepeatGroup allows notifications to be grouped by certain set of keys and only send
 	// one per group within the specified repeat interval.
-	RepeatGroup []string `json:"repeatGroup,omitempty" yaml:"repeatGroup,omitempty"`
+	// RepeatGroup []string `json:"repeatGroup,omitempty" yaml:"repeatGroup,omitempty"`
 
 	// Specify the recipient
 	To NotificationRecipientSpec `json:"to" yaml:"to"`
@@ -76,6 +76,10 @@ type NotificationSpec struct {
 	// WaitForEvalPeriod is an additional delay after WaitFor before evaluating
 	// Kubernetes config health. Format: "5m", "1h"
 	WaitForEvalPeriod *string `json:"waitForEvalPeriod,omitempty" yaml:"waitForEvalPeriod,omitempty"`
+
+	// WaitForGroup allows notifications in waiting status to be grouped together
+	// based on certain set of keys.
+	WaitForGroup []string `json:"waitForGroup,omitempty"`
 }
 
 var NotificationReconciler kopper.Reconciler[Notification, *Notification]

--- a/api/v1/notification_types.go
+++ b/api/v1/notification_types.go
@@ -79,6 +79,9 @@ type NotificationSpec struct {
 
 	// GroupBy allows notifications in waiting status to be grouped together
 	// based on certain set of keys.
+	//
+	// Valid keys: type, description, status_reason or
+	// labels & tags in the format `label:<key>` or `tag:<key>`
 	GroupBy []string `json:"groupBy,omitempty"`
 }
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1626,11 +1626,6 @@ func (in *NotificationSpec) DeepCopyInto(out *NotificationSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.RepeatGroup != nil {
-		in, out := &in.RepeatGroup, &out.RepeatGroup
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.To.DeepCopyInto(&out.To)
 	if in.WaitFor != nil {
 		in, out := &in.WaitFor, &out.WaitFor
@@ -1641,6 +1636,11 @@ func (in *NotificationSpec) DeepCopyInto(out *NotificationSpec) {
 		in, out := &in.WaitForEvalPeriod, &out.WaitForEvalPeriod
 		*out = new(string)
 		**out = **in
+	}
+	if in.WaitForGroup != nil {
+		in, out := &in.WaitForGroup, &out.WaitForGroup
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1637,8 +1637,8 @@ func (in *NotificationSpec) DeepCopyInto(out *NotificationSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.WaitForGroup != nil {
-		in, out := &in.WaitForGroup, &out.WaitForGroup
+	if in.GroupBy != nil {
+		in, out := &in.GroupBy, &out.GroupBy
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crds/mission-control.flanksource.com_notifications.yaml
+++ b/config/crds/mission-control.flanksource.com_notifications.yaml
@@ -51,6 +51,10 @@ spec:
                 description: |-
                   GroupBy allows notifications in waiting status to be grouped together
                   based on certain set of keys.
+
+
+                  Valid keys: type, description, status_reason or
+                  labels & tags in the format `label:<key>` or `tag:<key>`
                 items:
                   type: string
                 type: array

--- a/config/crds/mission-control.flanksource.com_notifications.yaml
+++ b/config/crds/mission-control.flanksource.com_notifications.yaml
@@ -47,6 +47,13 @@ spec:
                 description: Cel-expression used to decide whether this notification
                   client should send the notification
                 type: string
+              groupBy:
+                description: |-
+                  GroupBy allows notifications in waiting status to be grouped together
+                  based on certain set of keys.
+                items:
+                  type: string
+                type: array
               repeatInterval:
                 description: RepeatInterval is the waiting time to resend a notification
                   after it has been succefully sent.
@@ -107,13 +114,6 @@ spec:
                   WaitForEvalPeriod is an additional delay after WaitFor before evaluating
                   Kubernetes config health. Format: "5m", "1h"
                 type: string
-              waitForGroup:
-                description: |-
-                  WaitForGroup allows notifications in waiting status to be grouped together
-                  based on certain set of keys.
-                items:
-                  type: string
-                type: array
             required:
             - events
             - to

--- a/config/crds/mission-control.flanksource.com_notifications.yaml
+++ b/config/crds/mission-control.flanksource.com_notifications.yaml
@@ -47,13 +47,6 @@ spec:
                 description: Cel-expression used to decide whether this notification
                   client should send the notification
                 type: string
-              repeatGroup:
-                description: |-
-                  RepeatGroup allows notifications to be grouped by certain set of keys and only send
-                  one per group within the specified repeat interval.
-                items:
-                  type: string
-                type: array
               repeatInterval:
                 description: RepeatInterval is the waiting time to resend a notification
                   after it has been succefully sent.
@@ -114,6 +107,13 @@ spec:
                   WaitForEvalPeriod is an additional delay after WaitFor before evaluating
                   Kubernetes config health. Format: "5m", "1h"
                 type: string
+              waitForGroup:
+                description: |-
+                  WaitForGroup allows notifications in waiting status to be grouped together
+                  based on certain set of keys.
+                items:
+                  type: string
+                type: array
             required:
             - events
             - to

--- a/config/schemas/notification.schema.json
+++ b/config/schemas/notification.schema.json
@@ -106,12 +106,6 @@
         "repeatInterval": {
           "type": "string"
         },
-        "repeatGroup": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "to": {
           "$ref": "#/$defs/NotificationRecipientSpec"
         },
@@ -120,6 +114,12 @@
         },
         "waitForEvalPeriod": {
           "type": "string"
+        },
+        "waitForGroup": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/config/schemas/notification.schema.json
+++ b/config/schemas/notification.schema.json
@@ -115,7 +115,7 @@
         "waitForEvalPeriod": {
           "type": "string"
         },
-        "waitForGroup": {
+        "groupBy": {
           "items": {
             "type": "string"
           },

--- a/db/notifications.go
+++ b/db/notifications.go
@@ -45,7 +45,7 @@ func PersistNotificationFromCRD(ctx context.Context, obj *v1.Notification) error
 		Properties:     obj.Spec.To.Properties,
 		Source:         models.SourceCRD,
 		RepeatInterval: obj.Spec.RepeatInterval,
-		GroupBy:        obj.Spec.RepeatGroup,
+		GroupBy:        obj.Spec.WaitForGroup,
 	}
 
 	if obj.Spec.WaitFor != nil && *obj.Spec.WaitFor != "" {

--- a/db/notifications.go
+++ b/db/notifications.go
@@ -45,7 +45,7 @@ func PersistNotificationFromCRD(ctx context.Context, obj *v1.Notification) error
 		Properties:     obj.Spec.To.Properties,
 		Source:         models.SourceCRD,
 		RepeatInterval: obj.Spec.RepeatInterval,
-		GroupBy:        obj.Spec.WaitForGroup,
+		GroupBy:        obj.Spec.GroupBy,
 	}
 
 	if obj.Spec.WaitFor != nil && *obj.Spec.WaitFor != "" {
@@ -62,6 +62,10 @@ func PersistNotificationFromCRD(ctx context.Context, obj *v1.Notification) error
 		} else {
 			dbObj.WaitForEvalPeriod = parsed
 		}
+	}
+
+	if len(obj.Spec.GroupBy) > 0 && obj.Spec.WaitFor != nil && *obj.Spec.WaitFor == "" {
+		return fmt.Errorf("groupBy provided with an empty waitFor. either remove the groupBy or set a waitFor period.")
 	}
 
 	switch {

--- a/fixtures/notifications/config-health.yaml
+++ b/fixtures/notifications/config-health.yaml
@@ -1,0 +1,14 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Notification
+metadata:
+  name: config-health
+spec:
+  events:
+    - config.unhealthy
+    - config.warning
+  waitFor: 2m
+  waitForEvalPeriod: 30s
+  groupBy:
+    - label:app
+  to:
+    connection: connection://default/slack


### PR DESCRIPTION
repeatGroup (crd) was mapped to GroupByHash.

RepeatGroup was originally meant for different purpose.
Removing it for now as we aren't using it anywhere.