### PR TITLE
fix: do not delete notification send history linked to playbook runs

### DIFF
--- a/db/notifications.go
+++ b/db/notifications.go
@@ -152,6 +152,7 @@ func UpdateNotificationSilenceError(ctx context.Context, id string, err string) 
 func DeleteNotificationSendHistory(ctx context.Context, days int) (int64, error) {
 	tx := ctx.DB().
 		Model(&models.NotificationSendHistory{}).
+		Where("playbook_run_id IS NULL").
 		Where(fmt.Sprintf("created_at < NOW() - INTERVAL '%d DAYS'", days)).
 		Delete(&models.NotificationSendHistory{})
 	return tx.RowsAffected, tx.Error


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/1863