### PR TITLE
fix: set 'gemini-2.0-flash' as the default model for Gemini

### DIFF
--- a/llm/llm.go
+++ b/llm/llm.go
@@ -142,6 +142,8 @@ func getLLMModel(ctx context.Context, config Config) (llms.Model, error) {
 		}
 		if config.Model != "" {
 			opts = append(opts, googleai.WithDefaultModel(config.Model))
+		} else {
+			opts = append(opts, googleai.WithDefaultModel("gemini-2.0-flash"))
 		}
 
 		googleLLM, err := googleai.New(ctx, opts...)


### PR DESCRIPTION
Other LLMs have default model but Gemini doesn't & Gemini connection CRD doesn't require `model`