### PR TITLE
fix: add namespace context for webhook playbook

### DIFF
--- a/playbook/webhook.go
+++ b/playbook/webhook.go
@@ -55,8 +55,9 @@ func HandleWebhook(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, dutyAPI.HTTPError{Err: err.Error(), Message: "playbook has an invalid spec"})
 	}
 
+	ctx = ctx.WithNamespace(playbook.Namespace)
 	if err := authenticateWebhook(ctx, c.Request(), spec.On.Webhook.Authentication); err != nil {
-		return dutyAPI.WriteError(c, err)
+		return dutyAPI.WriteError(c, fmt.Errorf("error authenticating webhook[%s]: %w", path, err))
 	}
 
 	var runRequest RunParams


### PR DESCRIPTION
```
{"time":"2025-03-14T08:44:12.280486736Z","level":"ERROR","msg":"could not find secret /clerk-api: the server could not find the requested resource","cod
e":"internal","error":"Internal error."}
{"time":"2025-03-14T08:44:12.280651013Z","level":"ERROR","msg":"Internal Server Error","request":{"time":"2025-03-14T08:44:12.272882377Z","method":"POST
","host":"mc.org-puirhxj5j7oz.workload-prod-eu-01.flanksource.com","path":"/playbook/webhook/suspend-tenant","query":"","params":{"webhook_path":"suspen
```