### PR TITLE
fix: run consumer sql query

### DIFF
--- a/playbook/jobs.go
+++ b/playbook/jobs.go
@@ -133,7 +133,7 @@ func PullPlaybookAction(ctx job.JobRuntime, upstreamConfig upstream.UpstreamConf
 
 func MarkTimedOutPlaybookRuns(ctx context.Context) error {
 	return ctx.DB().Model(&models.PlaybookRun{}).
-		Where("timeout < EXTRACT(EPOCH FROM (NOW() - scheduled_time)) * 1000_000_000").
+		Where("timeout < EXTRACT(EPOCH FROM (NOW() - scheduled_time)) * 1000000000").
 		Where("status IN ?", models.PlaybookRunStatusExecutingGroup).
 		Update("status", models.PlaybookRunStatusTimedOut).Error
 }

--- a/playbook/run_consumer.go
+++ b/playbook/run_consumer.go
@@ -332,7 +332,7 @@ func RunConsumer(ctx context.Context) (int, error) {
 	INNER JOIN playbooks ON playbooks.id = playbook_runs.playbook_id
 	WHERE status IN ? AND scheduled_time <= NOW()
 	AND (agent_id IS NULL OR agent_id = ?)
-	AND (timeout IS NULL OR timeout > EXTRACT(EPOCH FROM (NOW() - scheduled_time)) * 1000_000_000)
+	AND (timeout IS NULL OR timeout > EXTRACT(EPOCH FROM (NOW() - scheduled_time)) * 1000000000)
 	ORDER BY scheduled_time
 	FOR UPDATE SKIP LOCKED
 	LIMIT 1


### PR DESCRIPTION
that syntax isn't supported in v14