### PR TITLE
test: Playbook permissions

### DIFF
--- a/playbook/actions/http.go
+++ b/playbook/actions/http.go
@@ -26,7 +26,8 @@ func (c *HTTP) Run(ctx context.Context, action v1.HTTPAction) (*HTTPResult, erro
 	}
 
 	if action.HTTPConnection.Connection != "" {
-		connection, err := pkgConnection.Get(ctx, action.HTTPConnection.Connection)
+		var err error
+		connection, err = pkgConnection.Get(ctx, action.HTTPConnection.Connection)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hydrate connection: %w", err)
 		} else if connection != nil {

--- a/playbook/testdata/action-http-authorized.yaml
+++ b/playbook/testdata/action-http-authorized.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../config/schemas/playbook.schema.json
+apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  uid: d9e3a32d-e9c7-470f-a8a6-60197730d8c8
+  name: http-authorized
+  namespace: mc
+spec:
+  configs:
+    - types:
+        - Kubernetes::Pod
+  actions:
+    - name: HTTP
+      http:
+        connection: connection://mc/httpbin

--- a/playbook/testdata/action-http-unauthorized.yaml
+++ b/playbook/testdata/action-http-unauthorized.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../config/schemas/playbook.schema.json
+apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  name: http-unauthorized
+  namespace: mc
+spec:
+  configs:
+    - types:
+        - Kubernetes::Pod
+  actions:
+    - name: HTTP
+      http:
+        url: https://httpbin.org/get
+        connection: connection://mc/httpbin

--- a/playbook/testdata/connections/httpbin.yaml
+++ b/playbook/testdata/connections/httpbin.yaml
@@ -1,0 +1,9 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Connection
+metadata:
+  name: httpbin
+  namespace: mc
+  uid: 7eb7d4c8-faad-4809-9643-e8116eef6e3e
+spec:
+  url: 
+    value: https://httpbin.org/status/200

--- a/playbook/testdata/permissions/allow-john-connection.yaml
+++ b/playbook/testdata/permissions/allow-john-connection.yaml
@@ -1,0 +1,14 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-playbook-connection
+spec:
+  description: allow john to read connection mc/httpbin
+  subject:
+    person: john@doe.com
+  actions:
+    - read
+  object:
+    connections:
+      - name: httpbin
+        namespace: mc

--- a/playbook/testdata/permissions/allow-playbook-connection.yaml
+++ b/playbook/testdata/permissions/allow-playbook-connection.yaml
@@ -1,0 +1,14 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-playbook-connection
+spec:
+  description: allow playbook mc/http-authorized to read connection mc/httpbin
+  subject:
+    playbook: mc/http-authorized
+  actions:
+    - read
+  object:
+    connections:
+      - name: httpbin
+        namespace: mc


### PR DESCRIPTION
Ensure that a playbook can read a connection only when it has the `read` permission.