### PR TITLE
fix: add context to ai action error

### DIFF
--- a/playbook/playbook_test.go
+++ b/playbook/playbook_test.go
@@ -305,9 +305,13 @@ var _ = Describe("Playbook", Ordered, func() {
 			err := DefaultContext.DB().Where("playbook_run_id = ?", run.ID).Find(&actions).Error
 			Expect(err).To(BeNil())
 
+			for i, a := range actions {
+				fmt.Printf("[%d] action %s: %d\n", i, a.Name, a.RetryCount)
+			}
+
 			Expect(len(actions)).To(Equal(1 + 2)) // 1 initial + 2 retries
 			for i, a := range actions {
-				Expect(a.RetryCount).To(Equal(i))
+				Expect(a.RetryCount).To(Equal(i), fmt.Sprintf("[%d] action %s should have been retried %d times", i, a.Name, i))
 			}
 		})
 	})


### PR DESCRIPTION
seeings a few unmarshal errors

`failed to unmarshal diagnosis report: invalid character 'y' in literal null (expecting 'u')`