### PR TITLE
feat: save resource health and status in notification send history

### DIFF
--- a/notification/cel.go
+++ b/notification/cel.go
@@ -63,7 +63,7 @@ type ResourceHealthRow struct {
 	UpdatedAt *time.Time
 }
 
-func (t *celVariables) GetResourceHealth(ctx context.Context) (ResourceHealthRow, error) {
+func (t *celVariables) GetResourceCurrentHealth(ctx context.Context) (ResourceHealthRow, error) {
 	var err error
 	var row ResourceHealthRow
 	switch {

--- a/notification/events.go
+++ b/notification/events.go
@@ -251,7 +251,7 @@ func addNotificationEvent(ctx context.Context, id string, celEnv *celVariables, 
 		}
 	}
 
-	payloads, err := CreateNotificationSendPayloads(ctx, event, n, celEnv.AsMap(ctx))
+	payloads, err := CreateNotificationSendPayloads(ctx, event, n, celEnv)
 	if err != nil {
 		return fmt.Errorf("failed to create notification.send payloads: %w", err)
 	}
@@ -268,6 +268,8 @@ func addNotificationEvent(ctx context.Context, id string, celEnv *celVariables, 
 			history := models.NotificationSendHistory{
 				NotificationID: n.ID,
 				ResourceID:     payload.ID,
+				ResourceHealth: payload.ResourceHealth,
+				ResourceStatus: payload.ResourceStatus,
 				SourceEvent:    payload.EventName,
 				Status:         blocker.BlockedWithStatus,
 				ParentID:       blocker.ParentID,
@@ -299,6 +301,8 @@ func addNotificationEvent(ctx context.Context, id string, celEnv *celVariables, 
 			pendingHistory := models.NotificationSendHistory{
 				NotificationID: n.ID,
 				ResourceID:     payload.ID,
+				ResourceHealth: payload.ResourceHealth,
+				ResourceStatus: payload.ResourceStatus,
 				SourceEvent:    event.Name,
 				Payload:        payload.AsMap(),
 				GroupID:        payload.GroupID,

--- a/notification/job.go
+++ b/notification/job.go
@@ -355,9 +355,9 @@ func shouldSkipNotificationDueToHealth(ctx context.Context, notif NotificationWi
 	// previousHealth is the health that triggered the notification event
 	previousHealth := api.EventToHealth(payload.EventName)
 
-	resourceHealth, err := celEnv.GetResourceHealth(ctx)
+	resourceHealth, err := celEnv.GetResourceCurrentHealth(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to get resource health from cel env: %w", err)
+		return false, fmt.Errorf("failed to get resource current health from cel env: %w", err)
 	}
 	currentHealth := resourceHealth.Health
 	deleted := resourceHealth.DeletedAt != nil


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2066

dependsOn: https://github.com/flanksource/duty/pull/1423