### PR TITLE
Fix/ai response limits

### DIFF
--- a/llm/gemini.go
+++ b/llm/gemini.go
@@ -20,11 +20,12 @@ var DiagnosisSchema = genai.Schema{
 		},
 		"summary": {
 			Type:        genai.TypeString,
-			Description: "Summary of the issue in markdown. Use bullet points if needed.",
+			Description: "Summary of the issue in markdown. Keep it short and concise.",
+			MaxLength:   lo.ToPtr(int64(50)),
 		},
 		"recommended_fix": {
 			Type:        genai.TypeString,
-			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed.",
+			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed and keep each points under 10 words.",
 		},
 	},
 	Required: []string{"headline", "summary", "recommended_fix"},

--- a/llm/gemini.go
+++ b/llm/gemini.go
@@ -20,12 +20,12 @@ var DiagnosisSchema = genai.Schema{
 		},
 		"summary": {
 			Type:        genai.TypeString,
-			Description: "Summary of the issue in markdown. Keep it short and concise.",
-			MaxLength:   lo.ToPtr(int64(50)),
+			Description: "Brief markdown summary (≤50 words) of the issue and impact.",
+			MaxLength:   lo.ToPtr(int64(50)), // Doesn't seem to work: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output
 		},
 		"recommended_fix": {
 			Type:        genai.TypeString,
-			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed and keep each points under 10 words.",
+			Description: "Markdown bullet array of 1–5 concise fixes (≤10 words each).",
 		},
 	},
 	Required: []string{"headline", "summary", "recommended_fix"},

--- a/llm/tools/extract_details.go
+++ b/llm/tools/extract_details.go
@@ -11,7 +11,7 @@ import (
 
 const ToolExtractDiagnosis = "extract_diagnosis"
 
-// NOTE: OpenAI response format doen't support max length.
+// NOTE: OpenAI response format doesn't support max length.
 // Notable keywords not supported include:
 // For strings: minLength, maxLength, pattern, format
 // https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#some-type-specific-keywords-are-not-yet-supported
@@ -25,11 +25,11 @@ var ExtractDiagnosisToolSchema = openai.ResponseFormatJSONSchemaProperty{
 		},
 		"summary": {
 			Type:        "string",
-			Description: "Summary of the issue in markdown. Keep it short and concise under 50 words.",
+			Description: "Brief markdown summary (≤50 words) of the issue and impact.",
 		},
 		"recommended_fix": {
 			Type:        "string",
-			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed. Keep each points under 10 words.",
+			Description: "Markdown bullet array of 1–5 concise fixes (≤10 words each).",
 		},
 	},
 	Required: []string{"headline", "summary", "recommended_fix"},

--- a/llm/tools/extract_details.go
+++ b/llm/tools/extract_details.go
@@ -11,6 +11,11 @@ import (
 
 const ToolExtractDiagnosis = "extract_diagnosis"
 
+// NOTE: OpenAI response format doen't support max length.
+// Notable keywords not supported include:
+// For strings: minLength, maxLength, pattern, format
+// https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#some-type-specific-keywords-are-not-yet-supported
+
 var ExtractDiagnosisToolSchema = openai.ResponseFormatJSONSchemaProperty{
 	Type: "object",
 	Properties: map[string]*openai.ResponseFormatJSONSchemaProperty{
@@ -20,11 +25,11 @@ var ExtractDiagnosisToolSchema = openai.ResponseFormatJSONSchemaProperty{
 		},
 		"summary": {
 			Type:        "string",
-			Description: "Summary of the issue in markdown. Use bullet points if needed.",
+			Description: "Summary of the issue in markdown. Keep it short and concise under 50 words.",
 		},
 		"recommended_fix": {
 			Type:        "string",
-			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed.",
+			Description: "Short and concise recommended fix for the issue in markdown. Use bullet points if needed. Keep each points under 10 words.",
 		},
 	},
 	Required: []string{"headline", "summary", "recommended_fix"},


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2101

Examples

```
headline: "HelmRelease 'mission-control-helm' Failing: Invalid YAML in Chart ⚠️"
recommended_fix: |-
  - Fix duplicate 'name' keys in Helm chart `mission-control-helm:0.1.4-beta.3`.
  - Review chart templates and post-renderers for errors.
  - Validate chart output locally with `helm template --post-renderer`.
  - Consider using a different, stable version of the Helm chart.
  - Check `values.yaml` for inputs causing malformed templates.
summary: The HelmRelease 'mission-control-helm' fails to install because the
  Helm chart version '0.1.4-beta.3' generates invalid YAML with duplicate 'name'
  keys during its post-rendering process.
```

```
headline: "🚨 Pod `nginx-744c4cb859-5p5hk` Failing: Invalid Image Name"
recommended_fix: |-
  - Correct image tag `nginx:invalid` in the parent Deployment/ReplicaSet.
  - Use a valid image tag like `nginx:latest` or a specific version.
  - Apply changes to redeploy the Pod with the correct image.
summary: Pod `nginx-744c4cb859-5p5hk` is stuck in `Pending` state with
  `ImagePullBackOff` because the container image `nginx:invalid` does not exist
  or is invalid.
```