### PR TITLE
fix: error handling in /view endpoint

### DIFF
--- a/db/views.go
+++ b/db/views.go
@@ -62,8 +62,10 @@ func DeleteStaleView(ctx context.Context, newer *v1.View) error {
 // GetView retrieves a view by name and namespace
 func GetView(ctx context.Context, namespace, name string) (*v1.View, error) {
 	var view models.View
-	if err := ctx.DB().Where("name = ? AND namespace = ? AND deleted_at IS NULL", name, namespace).First(&view).Error; err != nil {
+	if err := ctx.DB().Where("name = ? AND namespace = ? AND deleted_at IS NULL", name, namespace).Find(&view).Error; err != nil {
 		return nil, err
+	} else if view.ID == uuid.Nil {
+		return nil, nil
 	}
 
 	var spec v1.ViewSpec

--- a/views/table.go
+++ b/views/table.go
@@ -57,6 +57,8 @@ func ReadOrPopulateViewTable(ctx context.Context, namespace, name string, opts .
 	view, err := db.GetView(ctx, namespace, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get view: %w", err)
+	} else if view == nil {
+		return nil, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view %s/%s not found", namespace, name)
 	}
 
 	config := &viewConfig{}


### PR DESCRIPTION
Don't return INTERNAL SERVER ERROR if view doesn't exist