### PR TITLE
feat: support direct ID-based permissions in RLS payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.30.0 // indirect
 	github.com/flanksource/commons v1.42.0
-	github.com/flanksource/duty v1.0.1058
+	github.com/flanksource/duty v1.0.1059
 	github.com/flanksource/gomplate/v3 v3.24.60
 	github.com/flanksource/kopper v1.0.13
 	github.com/gomarkdown/markdown v0.0.0-20240419095408-642f0ee99ae2

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/flanksource/clicky v1.4.0 h1:Ykt6Si6dp2skET3ACzDAS33KhGmWTK98B+NMACQV
 github.com/flanksource/clicky v1.4.0/go.mod h1:cehT6l6JJq2nVLL791FeGZgqxclLVlUhTl4K8Pm045A=
 github.com/flanksource/commons v1.42.0 h1:vg1Zvb4rmqqiOnJzmUl7aCVlg6wtNtkkkH4Vn5InNYU=
 github.com/flanksource/commons v1.42.0/go.mod h1:xEBCobwaM0+EHn2SvFpqiCBJCVk1803An1kZleXFR9Y=
-github.com/flanksource/duty v1.0.1058 h1:wiyWfdrYzuW3xv0/VQpJLpue7HWspMABw2q2EB7WtZs=
-github.com/flanksource/duty v1.0.1058/go.mod h1:+XXDJK7YwuKpRbSH8OjWLNYEoZWbC9lFXyFX3j9x3ME=
+github.com/flanksource/duty v1.0.1059 h1:MHq4AjTWGhb0wGnpZwhX9p87T2mGvNghTiF2OCkdUq4=
+github.com/flanksource/duty v1.0.1059/go.mod h1:+XXDJK7YwuKpRbSH8OjWLNYEoZWbC9lFXyFX3j9x3ME=
 github.com/flanksource/gomplate/v3 v3.24.60 h1:g1SjmR3m5YlXpuxyegvEj6OVbkoqP3btZbqUH0f7920=
 github.com/flanksource/gomplate/v3 v3.24.60/go.mod h1:hGEObNtnOQs8rNUX8sM8aJTAhnt4ehjyOw1MvDhl6AU=
 github.com/flanksource/is-healthy v1.0.79 h1:fBdmJJ7CoNtphZ08gOKxHWS76HltGwIi2L1396cxU2s=


### PR DESCRIPTION
Add support for permissions that use direct resource IDs (playbook_id, canary_id, component_id, config_id) instead of object_selector.
