### PR TITLE
fix: set default column type for Prometheus view queries

### DIFF
--- a/tests/e2e/testdata/pod-metric.yaml
+++ b/tests/e2e/testdata/pod-metric.yaml
@@ -41,6 +41,9 @@ spec:
       type: string
   queries:
     metrics:
+      columns:
+        namespace: string
+        pod: string
       prometheus:
         connection: connection://mc/prometheus
         query: |


### PR DESCRIPTION
## Summary

Ensures Prometheus view queries have proper column definitions by setting the value column to Decimal type when not explicitly defined.