### PR TITLE
chore: add job to cleanup playbooks

### DIFF
--- a/db/playbooks.go
+++ b/db/playbooks.go
@@ -182,7 +182,7 @@ func FindPlaybooksForEvent(ctx context.Context, eventClass, event string) ([]mod
 
 func FindPlaybookByWebhookPath(ctx context.Context, path string) (*models.Playbook, error) {
 	var p models.Playbook
-	if err := ctx.DB().Debug().Where("deleted_at IS NULL").Where("spec->'on'->'webhook'->>'path' = ?", path).First(&p).Error; err != nil {
+	if err := ctx.DB().Where("deleted_at IS NULL").Where("spec->'on'->'webhook'->>'path' = ?", path).First(&p).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -91,6 +91,9 @@ func Start(ctx context.Context, mcpServer *server.MCPServer) {
 	if err := MarkTimedOutPlaybookRuns(ctx).AddToScheduler(FuncScheduler); err != nil {
 		shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to schedule job MarkTimedOutPlaybookRuns: %v", err))
 	}
+	if err := CleanupDeletedPlaybooks(ctx).AddToScheduler(FuncScheduler); err != nil {
+		shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to schedule job CleanupDeletedPlaybooks: %v", err))
+	}
 
 	if err := notification.SyncCRDStatusJob(ctx).AddToScheduler(FuncScheduler); err != nil {
 		shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to schedule job SyncCRDStatusJob: %v", err))

--- a/jobs/playbook.go
+++ b/jobs/playbook.go
@@ -66,3 +66,19 @@ func MarkTimedOutPlaybookRuns(ctx context.Context) *job.Job {
 		},
 	}
 }
+
+func CleanupDeletedPlaybooks(ctx context.Context) *job.Job {
+	return &job.Job{
+		Name:       "CleanupDeletedPlaybooks",
+		Schedule:   "@every 24h",
+		Context:    ctx,
+		JobHistory: true,
+		Retention:  job.RetentionFailed,
+		Singleton:  true,
+		Fn: func(ctx job.JobRuntime) error {
+			count, err := playbook.CleanupDeletedPlaybooks(ctx.Context)
+			ctx.History.SuccessCount = count
+			return err
+		},
+	}
+}

--- a/playbook/jobs.go
+++ b/playbook/jobs.go
@@ -148,3 +148,13 @@ func MarkTimedOutPlaybookRuns(ctx context.Context) error {
 
 	return nil
 }
+
+func CleanupDeletedPlaybooks(ctx context.Context) (int, error) {
+	retention := ctx.Properties().Duration("playbook.retention.age", 30*24*time.Hour)
+	tx := ctx.DB().Exec(`
+		DELETE FROM playbooks
+		WHERE (NOW() - deleted_at) > INTERVAL '1 second' * ?
+		`, int64(retention.Seconds()))
+
+	return int(tx.RowsAffected), tx.Error
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated cleanup of deleted playbooks: items marked deleted are permanently removed after a configurable retention period (default 30 days).
  * Cleanup runs automatically on a daily schedule and reports the number of removed playbooks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->