### PR TITLE
chore: add newline for slack messages in Also Failing section

### DIFF
--- a/notification/templates/component.health
+++ b/notification/templates/component.health
@@ -15,7 +15,7 @@
 			]
 		},
 		{{if .component.labels}}{{slackSectionLabels .component}},{{end}}
-		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
+		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:*\n - %s` (join .groupedResources "\n - "))}},{{end}}
 		{{slackURLAction "View Component" .permalink "🔕 Silence" .silenceURL}}
 	]
 }

--- a/notification/templates/config.db.update
+++ b/notification/templates/config.db.update
@@ -15,7 +15,7 @@
 			]
 		},
 		{{if .config.labels}}{{slackSectionLabels .config}},{{end}}
-		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
+		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:*\n - %s` (join .groupedResources "\n - "))}},{{end}}
 		{{slackURLAction "View Catalog" .permalink "🔕 Silence" .silenceURL}}
 	]
 }

--- a/notification/templates/config.health
+++ b/notification/templates/config.health
@@ -16,7 +16,7 @@
 		},
 		{{if .config.labels}}{{slackSectionLabels .config}},{{end}}
 		{{if .recent_events}}{{slackSectionTextMD (printf `*Recent Events:* %v` (join .recent_events ", "))}},{{end}}
-		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
+		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:*\n - %s` (join .groupedResources "\n - "))}},{{end}}
 		{"type": "divider"},
 		{{slackURLAction "View Catalog" .permalink "🔕 Silence" .silenceURL}}
 	]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Slack health notification formatting to display failing resources on separate lines, improving readability of status updates in the "Also Failing" section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->