### PR TITLE
feat: slack block generation when config has no tags/labels

### DIFF
--- a/notification/template.go
+++ b/notification/template.go
@@ -64,12 +64,12 @@ var TemplateFuncs = map[string]any{
 		slackFields := CreateSlackFieldsSection(fields)
 
 		if len(slackFields) == 0 {
-			return "{}"
+			return ""
 		}
 
 		out, err := json.Marshal(slackFields)
 		if err != nil {
-			return "{}"
+			return ""
 		}
 
 		return string(out)
@@ -166,6 +166,10 @@ func CreateSlackFieldsSection(labels []models.Label) map[string]any {
 			"verbatim": true,
 		})
 		count++
+	}
+
+	if len(fields) == 0 {
+		return nil
 	}
 
 	section := map[string]any{

--- a/notification/templates/check.failed
+++ b/notification/templates/check.failed
@@ -14,7 +14,10 @@
 				{{end}}
 			]
 		},
-		{{ if .check.labels}}{{slackSectionLabels .check}},{{end}}
+		{{- if .check.labels -}}
+			{{- $labelSection := slackSectionLabels .check -}}
+			{{- if $labelSection }}{{$labelSection}},{{end}}
+		{{- end}}
 		{{if .groupedResources}}{{slackSectionTextMD (printf `*Resources grouped with notification:* %s` (join .groupedResources "\n"))}},{{end}}
 		{{ slackURLAction "View Health Check" .permalink "🔕 Silence" .silenceURL}}
 	]

--- a/notification/templates/check.passed
+++ b/notification/templates/check.passed
@@ -14,10 +14,13 @@
 				{{end}}
 			]
 		},
-    {{ if .check.labels}}{{slackSectionLabels .check}},{{end}}
+    {{- if .check.labels -}}
+		{{- $labelSection := slackSectionLabels .check -}}
+		{{- if $labelSection }}{{$labelSection}},{{end}}
+	{{- end}}
 		{{if .groupedResources}}{{slackSectionTextMD (printf `*Resources grouped with notification:* %s` (join .groupedResources "\n"))}},{{end}}
     {{ slackURLAction "View Health Check" .permalink "🔕 Silence" .silenceURL}}
-  ]
+	]
 }
 {{ else }}
 Canary: {{.canary.name}}

--- a/notification/templates/component.health
+++ b/notification/templates/component.health
@@ -14,7 +14,10 @@
 				{{end}}
 			]
 		},
-		{{if .component.labels}}{{slackSectionLabels .component}},{{end}}
+		{{- if .component.labels -}}
+			{{- $labelSection := slackSectionLabels .component -}}
+			{{- if $labelSection }}{{$labelSection}},{{end}}
+		{{- end}}
 		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
 		{{slackURLAction "View Component" .permalink "🔕 Silence" .silenceURL}}
 	]

--- a/notification/templates/config.db.update
+++ b/notification/templates/config.db.update
@@ -14,7 +14,10 @@
 				{{end}}
 			]
 		},
-		{{if .config.labels}}{{slackSectionLabels .config}},{{end}}
+		{{- if .config.labels -}}
+			{{- $labelSection := slackSectionLabels .config -}}
+			{{- if $labelSection }}{{$labelSection}},{{end}}
+		{{- end}}
 		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
 		{{slackURLAction "View Catalog" .permalink "🔕 Silence" .silenceURL}}
 	]

--- a/notification/templates/config.health
+++ b/notification/templates/config.health
@@ -14,7 +14,10 @@
 				{{end}}
 			]
 		},
-		{{if .config.labels}}{{slackSectionLabels .config}},{{end}}
+		{{- if .config.labels -}}
+			{{- $labelSection := slackSectionLabels .config -}}
+			{{- if $labelSection }}{{$labelSection}},{{end}}
+		{{- end}}
 		{{if .recent_events}}{{slackSectionTextMD (printf `*Recent Events:* %v` (join .recent_events ", "))}},{{end}}
 		{{if .groupedResources}}{{slackSectionTextMD (printf `*Also Failing:* - %s` (join .groupedResources "\n - "))}},{{end}}
 		{"type": "divider"},

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -202,7 +202,7 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 				return nil, fmt.Errorf("failed to get grouped resources: %w", err)
 			}
 
-			result.Slack, err = slackBlocks(ctx, knowledgebase, diagnosisReport, llm.PlaybookRecommendations{}, groupedResources)
+			result.Slack, err = formatDiagnosisReportAsSlackBlocks(ctx, knowledgebase, diagnosisReport, llm.PlaybookRecommendations{}, groupedResources)
 			if err != nil {
 				return nil, fmt.Errorf("failed to merge blocks: %w", err)
 			}
@@ -258,7 +258,7 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 				return nil, fmt.Errorf("failed to get grouped resources: %w", err)
 			}
 
-			blocks, err := slackBlocks(ctx, knowledgebase, diagnosisReport, recommendations, groupedResources)
+			blocks, err := formatDiagnosisReportAsSlackBlocks(ctx, knowledgebase, diagnosisReport, recommendations, groupedResources)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal blocks: %w", err)
 			}

--- a/playbook/actions/ai_slack.go
+++ b/playbook/actions/ai_slack.go
@@ -133,9 +133,9 @@ func createResourceActionButtons(resourceID string) map[string]any {
 	}
 }
 
-// slackBlocks generates a Slack message with blocks for the diagnosis report and recommendations.
+// formatDiagnosisReportAsSlackBlocks generates a Slack message with blocks for the diagnosis report and recommendations.
 // It returns the JSON string representation of the Slack blocks.
-func slackBlocks(ctx context.Context, knowledge *KnowledgeGraph, diagnosisReport llm.DiagnosisReport, recommendations llm.PlaybookRecommendations, groupedResources []string) (string, error) {
+func formatDiagnosisReportAsSlackBlocks(ctx context.Context, knowledge *KnowledgeGraph, diagnosisReport llm.DiagnosisReport, recommendations llm.PlaybookRecommendations, groupedResources []string) (string, error) {
 	var blocks []map[string]any
 	divider := map[string]any{"type": slackBlockTypeDivider}
 	affectedResource := knowledge.Configs[0]
@@ -149,7 +149,9 @@ func slackBlocks(ctx context.Context, knowledge *KnowledgeGraph, diagnosisReport
 	})
 
 	if trimmedTagsAndLabels := affectedResource.GetTrimmedLabels(); len(trimmedTagsAndLabels) > 0 {
-		blocks = append(blocks, notification.CreateSlackFieldsSection(trimmedTagsAndLabels))
+		if section := notification.CreateSlackFieldsSection(trimmedTagsAndLabels); section != nil {
+			blocks = append(blocks, section)
+		}
 	}
 
 	blocks = append(blocks, divider)


### PR DESCRIPTION
mission control job config had neither tags nor the labels which
generated a slack block for labels with empty fields
```json
{
  "fields": null,
  "type": "section"
}
```

resolves: https://github.com/flanksource/mission-control/issues/2600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty label sections and stray commas appearing in Slack notifications
  * Improved whitespace handling in notification templates for cleaner formatting

* **New Features**
  * Added Agent and Message line display in notification blocks when available

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->