### PR TITLE
fix: handle playbook run fk in notification send history cleanup

### DIFF
--- a/db/notifications.go
+++ b/db/notifications.go
@@ -235,6 +235,7 @@ func DeleteNotificationSendHistory(ctx context.Context, days int) (int64, error)
 	tx := ctx.DB().
 		Model(&models.NotificationSendHistory{}).
 		Where("playbook_run_id IS NULL").
+		Where("id NOT IN (SELECT notification_send_id FROM playbook_runs WHERE notification_send_id IS NOT NULL)").
 		Where(fmt.Sprintf("created_at < NOW() - INTERVAL '%d DAYS'", days)).
 		Delete(&models.NotificationSendHistory{})
 	return tx.RowsAffected, tx.Error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification send history retention to prevent deletion of records linked to playbook runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->