### PR TITLE
fix: MCP tool schema

### DIFF
--- a/mcp/catalog.go
+++ b/mcp/catalog.go
@@ -363,7 +363,10 @@ func registerCatalog(s *server.MCPServer) {
 			mcp.Description("Search query."+queryDescription),
 		),
 		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Number of items to return. Default: %d", defaultQueryLimit))),
-		mcp.WithArray("select", mcp.Description("a list of columns to return. Default: id,name,type,health,status,description,updated_at,created_at. Always specify minimal columns needed for token efficiency.")),
+		mcp.WithArray("select",
+			mcp.WithStringItems(),
+			mcp.Description("a list of columns to return. Default: id,name,type,health,status,description,updated_at,created_at. Always specify minimal columns needed for token efficiency."),
+		),
 	)
 	s.AddTool(searchCatalogTool, searchCatalogHandler)
 
@@ -471,7 +474,10 @@ func registerCatalog(s *server.MCPServer) {
 			mcp.Description("Search query"+configChangeQueryDescription),
 		),
 		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Number of results to return. Default: %d", defaultQueryLimit))),
-		mcp.WithArray("select", mcp.Description("a list of columns to return. Default: id,config_id,name,type,change_type,severity,summary,created_at,first_observed,count. Always specify minimal columns needed for token efficiency. Avoid 'config', 'details', and 'diff' columns unless absolutely necessary as they contain large JSON data.")),
+		mcp.WithArray("select",
+			mcp.WithStringItems(),
+			mcp.Description("a list of columns to return. Default: id,config_id,name,type,change_type,severity,summary,created_at,first_observed,count. Always specify minimal columns needed for token efficiency. Avoid 'config', 'details', and 'diff' columns unless absolutely necessary as they contain large JSON data."),
+		),
 	)
 	s.AddTool(searchCatalogChangesTool, searchConfigChangesHandler)
 


### PR DESCRIPTION
fixes tool schema for 2 tools. Never had issue with Claude code but the vercel ai sdk complained about it.

    responseBody: '{\n' +
      '  "error": {\n' +
      `    "message": "Invalid schema for function 'search_catalog': In context=('properties', 'select'), array schema missing items.",\n` +
      '    "type": "invalid_request_error",\n' +
      '    "param": "tools[34].parameters",\n' +
      '    "code": "invalid_function_parameters"\n' +
      '  }\n' +
      '}',


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced parameter validation for catalog search operations to ensure consistent data handling and prevent input errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->