### PR TITLE
feat: gitops patch default path

### DIFF
--- a/playbook/actions/gitops_test.go
+++ b/playbook/actions/gitops_test.go
@@ -9,15 +9,17 @@ import (
 	commons "github.com/flanksource/commons/context"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/types"
-	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/flanksource/incident-commander/pkg/clients/git"
-	"github.com/flanksource/incident-commander/pkg/clients/git/connectors"
 	"github.com/flanksource/gomplate/v3"
 	gitv5 "github.com/go-git/go-git/v5"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/yaml"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/pkg/clients/git"
+	"github.com/flanksource/incident-commander/pkg/clients/git/connectors"
 )
 
 var _ = ginkgo.Describe("Playbook Action Gitops", ginkgo.Label("slow"), ginkgo.Ordered, func() {
@@ -90,7 +92,7 @@ var _ = ginkgo.Describe("Playbook Action Gitops", ginkgo.Label("slow"), ginkgo.O
 		}
 
 		var runner = GitOps{Context: ctx}
-		res, err := runner.Run(ctx, spec)
+		res, err := runner.Run(ctx, spec, query.GitOpsSource{})
 		Expect(err).To(BeNil())
 		Expect(len(res.Links)).To(BeZero())
 

--- a/playbook/runner/exec.go
+++ b/playbook/runner/exec.go
@@ -109,7 +109,7 @@ func executeAction(ctx context.Context, playbookID any, runID uuid.UUID, runActi
 
 	if actionSpec.GitOps != nil {
 		var e = actions.GitOps{Context: ctx}
-		result1, err2 := e.Run(ctx, *actionSpec.GitOps)
+		result1, err2 := e.Run(ctx, *actionSpec.GitOps, templateEnv.GitOps)
 		if result != nil {
 			result = []any{result, result1}
 		} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps actions now use the configured source file as a default patch location, so patches without explicit paths automatically resolve to the repository's default patch path.

* **Refactor**
  * Improved patch path resolution and fallback behavior for GitOps, streamlining how patches are located and applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->