### PR TITLE
chore: make sql driver optional in playbooks

### DIFF
--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -249,7 +249,7 @@ type SQLAction struct {
 	Query string `yaml:"query" json:"query" template:"true"`
 	// Driver is the name of the underlying database to connect to.
 	// Example: postgres, mysql, ...
-	Driver string `yaml:"driver" json:"driver"`
+	Driver string `yaml:"driver,omitempty" json:"driver,omitempty"`
 }
 
 type HTTPConnection struct {

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -3355,7 +3355,6 @@ spec:
                           description: URL is the database connection url
                           type: string
                       required:
-                      - driver
                       - query
                       type: object
                     templatesOn:

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -1698,8 +1698,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "query",
-        "driver"
+        "query"
       ]
     },
     "SecretKeySelector": {

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -1852,8 +1852,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "query",
-        "driver"
+        "query"
       ]
     },
     "SecretKeySelector": {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/mission-control/issues/2576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * The driver field for SQL playbook actions is now optional, providing greater flexibility when configuring SQL actions. Users can now omit explicit driver specification when defaults apply.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->