### PR TITLE
fix: propagate view refresh error when respondign with cached view

### DIFF
--- a/api/openapi-full.yaml
+++ b/api/openapi-full.yaml
@@ -2668,6 +2668,12 @@ components:
           type: string
         icon:
           type: string
+        refresh_status:
+          type: string
+        refresh_error:
+          type: string
+        response_source:
+          type: string
         last_refreshed_at:
           type: string
           format: date-time

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1701,6 +1701,12 @@ components:
           type: string
         icon:
           type: string
+        refresh_status:
+          type: string
+        refresh_error:
+          type: string
+        response_source:
+          type: string
         last_refreshed_at:
           type: string
           format: date-time

--- a/api/view.go
+++ b/api/view.go
@@ -64,7 +64,11 @@ type ViewResult struct {
 	Title     string `json:"title"`
 	Icon      string `json:"icon,omitempty"`
 
-	LastRefreshedAt    time.Time        `json:"lastRefreshedAt"`
+	RefreshStatus   string    `json:"refreshStatus,omitempty"`
+	RefreshError    string    `json:"refreshError,omitempty"`
+	ResponseSource  string    `json:"responseSource,omitempty"`
+	LastRefreshedAt time.Time `json:"lastRefreshedAt"`
+
 	RequestFingerprint string           `json:"requestFingerprint,omitempty"`
 	Columns            []view.ColumnDef `json:"columns,omitempty"`
 	Rows               []view.Row       `json:"rows,omitempty"`
@@ -83,6 +87,15 @@ type ViewResult struct {
 
 	Sections []ViewSection `json:"sections,omitempty"`
 }
+
+const (
+	ViewRefreshStatusCache = "cache"
+	ViewRefreshStatusFresh = "fresh"
+	ViewRefreshStatusError = "error"
+
+	ViewResponseSourceCache = "cache"
+	ViewResponseSourceFresh = "fresh"
+)
 
 // +kubebuilder:object:generate=true
 // +kubebuilder:validation:XValidation:rule="(has(self.values) && !has(self.valueFrom)) || (!has(self.values) && has(self.valueFrom))",message="exactly one of values or valueFrom is required"


### PR DESCRIPTION
related: https://github.com/flanksource/mission-control/issues/2597
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * View API results now include refresh metadata: status indicators, error details (when refresh fails), and a source flag indicating whether returned data is cached or fresh. This provides greater transparency into data refresh operations and failure scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->