### PR TITLE
feat: Change prometheus connection testing to run a simple query

### DIFF
--- a/connection/check.go
+++ b/connection/check.go
@@ -267,7 +267,7 @@ func Test(ctx context.Context, c *models.Connection) error {
 			client = client.Auth(c.Username, c.Password)
 		}
 
-		response, err := client.R(ctx).Get("api/v1/status/config")
+		response, err := client.R(ctx).Get("api/v1/query?query=1")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Google’s docs do not list /api/v1/status/config as a supported endpoint for Managed Service for Prometheus. Their “API compatibility” list only includes query/labels/metadata endpoints (e.g., /api/v1/query, /api/v1/query_range, /api/v1/metadata, /api/v1/labels, /
  api/v1/query_exemplars) and does not include any /api/v1/status/* endpoints. So it’s reasonable to treat /api/v1/status/config as unsupported there. (docs.cloud.google.com (https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/query-api-ui?utm_source=openai))
