### PR TITLE
feat: require authentication for /metrics endpoint by default

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flanksource/commons/hash"
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/commons/properties"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
@@ -51,7 +52,6 @@ var (
 
 var skipAuthPaths = []string{
 	"/health",
-	"/metrics",
 	"/kratos/",
 	"/canary/webhook/",
 	"/playbook/webhook/", // Playbook webhooks handle the authentication themselves
@@ -121,6 +121,12 @@ func canSkipAuth(c echo.Context) bool {
 			return true
 		}
 	}
+
+	// /metrics requires auth by default, unless metrics.auth.disabled is true
+	if c.Path() == "/metrics" && properties.On(false, "metrics.auth.disabled") {
+		return true
+	}
+
 	return false
 }
 

--- a/mission-control.properties.example
+++ b/mission-control.properties.example
@@ -29,6 +29,8 @@ log.level.view=trace
 # Disable metrics by name (comma-separated). Use * to disable all.
 # metrics.disable=config_items_info,config_items_health
 # metrics.disable=*
+# Disable authentication requirement for /metrics endpoint
+# metrics.auth.disabled=false
 metrics.agents.cache_ttl=5m
 metrics.checks.cache_ttl=5m
 metrics.config_items.cache_ttl=5m

--- a/tests/middleware_test.go
+++ b/tests/middleware_test.go
@@ -180,7 +180,6 @@ var _ = Describe("Authorization", func() {
 	}
 
 	var anonymous = []string{
-		"GET /metrics",
 		"GET /health",
 		"GET /properties",
 	}


### PR DESCRIPTION
Implement configurable authentication for the /metrics endpoint.

Set `metrics.auth.disabled=true` to allow unauthenticated access.

resolves: https://github.com/flanksource/mission-control/issues/2753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics endpoint now requires authentication by default. Authentication can be disabled through configuration settings.

* **Tests**
  * Updated test expectations to reflect new metrics endpoint authentication behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->