### PR TITLE
feat: add dedicated metrics listener

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&httpPort, "httpPort", 8080, "Server port")
 	flags.StringVar(&api.Namespace, "namespace", utils.Coalesce(os.Getenv("NAMESPACE"), "default"), "Namespace to use for config/secret lookups")
 	flags.IntVar(&devGuiPort, "devGuiPort", 3004, "Port used by a local npm server in development mode")
-	flags.IntVar(&metricsPort, "metricsPort", 8081, "Port to expose a health dashboard ")
+	flags.IntVar(&metricsPort, "metricsPort", 0, "Dedicated unauthenticated metrics port (0 disables). /metrics on main server unchanged")
 	flags.BoolVar(&dev, "dev", false, "Run in development mode")
 	flags.BoolVar(&disableOperators, "disable-operators", false, "Disable Kubernetes Operators")
 	flags.StringVar(&api.FrontendURL, "frontend-url", "http://localhost:3000", "URL of the frontend")

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -42,7 +42,7 @@ func getMetricLabels(m *dto.Metric) map[string]string {
 
 var _ = ginkgo.Describe("Metrics", func() {
 	ginkgo.It("should expose config_items metrics with correct labels and values", func() {
-		families, err := fetchAndParseMetrics(server.URL)
+		families, err := fetchAndParseMetrics(metricsServer.URL)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get expected config count
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 	})
 
 	ginkgo.It("should expose checks metrics with correct labels and values", func() {
-		families, err := fetchAndParseMetrics(server.URL)
+		families, err := fetchAndParseMetrics(metricsServer.URL)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Get expected check count
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 		// This excludes high-cardinality labels like pod names, instance IDs, and revisions
 		// but includes useful labels like cluster, namespace, env, region
 
-		families, err := fetchAndParseMetrics(server.URL)
+		families, err := fetchAndParseMetrics(metricsServer.URL)
 		Expect(err).ToNot(HaveOccurred())
 
 		infoFamily, ok := families["mission_control_checks_info"]
@@ -181,7 +181,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 	})
 
 	ginkgo.It("should expose db stats metrics with correct values", func() {
-		families, err := fetchAndParseMetrics(server.URL)
+		families, err := fetchAndParseMetrics(metricsServer.URL)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify db_size_mb

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -46,6 +46,7 @@ var (
 	tempPath       string
 	e              *echo.Echo
 	server         *httptest.Server
+	metricsServer  *httptest.Server
 	DefaultContext context.Context
 	client         sdk.PlaybookAPI
 )
@@ -101,11 +102,13 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	server = httptest.NewServer(e)
+	metricsServer = httptest.NewServer(echoSrv.MetricsHandler())
 	client = sdk.NewPlaybookClient(server.URL)
 	client.Client = client.
 		Auth(dummy.JohnDoe.Name, "admin").
 		Header("X-Trace", "true")
 	logger.Infof("Started test server @ %s", server.URL)
+	logger.Infof("Started metrics server @ %s", metricsServer.URL)
 
 	if err := testdata.LoadConnections(DefaultContext); err != nil {
 		ginkgo.Fail(err.Error())
@@ -118,4 +121,5 @@ var _ = ginkgo.BeforeSuite(func() {
 var _ = ginkgo.AfterSuite(func() {
 	setup.AfterSuiteFn()
 	server.Close()
+	metricsServer.Close()
 })


### PR DESCRIPTION
Add optional unauthenticated metrics server and update e2e metrics tests to scrape it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics are now exposed via a dedicated, unauthenticated HTTP server running on a separate port.

* **Breaking Changes**
  * The metrics server is disabled by default (port 0). Configure the metrics port flag explicitly to enable it and expose Prometheus metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->