### PR TITLE
fix(mcp): prevent sporadic panics in MCP tests using stateless mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jenkins-x/go-scm v1.15.16
-	github.com/mark3labs/mcp-go v0.43.0
+	github.com/mark3labs/mcp-go v0.43.2
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.4

--- a/go.sum
+++ b/go.sum
@@ -834,6 +834,8 @@ github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mark3labs/mcp-go v0.43.0 h1:lgiKcWMddh4sngbU+hoWOZ9iAe/qp/m851RQpj3Y7jA=
 github.com/mark3labs/mcp-go v0.43.0/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
+github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
+github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
The MCP tests were failing intermittently (roughly 50% of the time) with
a nil pointer dereference panic in the mcp-go library:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x55b9d2]

  goroutine 267 [running]:
  bufio.(*Writer).Flush(0x6005e40?)
      /opt/hostedtoolcache/go/1.25.6/x64/src/bufio/bufio.go:639 +0x12
  net/http.(*chunkWriter).flush(0x60bb500?)
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:405 +0x39
  net/http.(*response).FlushError(0xc0007b93b0)
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:1765 +0x4b
  net/http.(*ResponseController).Flush(0x60bb500?)
      /opt/hostedtoolcache/go/1.25.6/x64/src/net/http/responsecontroller.go:52 +0xf9
  github.com/labstack/echo/v4.(*Response).Flush(0xbb696f0?)
      /home/runner/go/pkg/mod/github.com/labstack/echo/v4@v4.13.4/response.go:89 +0x29
  github.com/mark3labs/mcp-go/server.(*StreamableHTTPServer).handlePost.func1.1.1()
      /server/streamable_http.go:400 +0x39
```

## Root cause:

The MCP server uses SSE (Server-Sent Events) by default. When handling a
request, it spawns a goroutine that waits for notifications. This goroutine
has a deferred flusher.Flush() (at streamable_http.go:398-403) that runs when
the goroutine exits.

The race condition:
1. Test makes request → MCP server spawns notification goroutine
2. Test receives response and completes
3. testServer.Close() kills the HTTP response writer
4. The goroutine exits (due to context cancellation)
5. Deferred flusher.Flush() runs on the closed writer → PANIC

## Fix:

Use server.WithStateLess(true) for the test MCP server. Stateless mode handles
requests synchronously without spawning persistent goroutines, eliminating the
race between server shutdown and goroutine cleanup.

Also ensure proper cleanup order in AfterSuite: close the MCP client before
closing the test server to allow graceful termination of any in-flight requests.

Additionally updated `mcp-go` from v0.43.0 to v0.43.2 for latest bug fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP library dependency to v0.43.2.

* **Tests**
  * Enhanced test server configuration with updated request processing settings.
  * Improved test cleanup procedures with refined resource shutdown sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->