### PR TITLE
feat: add HTTP query support to views

### DIFF
--- a/fixtures/views/recipes-http.yaml
+++ b/fixtures/views/recipes-http.yaml
@@ -1,0 +1,38 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: View
+metadata:
+  name: recipes
+  namespace: mc
+spec:
+  description: Display recipes from DummyJSON API
+  cache:
+    maxAge: 30m
+    minAge: 5s
+  display:
+    title: Recipes
+    icon: book
+    sidebar: true
+  columns:
+    - name: id
+      type: number
+      primaryKey: true
+    - name: name
+      type: string
+    - name: cuisine
+      type: string
+    - name: difficulty
+      type: string
+    - name: rating
+      type: number
+    - name: prepTimeMinutes
+      type: number
+    - name: cookTimeMinutes
+      type: number
+    - name: servings
+      type: number
+  queries:
+    recipes:
+      http:
+        url: https://dummyjson.com/recipes
+        jsonpath: $.recipes[:10]
+ 

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gorm.io/driver/mysql v1.6.0 // indirect
 	gorm.io/driver/postgres v1.6.0 // indirect
-	gorm.io/driver/sqlserver v1.6.1 // indirect
+	gorm.io/driver/sqlserver v1.6.3 // indirect
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
 	gorm.io/plugin/prometheus v0.1.0 // indirect
 	k8s.io/apiextensions-apiserver v0.34.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1706,8 +1706,8 @@ gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXD
 gorm.io/driver/sqlite v1.5.0/go.mod h1:kDMDfntV9u/vuMmz8APHtHF0b4nyBB7sfCieC6G8k8I=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
-gorm.io/driver/sqlserver v1.6.1 h1:XWISFsu2I2pqd1KJhhTZNJMx1jNQ+zVL/Q8ovDcUjtY=
-gorm.io/driver/sqlserver v1.6.1/go.mod h1:VZeNn7hqX1aXoN5TPAFGWvxWG90xtA8erGn2gQmpc6U=
+gorm.io/driver/sqlserver v1.6.3 h1:UR+nWCuphPnq7UxnL57PSrlYjuvs+sf1N59GgFX7uAI=
+gorm.io/driver/sqlserver v1.6.3/go.mod h1:VZeNn7hqX1aXoN5TPAFGWvxWG90xtA8erGn2gQmpc6U=
 gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/gorm v1.25.0/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/gorm v1.30.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=


### PR DESCRIPTION
Add HTTP query support to the view dataquery system. This enables views to fetch
data from external HTTP APIs and use it in their queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom headers support for webhooks, Prometheus queries, and HTTP requests with configurable value sources
  * PowerShell runtime option for playbook setup steps alongside existing shells
  * HTTP query integration for views with support for JSONPath extraction, multiple authentication methods, and TLS configuration

* **Chores**
  * Modernized dependencies including Kubernetes, OpenTelemetry, and core libraries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->