### PR TITLE
fix(views): include namespace in context when running views

### DIFF
--- a/views/run.go
+++ b/views/run.go
@@ -26,7 +26,7 @@ const valueFromMaxResults = 100
 
 // Run executes the view queries and returns the rows with data
 func Run(ctx context.Context, view *v1.View, request *requestOpt) (*api.ViewResult, error) {
-	ctx = ctx.WithName("view")
+	ctx = ctx.WithName("view").WithNamespace(view.GetNamespace())
 
 	output := api.ViewResult{
 		Namespace:          view.Namespace,


### PR DESCRIPTION
Add namespace to the context during view execution so that namespace-aware operations have proper context information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected namespace context propagation in view operations to ensure the view's namespace is properly available to all dependent queries, logging, and tracing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->