### PR TITLE
docs: add HTTP query view fixtures with real API examples

### DIFF
--- a/fixtures/views/http-connection.yaml
+++ b/fixtures/views/http-connection.yaml
@@ -1,0 +1,30 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: View
+metadata:
+  name: http-connection-example
+  namespace: default
+spec:
+  description: Example of using a stored connection for HTTP queries
+  display:
+    title: GitHub Repos
+    icon: github
+    sidebar: true
+  columns:
+    - name: name
+      type: string
+      primaryKey: true
+    - name: stars
+      type: number
+    - name: language
+      type: string
+  queries:
+    repos:
+      http:
+        url: https://api.github.com/users/flanksource/repos
+        headers:
+          - name: Accept
+            value: application/vnd.github.v3+json
+  mapping:
+    name: row.name
+    stars: row.stargazers_count
+    language: row.language

--- a/fixtures/views/http-post-body.yaml
+++ b/fixtures/views/http-post-body.yaml
@@ -1,0 +1,44 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: View
+metadata:
+  name: http-post-body-example
+  namespace: default
+spec:
+  description: Example of POST request with templated body using httpbin
+  display:
+    title: HTTP POST Echo
+    icon: web
+  columns:
+    - name: url
+      type: string
+      primaryKey: true
+    - name: origin
+      type: string
+    - name: content_type
+      type: string
+    - name: sent_message
+      type: string
+      description: The message sent in the POST body (echoed back by httpbin)
+  templating:
+    - key: message
+      label: Message
+      values:
+        - "Hello from Mission Control"
+        - "Test message"
+        - "API call"
+      default: "Hello from Mission Control"
+  queries:
+    echo:
+      http:
+        url: https://httpbin.org/post
+        method: POST
+        body: |
+          {"message": "$(var.message)", "timestamp": "2024-01-15T10:30:00Z"}
+        headers:
+          - name: Content-Type
+            value: application/json
+  mapping:
+    url: row.url
+    origin: row.origin
+    content_type: row.headers["Content-Type"]
+    sent_message: row.json.message


### PR DESCRIPTION
Add example views demonstrating HTTP query features:
- http-connection.yaml: GitHub API with stored connection
- http-post-body.yaml: httpbin.org POST with templated body and variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example configurations demonstrating HTTP-based data retrieval from external APIs.
  * Included examples for HTTP GET and POST request patterns with response mapping and templating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->