### PR TITLE
feat(fixtures): add kubectl playbook fixture

### DIFF
--- a/fixtures/playbooks/kubectl.yaml
+++ b/fixtures/playbooks/kubectl.yaml
@@ -1,0 +1,26 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  name: kubectl
+  namespace: mc
+spec:
+  title: Kubectl
+  description: Run a kubectl command against a Kubernetes cluster
+  icon: k8s
+  configs:
+    - types:
+        - Kubernetes::*
+  parameters:
+    - name: command
+      label: Kubectl Command
+      type: code
+      required: true
+      default: get pods
+      properties:
+        language: shell
+  actions:
+    - name: Run kubectl command
+      exec:
+        script: kubectl {{.params.command}}
+        connections:
+          fromConfigItem: "{{.config.id}}" # uses the kubeconfig from the selected config's scrapeconfig.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kubectl playbook template that enables users to execute kubectl commands directly through the platform with configurable command parameters and seamless integration with existing Kubernetes configurations, enhancing container management and operational automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->