### PR TITLE
fix(application): skip scraper generation for non-azure scrapers

### DIFF
--- a/application/scraper.go
+++ b/application/scraper.go
@@ -79,17 +79,19 @@ func generateConfigScraper(ctx context.Context, app *v1.Application) error {
 			return ctx.Oops().Wrapf(err, "failed to unmarshal scrape config %s", scraperID)
 		}
 
-		if len(spec.Azure) > 0 {
-			appRoleSelectors := lo.Map(selectors, func(selector types.ResourceSelector, _ int) types.ResourceSelector {
-				selector.Scope = scraperID.String()
-				return selector
-			})
+		if len(spec.Azure) == 0 {
+			continue
+		}
 
-			// Keep the remaining fields the same. Just modify the Entra config.
-			spec.Azure[0].Include = []string{"entra"}
-			spec.Azure[0].Entra = &Entra{
-				AppRoleAssignments: appRoleSelectors,
-			}
+		appRoleSelectors := lo.Map(selectors, func(selector types.ResourceSelector, _ int) types.ResourceSelector {
+			selector.Scope = scraperID.String()
+			return selector
+		})
+
+		// Keep the remaining fields the same. Just modify the Entra config.
+		spec.Azure[0].Include = []string{"entra"}
+		spec.Azure[0].Entra = &Entra{
+			AppRoleAssignments: appRoleSelectors,
 		}
 
 		specJSON, err := json.Marshal(spec)


### PR DESCRIPTION
generateConfigScraper only makes sense for Azure scrapers — its sole purpose is to set up Entra AppRoleAssignments scraping. The original code guarded the spec modification with `if len(spec.Azure) > 0`, but the Marshal and DB save ran unconditionally outside that block. This meant non-Azure scrapers (e.g. configs of type MissionControl::Playbook) would still produce a generated scraper.

Fix by skipping the scraper entirely with an early `continue` when spec.Azure is empty.

<img width="452" height="362" alt="image" src="https://github.com/user-attachments/assets/c2dc8b61-9e86-4801-95bc-54d60f75ce80" />
