### PR TITLE
fix(application): deduplicate users list and populate missing fields

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -46,21 +46,12 @@ func buildApplication(ctx context.Context, app *v1.Application) (*api.Applicatio
 			return nil, ctx.Oops().Errorf("failed to find login IDs: %w", err)
 		}
 
-		configAccesses, err := query.FindConfigAccessByConfigIDs(ctx, configs)
+		users, err := db.GetDistinctUserRoleFromConfigAccess(ctx, configs)
 		if err != nil {
 			return nil, ctx.Oops().Errorf("failed to find config accesses: %w", err)
 		}
 
-		for _, ca := range configAccesses {
-			response.AccessControl.Users = append(response.AccessControl.Users, api.UserAndRole{
-				Name:             ca.User,
-				Email:            ca.Email,
-				Role:             ca.Role,
-				CreatedAt:        ca.CreatedAt,
-				LastLogin:        ca.LastSignedInAt,
-				LastAccessReview: ca.LastReviewedAt,
-			})
-		}
+		response.AccessControl.Users = users
 	}
 
 	if len(mapping.Datasources) > 0 {


### PR DESCRIPTION
Deduplicate Users & Roles 

Also populate the previously missing ID and AuthType fields on UserAndRole.


fixes:

<img width="1502" height="535" alt="image" src="https://github.com/user-attachments/assets/3e8fdcae-bc19-416a-adcd-71bc49fbab80" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved user access control data retrieval for configuration management. User-role relationships are now obtained through a consolidated query operation instead of iterative processing, eliminating unnecessary loops. This streamlines how access control information is aggregated across multiple configurations, resulting in a more direct data flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->