### PR TITLE
fix(playbook): clear stale body_payload for playbook notifications

### DIFF
--- a/playbook/actions/notification.go
+++ b/playbook/actions/notification.go
@@ -36,7 +36,6 @@ func (t *Notification) Run(ctx context.Context, action v1.NotificationAction) (*
 		Message: data.Message,
 	}
 	if service == "slack" {
-		output.Message = ""
 		if notification.IsSlackBlocksJSON(data.Message) {
 			output.Slack = data.Message
 		} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Slack notifications to properly display and preserve message content.

* **Improvements**
  * Optimized notification record updates to only modify changed fields for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->