### PR TITLE
fix(notifications): add limit to silence preview and sort by newest

### DIFF
--- a/db/notifications.go
+++ b/db/notifications.go
@@ -448,7 +448,8 @@ func GetNotificationSendHistory(ctx context.Context, timeWindowDays int, status 
 			OR (source_event LIKE 'component.%' AND EXISTS (SELECT 1 FROM components c WHERE c.id = notification_send_history.resource_id AND c.deleted_at IS NULL))
 			OR (source_event LIKE 'check.%' AND EXISTS (SELECT 1 FROM checks ch WHERE ch.id = notification_send_history.resource_id AND ch.deleted_at IS NULL))
 			OR (source_event LIKE 'canary.%' AND EXISTS (SELECT 1 FROM canaries ca WHERE ca.id = notification_send_history.resource_id AND ca.deleted_at IS NULL))
-		)`)
+		)`).
+		Order("created_at DESC")
 
 	if len(status) > 0 {
 		q = q.Where("status IN ?", status)

--- a/notification/controllers.go
+++ b/notification/controllers.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/flanksource/duty/api"
@@ -108,13 +109,20 @@ type NotificationSilencePreviewItem struct {
 	BodyMarkdown                   string         `json:"body_markdown,omitempty"`
 }
 
+const DefaultNotificationSilencePreviewLimit = 30
+
 func NotificationSilencePreview(c echo.Context) error {
 	ctx := c.Request().Context().(context.Context)
+
 	params := CanSilenceParams{
 		ResourceID:   c.QueryParam("id"),
 		ResourceType: c.QueryParam("type"),
 		Recursive:    c.QueryParam("recursive") == "true",
 		Filter:       c.QueryParam("filter"),
+		Limit:        DefaultNotificationSilencePreviewLimit,
+	}
+	if limit, err := strconv.Atoi(c.QueryParam("limit")); err == nil {
+		params.Limit = limit
 	}
 
 	if selectorsRaw := c.QueryParam("selectors"); selectorsRaw != "" {
@@ -126,7 +134,7 @@ func NotificationSilencePreview(c echo.Context) error {
 		params.Selectors = selectors
 	}
 
-	h, err := db.GetNotificationSendHistory(ctx, 15, []string{models.NotificationStatusSent}, -1, -1)
+	h, err := db.GetNotificationSendHistory(ctx, 15, []string{models.NotificationStatusSent}, params.Limit, -1)
 	if err != nil {
 		return api.WriteError(c, err)
 	}

--- a/notification/silence.go
+++ b/notification/silence.go
@@ -212,6 +212,7 @@ type CanSilenceParams struct {
 	Recursive    bool
 	Filter       string
 	Selectors    types.ResourceSelectors
+	Limit        int
 }
 
 func CanSilence(ctx context.Context, h []models.NotificationSendHistory, params CanSilenceParams) ([]models.NotificationSendHistory, error) {


### PR DESCRIPTION
Fixes: https://github.com/flanksource/flanksource-ui/issues/2891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customize the number of notifications displayed in the silence preview using an optional query parameter (defaults to 30).

* **Improvements**
  * Notification history is now ordered by creation date, displaying most recent entries first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->