### PR TITLE
chore: set max limit for notification silence preview

### DIFF
--- a/notification/controllers.go
+++ b/notification/controllers.go
@@ -109,7 +109,10 @@ type NotificationSilencePreviewItem struct {
 	BodyMarkdown                   string         `json:"body_markdown,omitempty"`
 }
 
-const DefaultNotificationSilencePreviewLimit = 30
+const (
+	DefaultNotificationSilencePreviewLimit = 30
+	MaxNotificationSilencePreviewLimit     = 100
+)
 
 func NotificationSilencePreview(c echo.Context) error {
 	ctx := c.Request().Context().(context.Context)
@@ -122,7 +125,7 @@ func NotificationSilencePreview(c echo.Context) error {
 		Limit:        DefaultNotificationSilencePreviewLimit,
 	}
 	if limit, err := strconv.Atoi(c.QueryParam("limit")); err == nil {
-		params.Limit = limit
+		params.Limit = max(limit, MaxNotificationSilencePreviewLimit)
 	}
 
 	if selectorsRaw := c.QueryParam("selectors"); selectorsRaw != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification silence preview behavior: preview request limits are now validated and clamped to a sensible maximum, preventing overly large or invalid preview requests and ensuring consistent, reliable preview results for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->