### PR TITLE
feat(middleware): add Server-Timing response header

### DIFF
--- a/echo/serve.go
+++ b/echo/serve.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/flanksource/incident-commander/agent"
 	"github.com/flanksource/incident-commander/api"
+	mcMiddleware "github.com/flanksource/incident-commander/middleware"
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/auth"
 	"github.com/flanksource/incident-commander/db"
@@ -131,6 +132,7 @@ func New(ctx context.Context) *echov4.Echo {
 	dutyEcho.AddDebugHandlers(ctx, e, rbac.Authorization(policy.ObjectMonitor, policy.ActionUpdate))
 
 	e.Use(ServerCache)
+	e.Use(mcMiddleware.ServerTiming)
 
 	e.GET("/kubeconfig", DownloadKubeConfig, rbac.Authorization(policy.ObjectKubernetesProxy, policy.ActionCreate))
 	Forward(ctx, e, "/kubeproxy", "https://kubernetes.default.svc", &ForwardOptions{

--- a/middleware/server_timing.go
+++ b/middleware/server_timing.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"fmt"
+	"time"
+
+	echov4 "github.com/labstack/echo/v4"
+)
+
+// ServerTiming is a middleware that measures the total time taken by the
+// HTTP handler chain and returns it in the standard Server-Timing response
+// header (RFC 7611).
+//
+// The header value looks like: server;dur=12.34
+// where dur is the wall-clock milliseconds spent inside the handler.
+func ServerTiming(next echov4.HandlerFunc) echov4.HandlerFunc {
+	return func(c echov4.Context) error {
+		start := time.Now()
+		c.Response().Before(func() {
+			dur := time.Since(start)
+			c.Response().Header().Set("Server-Timing", fmt.Sprintf("server;dur=%.2f", float64(dur.Microseconds())/1000.0))
+		})
+		return next(c)
+	}
+}


### PR DESCRIPTION
Add a global middleware that measures handler duration and returns it
in the Server-Timing response header on every endpoint.

Example response:

```
HTTP/1.1 200 OK
Content-Type: application/json
Server-Timing: server;dur=3.02
Vary: Origin
Date: Wed, 11 Mar 2026 11:35:15 GMT
Content-Length: 1924
```


resolves: https://github.com/flanksource/mission-control/issues/2843