### PR TITLE
fix(notification): add context to shoutrrr send failures

### DIFF
--- a/notification/send.go
+++ b/notification/send.go
@@ -398,9 +398,7 @@ func SendRawNotification(ctx *Context, connectionName, shoutrrrURL string, celEn
 
 	service, err := shoutrrrSendRaw(ctx, celEnv, shoutrrrURL, data)
 	if err != nil {
-		return "", ctx.Oops().
-			With("notification", ctx.notificationID, "connection", connectionName, "properties", data.Properties).
-			Wrapf(err, "failed to send message with Shoutrrr")
+		return "", fmt.Errorf("failed to send message with Shoutrrr: %w", err)
 	}
 	resourceID := ""
 	if ctx.log != nil && ctx.log.ResourceID != uuid.Nil {
@@ -462,9 +460,7 @@ func SendNotification(ctx *Context, connectionName, shoutrrrURL string, payload 
 
 	service, err := shoutrrrSend(ctx, shoutrrrURL, payload, properties)
 	if err != nil {
-		return "", ctx.Oops().
-			With("notification", ctx.notificationID, "connection", connectionName, "properties", properties).
-			Wrapf(err, "failed to send message with Shoutrrr")
+		return "", fmt.Errorf("failed to send message with Shoutrrr: %w", err)
 	}
 	resourceID := ""
 	if ctx.log != nil && ctx.log.ResourceID != uuid.Nil {

--- a/notification/shoutrrr.go
+++ b/notification/shoutrrr.go
@@ -161,7 +161,12 @@ func dispatchNotification(ctx *Context, service, shoutrrrURL string, sender *rou
 				m.SetHeader(k, v)
 			}
 		}
-		return m.Send(conn)
+		if err := m.Send(conn); err != nil {
+			return ctx.Oops().
+				With("to", to, "from", from, "host", parsedURL.Hostname()).
+				Wrap(err)
+		}
+		return nil
 	}
 
 	sendErrors := sender.Send(data.Message, params)


### PR DESCRIPTION
Replace bare fmt.Errorf with ctx.Oops().With() to include notification ID,
connection name, and properties in shoutrrr error messages.

Closes #2846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for SMTP notifications with more detailed error context when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->