### PR TITLE
feat: support global resources in subject access reviews

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.33.0 // indirect
 	github.com/flanksource/commons v1.50.1
-	github.com/flanksource/duty v1.0.1252
+	github.com/flanksource/duty v1.0.1253
 	github.com/flanksource/gomplate/v3 v3.24.74
 	github.com/flanksource/kopper v1.0.21
 	github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFE
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
 github.com/flanksource/deps v1.0.24 h1:X23SZb2nxCDsS1wRiuqyvUYpA3KQxcQR9YfB8H/oTgo=
 github.com/flanksource/deps v1.0.24/go.mod h1:emsZRgkplqo9xe2wTAPyFm6XWk8CS6H9cxjp6eYR1Vg=
-github.com/flanksource/duty v1.0.1252 h1:NCuEGbexi8s6ihRbC2jfFevNXPJSN44NCrkkG4dyYgQ=
-github.com/flanksource/duty v1.0.1252/go.mod h1:u6dCwn0WUEae0c4sH0Hpm6OAI0l5NvzazDVl/Yxymko=
+github.com/flanksource/duty v1.0.1253 h1:JOum3dGmHjj6oPlm62+tHSFufhRCknp12Fa3rNt5v44=
+github.com/flanksource/duty v1.0.1253/go.mod h1:u6dCwn0WUEae0c4sH0Hpm6OAI0l5NvzazDVl/Yxymko=
 github.com/flanksource/gomplate/v3 v3.24.74 h1:LR1TGUxbQiZyjPgxP7dElVZi6LzMwBVqyZ3z0FgkMPU=
 github.com/flanksource/gomplate/v3 v3.24.74/go.mod h1:l3iet81uj0sje3uMIkAURjOu1E4UErJ3PMVTYhvABCM=
 github.com/flanksource/is-healthy v1.0.86 h1:N4oxqdW8/YN7+EmEHk4rStpYXzuGADiMAXP2T75bynw=

--- a/rbac/controllers.go
+++ b/rbac/controllers.go
@@ -87,13 +87,12 @@ func GetPermissionsForToken(c echo.Context) error {
 
 const maxSubjectAccessReviewSubjects = 500
 
-
-
 type SubjectAccessReviewResource struct {
 	Playbook string `json:"playbook,omitempty"`
 	Config   string `json:"config,omitempty"`
 	Check    string `json:"check,omitempty"`
 	View     string `json:"view,omitempty"`
+	Global   string `json:"global,omitempty"`
 }
 
 type SubjectAccessReviewRequest struct {
@@ -116,6 +115,9 @@ func (req SubjectAccessReviewRequest) Validate(ctx context.Context) error {
 	}
 
 	resourceFields := 0
+	if req.Resource.Global != "" {
+		resourceFields++
+	}
 	if req.Resource.Playbook != "" {
 		resourceFields++
 	}
@@ -129,11 +131,13 @@ func (req SubjectAccessReviewRequest) Validate(ctx context.Context) error {
 		resourceFields++
 	}
 	if resourceFields == 0 {
-		return api.Errorf(api.EINVALID, "at least one of resource.playbook, resource.config, resource.check or resource.view is required")
+		return api.Errorf(api.EINVALID, "at least one of resource.global, resource.playbook, resource.config, resource.check or resource.view is required")
 	}
+
 	if !lo.Contains(policy.AllActions, req.Action) {
 		return api.Errorf(api.EINVALID, "unsupported action %q, only %s are supported", req.Action, strings.Join(policy.AllActions, ", "))
 	}
+
 	if len(req.Subjects) == 0 {
 		return api.Errorf(api.EINVALID, "at least one subject is required")
 	}
@@ -180,6 +184,10 @@ func SubjectAccessReviews(c echo.Context) error {
 		}
 
 		allowed := rbac.HasPermission(ctx, subject, resourceAttr, req.Action)
+		if req.Resource.Global != "" {
+			allowed = rbac.Check(ctx, subject, req.Resource.Global, req.Action)
+		}
+
 		results = append(results, SubjectAccessReviewResult{Subject: subject, Allowed: allowed})
 	}
 


### PR DESCRIPTION
- add resource.global to SubjectAccessReviewResource requests
- treat resource.global as a valid resource selector during validation
- use rbac.Check for global resource checks while preserving ABAC checks for resource-bound requests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global resource selector support in SubjectAccessReview requests for expanded permission validation options

* **Chores**
  * Updated Go module dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->