### PR TITLE
fix(notification): check resource exists before attempting to send pending

### DIFF
--- a/notification/job.go
+++ b/notification/job.go
@@ -498,6 +498,8 @@ func resourceExists(ctx context.Context, sourceEvent string, resourceID uuid.UUI
 		table = (&models.Component{}).TableName()
 	case strings.HasPrefix(sourceEvent, "check."):
 		table = (&models.Check{}).TableName()
+	case strings.HasPrefix(sourceEvent, "canary."):
+		table = (&models.Canary{}).TableName()
 	default:
 		return true, nil
 	}

--- a/notification/job.go
+++ b/notification/job.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/flanksource/commons/collections"
@@ -389,6 +390,18 @@ func traceLog(format string, args ...any) {
 }
 
 func processPendingNotification(ctx context.Context, currentHistory models.NotificationSendHistory) error {
+	if exists, err := resourceExists(ctx, currentHistory.SourceEvent, currentHistory.ResourceID); err != nil {
+		return fmt.Errorf("failed to check resource existence: %w", err)
+	} else if !exists {
+		if dberr := ctx.DB().Model(&models.NotificationSendHistory{}).Where("id = ?", currentHistory.ID).UpdateColumns(map[string]any{
+			"status": models.NotificationStatusSkipped,
+			"error":  "resource no longer exists",
+		}).Error; dberr != nil {
+			return fmt.Errorf("failed to mark notification as skipped: %w", dberr)
+		}
+		return nil
+	}
+
 	notif, err := GetNotification(ctx, currentHistory.NotificationID.String())
 	if err != nil {
 		return fmt.Errorf("failed to get notification: %w", err)
@@ -466,6 +479,34 @@ func triggerIncrementalScrape(ctx context.Context, configID string) error {
 	}
 
 	return ctx.DB().Clauses(events.EventQueueOnConflictClause).Create(&event).Error
+}
+
+// resourceExists reports whether the resource referenced by a pending notification
+// still exists in the database. Only configs, components and checks are checked —
+// other event types either don't reference a tracked resource or can't FK-violate
+// downstream consumers, so they're treated as existing.
+func resourceExists(ctx context.Context, sourceEvent string, resourceID uuid.UUID) (bool, error) {
+	if resourceID == uuid.Nil {
+		return true, nil
+	}
+
+	var table string
+	switch {
+	case strings.HasPrefix(sourceEvent, "config."):
+		table = (&models.ConfigItem{}).TableName()
+	case strings.HasPrefix(sourceEvent, "component."):
+		table = (&models.Component{}).TableName()
+	case strings.HasPrefix(sourceEvent, "check."):
+		table = (&models.Check{}).TableName()
+	default:
+		return true, nil
+	}
+
+	var count int64
+	if err := ctx.DB().Table(table).Where("id = ?", resourceID).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func isKubernetesConfigItem(ctx context.Context, configID string) (bool, error) {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -781,13 +781,15 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 			}
 			Expect(DefaultContext.DB().Create(&sendHistory).Error).To(BeNil())
 
-			_, err := notification.ProcessPendingNotifications(DefaultContext)
-			Expect(err).To(BeNil())
+			Eventually(func(g Gomega) {
+				_, err := notification.ProcessPendingNotifications(DefaultContext)
+				g.Expect(err).To(BeNil())
 
-			var got models.NotificationSendHistory
-			Expect(DefaultContext.DB().Where("id = ?", sendHistory.ID).First(&got).Error).To(BeNil())
-			Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
-			Expect(lo.FromPtr(got.Error)).To(Equal("resource no longer exists"))
+				var got models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("id = ?", sendHistory.ID).First(&got).Error).To(BeNil())
+				g.Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
+				g.Expect(lo.FromPtr(got.Error)).To(Equal("resource no longer exists"))
+			}, "10s", "200ms").Should(Succeed())
 		})
 	})
 

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -750,6 +750,46 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 		})
 	})
 
+	var _ = ginkgo.Describe("missing resource", ginkgo.Ordered, func() {
+		var n models.Notification
+
+		ginkgo.BeforeAll(func() {
+			n = models.Notification{
+				ID:             uuid.New(),
+				Name:           "missing-resource-test",
+				Events:         pq.StringArray([]string{"config.unhealthy"}),
+				Source:         models.SourceCRD,
+				Title:          "Dummy",
+				Template:       "dummy",
+				CustomServices: types.JSON(customReceiverJson),
+			}
+			Expect(DefaultContext.DB().Create(&n).Error).To(BeNil())
+		})
+
+		ginkgo.AfterAll(func() {
+			Expect(DefaultContext.DB().Delete(&n).Error).To(BeNil())
+			notification.PurgeCache(n.ID.String())
+		})
+
+		ginkgo.It("should mark the notification as skipped when the resource no longer exists", func() {
+			sendHistory := models.NotificationSendHistory{
+				NotificationID: n.ID,
+				ResourceID:     uuid.New(),
+				SourceEvent:    "config.unhealthy",
+				Status:         models.NotificationStatusPending,
+			}
+			Expect(DefaultContext.DB().Create(&sendHistory).Error).To(BeNil())
+
+			_, err := notification.ProcessPendingNotifications(DefaultContext)
+			Expect(err).To(BeNil())
+
+			var got models.NotificationSendHistory
+			Expect(DefaultContext.DB().Where("id = ?", sendHistory.ID).First(&got).Error).To(BeNil())
+			Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
+			Expect(lo.FromPtr(got.Error)).To(Equal("resource no longer exists"))
+		})
+	})
+
 	var _ = ginkgo.Describe("notification wait for", ginkgo.Ordered, func() {
 		var n models.Notification
 		var config models.ConfigItem

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -777,6 +777,7 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 				ResourceID:     uuid.New(),
 				SourceEvent:    "config.unhealthy",
 				Status:         models.NotificationStatusPending,
+				NotBefore:      lo.ToPtr(time.Now().Add(-time.Minute)),
 			}
 			Expect(DefaultContext.DB().Create(&sendHistory).Error).To(BeNil())
 

--- a/tests/e2e/playbooks_test.go
+++ b/tests/e2e/playbooks_test.go
@@ -20,7 +20,6 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/robfig/cron/v3"
-	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -107,12 +106,10 @@ var _ = ginkgo.Describe("Playbooks", ginkgo.Ordered, func() {
 		panic(fmt.Sprintf("failed to glob playbook fixtures: %v", err))
 	}
 
-	// FIXME: Disable email playbooks for now
-	// Fails most of the time in CI
-	skipped := []string{"email-report"}
-	fixtures = lo.Filter(fixtures, func(f string, _ int) bool {
-		return !lo.Contains(skipped, f)
-	})
+	// Fixtures that are flaky in CI and need multiple attempts.
+	flakyFixtures := map[string]int{
+		"email-report": 5,
+	}
 
 	for _, fixturePath := range fixtures {
 		setup := peekFixtureSetup(fixturePath)
@@ -123,6 +120,10 @@ var _ = ginkgo.Describe("Playbooks", ginkgo.Ordered, func() {
 			for _, l := range h.Labels(setup) {
 				decorators = append(decorators, ginkgo.Label(l))
 			}
+		}
+
+		if attempts, ok := flakyFixtures[name]; ok {
+			decorators = append(decorators, ginkgo.FlakeAttempts(attempts))
 		}
 
 		decorators = append(decorators, func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications referencing deleted or non-existent resources are now skipped and marked "resource no longer exists" in send history, preventing repeated processing.

* **Tests**
  * Added an ordered unit test verifying missing-resource notification handling.
  * Marked the intermittent end-to-end playbook fixture as flaky and enabled targeted retry attempts to reduce sporadic failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->