### PR TITLE
ci(build): defer release publication until all artifacts are uploaded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,10 @@ jobs:
       - run: make release
         env:
           VERSION: v${{ needs.semantic-release.outputs.release-version }}
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./.release/*
-          tag: v${{ needs.semantic-release.outputs.release-version }}
-          overwrite: true
-          file_glob: true
+      - name: Upload binaries to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "v${{ needs.semantic-release.outputs.release-version }}" ./.release/* --clobber --repo "${{ github.repository }}"
 
   docker:
     needs: semantic-release
@@ -133,3 +129,13 @@ jobs:
           commit_message: "chore: update incident-commander image version to ${{ env.RELEASE_VERSION }}"
           repository: ./incident-commander-chart
           branch: main
+
+  publish-release:
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    runs-on: ubuntu-latest
+    needs: [semantic-release, binary, docker, update-incident-commander-chart]
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "v${{ needs.semantic-release.outputs.release-version }}" --draft=false --repo "${{ github.repository }}"

--- a/.releaserc
+++ b/.releaserc
@@ -15,17 +15,7 @@ plugins:
           - MAJOR RELEASE
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/github"
-    - assets:
-        - path: ./.bin/incident-commander-amd64
-          name: incident-commander-amd64
-        - path: ./.bin/incident-commander.exe
-          name: incident-commander.exe
-        - path: ./.bin/incident-commander_osx-amd64
-          name: incident-commander_osx-amd64
-        - path: ./.bin/incident-commander_osx-arm64
-          name: incident-commander_osx-arm64
-      # - path: ./.bin/release.yaml
-      #   name: release.yaml
-      # From: https://github.com/semantic-release/github/pull/487#issuecomment-1486298997  
+    - draftRelease: true
+      # From: https://github.com/semantic-release/github/pull/487#issuecomment-1486298997
       successComment: false
       failTitle: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to streamline the draft release creation and publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->