### PR TITLE
chore(auth): allow only localhost requests if htpasswd file not found

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/flanksource/commons/logger"
@@ -21,7 +23,8 @@ var (
 	OIDCEnabled        bool
 	OIDCSigningKeyPath string
 
-	checker *htpasswd.File
+	checker       *htpasswd.File
+	localhostOnly bool
 )
 
 const basicAuthCookieName = "authorization"
@@ -31,12 +34,23 @@ func UseBasic(e *echo.Echo) {
 	var err error
 	checker, err = htpasswd.New(HtpasswdFile, htpasswd.DefaultSystems, nil)
 	if err != nil {
-		panic(err)
+		if os.IsNotExist(err) {
+			logger.Warnf("htpasswd file %s not found, only localhost requests will be allowed", HtpasswdFile)
+			localhostOnly = true
+		} else {
+			panic(err)
+		}
 	}
 
 	e.POST("/auth/login", BasicLogin)
 
 	e.Use(basicAuthMiddleware)
+}
+
+func isLocalhostRequest(c echo.Context) bool {
+	ip := c.RealIP()
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
 }
 
 func authenticateFromCookie(c echo.Context) bool {
@@ -82,6 +96,9 @@ func authenticateFromCookie(c echo.Context) bool {
 }
 
 func validateBasicAuth(c echo.Context, user, pass string) (bool, error) {
+	if localhostOnly || checker == nil {
+		return false, nil
+	}
 	logger.Tracef("authenticating user %s:%s via htpasswd", user, logger.PrintableSecret(pass))
 	if !checker.Match(user, pass) {
 		return false, nil
@@ -116,6 +133,13 @@ func basicAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		if canSkipAuth(c) || authenticateFromCookie(c) {
 			return next(c)
+		}
+
+		if localhostOnly {
+			if isLocalhostRequest(c) {
+				return next(c)
+			}
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "only localhost requests are allowed when htpasswd file is not configured"})
 		}
 
 		if token, ok := extractBearerAuthToken(c.Request().Header); ok {
@@ -204,6 +228,10 @@ type basicLoginRequest struct {
 
 func BasicLogin(c echo.Context) error {
 	ctx := c.Request().Context().(context.Context)
+
+	if localhostOnly {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "basic login is unavailable when htpasswd file is not configured"})
+	}
 
 	username, password, ok := extractBasicLoginCredentials(c)
 	if !ok {

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -48,7 +48,12 @@ func UseBasic(e *echo.Echo) {
 }
 
 func isLocalhostRequest(c echo.Context) bool {
-	ip := c.RealIP()
+	// Use RemoteAddr to avoid spoofing via X-Forwarded-For headers
+	host, _, err := net.SplitHostPort(c.Request().RemoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := host
 	parsed := net.ParseIP(ip)
 	return parsed != nil && parsed.IsLoopback()
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -99,14 +99,18 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 			adminUserID = admin.ID.String()
 		}
 		if OIDCEnabled {
-			htpasswdChecker, err := NewHtpasswdChecker(HtpasswdFile)
-			if err != nil {
-				return fmt.Errorf("failed to load htpasswd file: %w", err)
+			if localhostOnly {
+				logger.Warnf("OIDC provider disabled because htpasswd file is not available")
+			} else {
+				htpasswdChecker, err := NewHtpasswdChecker(HtpasswdFile)
+				if err != nil {
+					return fmt.Errorf("failed to load htpasswd file: %w", err)
+				}
+				if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, htpasswdChecker, LookupPersonByUsername); err != nil {
+					return fmt.Errorf("failed to mount OIDC routes: %w", err)
+				}
+				logger.Infof("OIDC provider enabled at %s", api.FrontendURL)
 			}
-			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, htpasswdChecker, LookupPersonByUsername); err != nil {
-				return fmt.Errorf("failed to mount OIDC routes: %w", err)
-			}
-			logger.Infof("OIDC provider enabled at %s", api.FrontendURL)
 		}
 	case Kratos:
 		kratosHandler := NewKratosHandler()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication no longer crashes when htpasswd is missing; server logs a warning and falls back to restricted mode.
  * When htpasswd is unavailable, authentication is limited to localhost requests only.
  * Login endpoint returns 503 Service Unavailable with a clear JSON error while in the restricted authentication mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->