### PR TITLE
fix: stop treating uuid.Nil as missing record in config lookups

### DIFF
--- a/application/job.go
+++ b/application/job.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/flanksource/duty"
@@ -11,6 +12,7 @@ import (
 	uuidV5 "github.com/gofrs/uuid/v5"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/db"
@@ -19,10 +21,11 @@ import (
 func linkToConfigs(ctx context.Context, app *v1.Application) error {
 	// Ensure the application config item exists before we form the relationships
 	var application models.ConfigItem
-	if err := ctx.DB().Where("id = ?", app.GetID()).Find(&application).Error; err != nil {
+	if err := ctx.DB().Where("id = ?", app.GetID()).First(&application).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
 		return err
-	} else if application.ID == uuid.Nil {
-		return nil
 	}
 
 	configIDs, err := query.FindConfigIDsByResourceSelector(ctx, -1, app.Spec.Mapping.Logins...)

--- a/auth/kratos_client.go
+++ b/auth/kratos_client.go
@@ -2,13 +2,14 @@ package auth
 
 import (
 	gocontext "context"
+	"errors"
 	"fmt"
 
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
-	"github.com/google/uuid"
 	client "github.com/ory/client-go"
+	"gorm.io/gorm"
 )
 
 var (
@@ -159,9 +160,10 @@ func (k *KratosHandler) CreateAdminUser(ctx context.Context) (string, error) {
 	{
 		// If in case the admin identity wasn't synced with the people table, we sync it now.
 		var admin models.Person
-		if err := ctx.DB().Where("id = ?", id).Find(&admin).Error; err != nil {
-			return "", err
-		} else if admin.ID == uuid.Nil {
+		if err := ctx.DB().Where("id = ?", id).First(&admin).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", err
+			}
 			// Do a dummy update so the postgres tirgger syncs the admin person.
 			// This way we have the sync logic in one place.
 			if err := ctx.DB().Raw(`UPDATE identities SET traits = traits WHERE id = ?`, id).Error; err != nil {

--- a/db/views.go
+++ b/db/views.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/flanksource/duty"
@@ -10,6 +11,7 @@ import (
 	dutyTypes "github.com/flanksource/duty/types"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,12 +58,11 @@ func PersistViewFromCRD(ctx context.Context, obj *v1.View) error {
 // DeleteView soft deletes a View by setting deleted_at timestamp and cleans up associated tables
 func DeleteView(ctx context.Context, id string) error {
 	var view models.View
-	if err := ctx.DB().Where("id = ? AND deleted_at IS NULL", id).Find(&view).Error; err != nil {
+	if err := ctx.DB().Where("id = ? AND deleted_at IS NULL", id).First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
 		return fmt.Errorf("failed to find view: %w", err)
-	}
-
-	if view.ID == uuid.Nil {
-		return nil
 	}
 
 	generatedTableName := view.GeneratedTableName()
@@ -91,10 +92,11 @@ func DeleteStaleView(ctx context.Context, newer *v1.View) error {
 // GetView retrieves a view by name and namespace
 func GetView(ctx context.Context, namespace, name string) (*v1.View, error) {
 	var view models.View
-	if err := ctx.DB().Where("name = ? AND namespace = ? AND deleted_at IS NULL", name, namespace).Find(&view).Error; err != nil {
+	if err := ctx.DB().Where("name = ? AND namespace = ? AND deleted_at IS NULL", name, namespace).First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
 		return nil, err
-	} else if view.ID == uuid.Nil {
-		return nil, nil
 	}
 
 	var spec v1.ViewSpec

--- a/events/resource.go
+++ b/events/resource.go
@@ -1,11 +1,13 @@
 package events
 
 import (
+	"errors"
+
 	"github.com/flanksource/duty"
 	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
-	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/flanksource/incident-commander/api"
 )
@@ -47,11 +49,11 @@ func BuildEventResource(ctx context.Context, event models.Event) (EventResource,
 	case api.EventCheckFailed, api.EventCheckPassed:
 		checkID := event.EventID
 		var check models.Check
-		if err := ctx.DB().Where("id = ?", checkID).Limit(1).Find(&check).Error; err != nil {
+		if err := ctx.DB().Where("id = ?", checkID).First(&check).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "check(id=%s) not found", checkID)
+			}
 			return eventResource, err
-		}
-		if check.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "check(id=%s) not found", checkID)
 		}
 		eventResource.Check = &check
 
@@ -62,51 +64,51 @@ func BuildEventResource(ctx context.Context, event models.Event) (EventResource,
 		}
 
 		var canary models.Canary
-		if err := ctx.DB().Where("id = ?", eventResource.Check.CanaryID).Limit(1).Find(&canary).Error; err != nil {
+		if err := ctx.DB().Where("id = ?", eventResource.Check.CanaryID).First(&canary).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "canary(id=%s) not found", eventResource.Check.CanaryID)
+			}
 			return eventResource, err
-		}
-		if canary.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "canary(id=%s) not found", eventResource.Check.CanaryID)
 		}
 		eventResource.Canary = &canary
 
 	case api.EventComponentHealthy, api.EventComponentUnhealthy, api.EventComponentWarning, api.EventComponentUnknown:
 		var component models.Component
-		if err := ctx.DB().Model(&models.Component{}).Where("id = ?", event.EventID).Limit(1).Find(&component).Error; err != nil {
+		if err := ctx.DB().Model(&models.Component{}).Where("id = ?", event.EventID).First(&component).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "component(id=%s) not found", event.EventID)
+			}
 			return eventResource, err
-		}
-		if component.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "component(id=%s) not found", event.EventID)
 		}
 		eventResource.Component = &component
 
 	case api.EventConfigHealthy, api.EventConfigUnhealthy, api.EventConfigWarning, api.EventConfigUnknown, api.EventConfigDegraded:
 		var config models.ConfigItem
-		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.EventID).Limit(1).Find(&config).Error; err != nil {
+		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.EventID).First(&config).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.EventID)
+			}
 			return eventResource, err
-		}
-		if config.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.EventID)
 		}
 		eventResource.Config = &config
 
 	case api.EventConfigCreated, api.EventConfigDeleted:
 		var config models.ConfigItem
-		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.EventID).Limit(1).Find(&config).Error; err != nil {
+		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.EventID).First(&config).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.EventID)
+			}
 			return eventResource, err
-		}
-		if config.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.EventID)
 		}
 		eventResource.Config = &config
 
 	case api.EventConfigChanged, api.EventConfigUpdated:
 		var config models.ConfigItem
-		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.Properties["config_id"]).Limit(1).Find(&config).Error; err != nil {
+		if err := ctx.DB().Model(&models.ConfigItem{}).Where("id = ?", event.Properties["config_id"]).First(&config).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.Properties["config_id"])
+			}
 			return eventResource, err
-		}
-		if config.ID == uuid.Nil {
-			return eventResource, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "config(id=%s) not found", event.Properties["config_id"])
 		}
 		eventResource.Config = &config
 	}

--- a/llm/context/context.go
+++ b/llm/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/flanksource/duty/query"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 
 	"github.com/flanksource/incident-commander/api"
 )
@@ -51,10 +53,11 @@ func Create(ctx context.Context, spec api.LLMContextRequest) (*Context, error) {
 	var kg Context
 
 	var config models.ConfigItem
-	if err := ctx.DB().Where("id = ?", spec.Config).Find(&config).Error; err != nil {
+	if err := ctx.DB().Where("id = ?", spec.Config).First(&config).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("config doesn't exist (%s)", spec.Config)
+		}
 		return nil, fmt.Errorf("failed to get config (%s): %w", spec.Config, err)
-	} else if config.ID == uuid.Nil {
-		return nil, fmt.Errorf("config doesn't exist (%s)", spec.Config)
 	} else {
 		ci := Config{
 			ID:          config.ID.String(),

--- a/llm/tools/config.go
+++ b/llm/tools/config.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	dutyContext "github.com/flanksource/duty/context"
@@ -10,6 +11,7 @@ import (
 	"github.com/flanksource/duty/query"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 const CatalogToolName = "getCatalogByNameOrID"
@@ -60,10 +62,11 @@ func (t *CatalogTool) Call(ctx context.Context, input string) (string, error) {
 		}
 	} else if data.Name != "" {
 		// TODO: add scraper id and cluster id
-		if err := t.dutyCtx.DB().Where("tags->>'namespace' = ?", data.Namespace).Where("name = ?", data.Name).Find(&config).Error; err != nil {
+		if err := t.dutyCtx.DB().Where("tags->>'namespace' = ?", data.Namespace).Where("name = ?", data.Name).First(&config).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "config was not found", nil
+			}
 			return "", err
-		} else if config.ID == uuid.Nil {
-			return "config was not found", nil
 		}
 	}
 

--- a/mcp/templates.go
+++ b/mcp/templates.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"gorm.io/gorm"
 
 	"github.com/flanksource/incident-commander/auth"
 )
@@ -59,11 +60,11 @@ func runTemplateHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*mcp.
 					return err
 				}
 				var change models.CatalogChange
-				if err := rlsCtx.DB().Where("id = ?", changeID).Find(&change).Error; err != nil {
+				if err := rlsCtx.DB().Where("id = ?", changeID).First(&change).Error; err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						return fmt.Errorf("change[%s] not found", changeID)
+					}
 					return err
-				}
-				if change.ID == uuid.Nil {
-					return fmt.Errorf("change[%s] not found", changeID)
 				}
 				args.Env["change"] = change.AsMap()
 			}

--- a/notification/events.go
+++ b/notification/events.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -19,6 +20,7 @@ import (
 	"github.com/flanksource/gomplate/v3"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
 	"github.com/flanksource/incident-commander/api"
@@ -206,10 +208,11 @@ func resolveGroupMembershipForNotification(ctx context.Context, celEnv *celVaria
 	}
 
 	var config models.ConfigItem
-	if err := ctx.DB().Where("id = ?", configID).Find(&config).Error; err != nil {
+	if err := ctx.DB().Where("id = ?", configID).First(&config).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, ctx.Oops().Errorf("config not found %s", configID)
+		}
 		return false, ctx.Oops().Wrapf(err, "failed to get config %s", configID)
-	} else if config.ID == uuid.Nil {
-		return false, ctx.Oops().Wrapf(err, "config not found %s", configID)
 	}
 
 	if !lo.Contains(notification.Events, fmt.Sprintf("config.%s", lo.FromPtr(config.Health))) {

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -2,6 +2,7 @@ package playbook
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/samber/oops"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"gorm.io/gorm"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/flanksource/incident-commander/api"
@@ -343,10 +345,11 @@ func savePlaybookRun(ctx context.Context, run *models.PlaybookRun) error {
 
 func ListPlaybooksForConfig(ctx context.Context, id string) ([]api.PlaybookListItem, error) {
 	var config models.ConfigItem
-	if err := ctx.DB().Where("id = ?", id).Find(&config).Error; err != nil {
+	if err := ctx.DB().Where("id = ?", id).First(&config).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("config(id=%s) not found", id)
+		}
 		return nil, ctx.Oops("db").Wrap(err)
-	} else if config.ID == uuid.Nil {
-		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("config(id=%s) not found", id)
 	}
 
 	list, _, err := db.FindPlaybooksForConfig(ctx, config)

--- a/views/controller.go
+++ b/views/controller.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/flanksource/commons/logger"
@@ -13,6 +14,7 @@ import (
 	"github.com/flanksource/gomplate/v3"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 
 	"github.com/flanksource/incident-commander/api"
 	"github.com/flanksource/incident-commander/db"
@@ -55,10 +57,11 @@ func HandleGetViewMetadataByID(c echo.Context) error {
 	}
 
 	var view models.View
-	if err := ctx.DB().Where("id = ? AND deleted_at IS NULL", id).Find(&view).Error; err != nil {
+	if err := ctx.DB().Where("id = ? AND deleted_at IS NULL", id).First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(id=%s) not found", id.String()))
+		}
 		return dutyAPI.WriteError(c, ctx.Oops().Wrap(err))
-	} else if view.ID == uuid.Nil {
-		return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(id=%s) not found", id.String()))
 	}
 
 	response, err := getViewMetadata(ctx, view)
@@ -139,10 +142,11 @@ func GetViewByID(c echo.Context) error {
 	id := c.Param("id")
 
 	var view models.View
-	if err := ctx.DB().Select("id, namespace, name").Where("id = ?", id).Where("deleted_at IS NULL").Find(&view).Error; err != nil {
+	if err := ctx.DB().Select("id, namespace, name").Where("id = ?", id).Where("deleted_at IS NULL").First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(id=%s) not found", id))
+		}
 		return dutyAPI.WriteError(c, err)
-	} else if view.ID == uuid.Nil {
-		return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(id=%s) not found", id))
 	}
 
 	// Check ABAC permissions for this specific view
@@ -164,10 +168,11 @@ func GetViewByNamespaceName(c echo.Context) error {
 
 	// Fetch the view to check ABAC permissions
 	var view models.View
-	if err := ctx.DB().Select("id, namespace, name").Where("namespace = ? AND name = ?", namespace, name).Where("deleted_at IS NULL").Find(&view).Error; err != nil {
+	if err := ctx.DB().Select("id, namespace, name").Where("namespace = ? AND name = ?", namespace, name).Where("deleted_at IS NULL").First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(namespace=%s, name=%s) not found", namespace, name))
+		}
 		return dutyAPI.WriteError(c, err)
-	} else if view.ID == uuid.Nil {
-		return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "view(namespace=%s, name=%s) not found", namespace, name))
 	}
 
 	// Check ABAC permissions for this specific view
@@ -239,10 +244,11 @@ func HandleViewList(c echo.Context) error {
 
 func listViewsForConfig(ctx context.Context, id string) ([]api.ViewListItem, error) {
 	var config models.ConfigItem
-	if err := ctx.DB().Where("id = ?", id).Find(&config).Error; err != nil {
+	if err := ctx.DB().Where("id = ?", id).First(&config).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("config(id=%s) not found", id)
+		}
 		return nil, ctx.Oops("db").Wrap(err)
-	} else if config.ID == uuid.Nil {
-		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("config(id=%s) not found", id)
 	}
 
 	list, err := db.FindViewsForConfig(ctx, config)

--- a/views/dashboard.go
+++ b/views/dashboard.go
@@ -1,12 +1,13 @@
 package views
 
 import (
+	"errors"
 	"strings"
 
 	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
-	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 const (
@@ -28,10 +29,11 @@ func resolveDashboardView(ctx context.Context) (*models.View, error) {
 		query = query.Where("name = ?", viewRef)
 	}
 
-	if err := query.Find(&view).Error; err != nil {
+	if err := query.First(&view).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "dashboard view %s not found", viewRef)
+		}
 		return nil, ctx.Oops().Wrap(err)
-	} else if view.ID == uuid.Nil {
-		return nil, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "dashboard view %s not found", viewRef)
 	}
 
 	return &view, nil

--- a/views/metadata.go
+++ b/views/metadata.go
@@ -1,14 +1,16 @@
 package views
 
 import (
+	"errors"
+
 	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	dutyRBAC "github.com/flanksource/duty/rbac"
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/flanksource/incident-commander/api"
-	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
+	"gorm.io/gorm"
 )
 
 // ViewMetadataResponse is the response for the view metadata endpoint.
@@ -94,10 +96,11 @@ func fetchSection(ctx context.Context, namespace, name string) (*api.ViewResult,
 	var viewModel models.View
 	if err := ctx.DB().Select("id, namespace, name").
 		Where("name = ? AND namespace = ? AND deleted_at IS NULL", name, namespace).
-		Find(&viewModel).Error; err != nil {
+		First(&viewModel).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "section view %s/%s not found", namespace, name)
+		}
 		return nil, ctx.Oops().Wrap(err)
-	} else if viewModel.ID == uuid.Nil {
-		return nil, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "section view %s/%s not found", namespace, name)
 	}
 
 	attr := &models.ABACAttribute{View: viewModel}


### PR DESCRIPTION
- `uuid.Nil` is a valid `config_items.id` for the local agent’s ConfigItem.
- Existence checks based on `config.ID == uuid.Nil` can misclassify that row as missing and return false not-found errors.
- Replace these with `First()` + `errors.Is(err, gorm.ErrRecordNotFound)` so not-found is determined by query result, not ID value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized database lookups to consistently surface “not found” results instead of silent/no-op cases.
  * Mapped absent resources to explicit ENOTFOUND responses across configs, events, views, notifications, and playbooks.
  * Unified error-handling so unexpected DB errors remain surfaced while missing rows are handled predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->