### PR TITLE
fix(notification): skip stale notification targets

### DIFF
--- a/notification/events.go
+++ b/notification/events.go
@@ -608,10 +608,18 @@ func sendPendingNotification(ctx context.Context, history models.NotificationSen
 
 	err := _sendNotification(notificationContext, payload)
 	if err != nil {
-		notificationContext.WithError(err)
+		if IsStaleResourceEventError(err) {
+			notificationContext.log.Status = models.NotificationStatusSkipped
+			notificationContext.log.Error = lo.ToPtr(ResourceNoLongerExistsReason)
+		} else {
+			notificationContext.WithError(err)
+		}
 	}
 
 	logs.IfError(notificationContext.EndLog(), "error persisting end of notification send history")
+	if IsStaleResourceEventError(err) {
+		return nil
+	}
 	return err
 }
 
@@ -687,14 +695,28 @@ func sendNotification(ctx context.Context, payload NotificationEventPayload) err
 
 	err := _sendNotification(notificationContext, payload)
 	if err != nil {
-		notificationContext.WithError(err)
+		if IsStaleResourceEventError(err) {
+			notificationContext.log.Status = models.NotificationStatusSkipped
+			notificationContext.log.Error = lo.ToPtr(ResourceNoLongerExistsReason)
+		} else {
+			notificationContext.WithError(err)
+		}
 	}
 
 	logs.IfError(notificationContext.EndLog(), "error persisting end of notification send history")
+	if IsStaleResourceEventError(err) {
+		return nil
+	}
 	return err
 }
 
 func _sendNotification(ctx *Context, payload NotificationEventPayload) error {
+	if exists, err := ResourceExists(ctx.Context, payload.EventName, payload.ResourceID); err != nil {
+		return fmt.Errorf("failed to check resource existence: %w", err)
+	} else if !exists {
+		return ErrStaleResourceEvent
+	}
+
 	originalEvent := payload.ParentEvent()
 	if len(payload.Properties) > 0 {
 		if err := json.Unmarshal(payload.Properties, &originalEvent.Properties); err != nil {

--- a/notification/job.go
+++ b/notification/job.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/flanksource/commons/collections"
@@ -393,12 +392,12 @@ func traceLog(format string, args ...any) {
 }
 
 func processPendingNotification(ctx context.Context, currentHistory models.NotificationSendHistory) error {
-	if exists, err := resourceExists(ctx, currentHistory.SourceEvent, currentHistory.ResourceID); err != nil {
+	if exists, err := ResourceExists(ctx, currentHistory.SourceEvent, currentHistory.ResourceID); err != nil {
 		return fmt.Errorf("failed to check resource existence: %w", err)
 	} else if !exists {
 		if dberr := ctx.DB().Model(&models.NotificationSendHistory{}).Where("id = ?", currentHistory.ID).UpdateColumns(map[string]any{
 			"status": models.NotificationStatusSkipped,
-			"error":  "resource no longer exists",
+			"error":  ResourceNoLongerExistsReason,
 		}).Error; dberr != nil {
 			return fmt.Errorf("failed to mark notification as skipped: %w", dberr)
 		}
@@ -482,36 +481,6 @@ func triggerIncrementalScrape(ctx context.Context, configID string) error {
 	}
 
 	return ctx.DB().Clauses(events.EventQueueOnConflictClause).Create(&event).Error
-}
-
-// resourceExists reports whether the resource referenced by a pending notification
-// still exists in the database. Only configs, components and checks are checked —
-// other event types either don't reference a tracked resource or can't FK-violate
-// downstream consumers, so they're treated as existing.
-func resourceExists(ctx context.Context, sourceEvent string, resourceID uuid.UUID) (bool, error) {
-	if resourceID == uuid.Nil {
-		return true, nil
-	}
-
-	var table string
-	switch {
-	case strings.HasPrefix(sourceEvent, "config."):
-		table = (&models.ConfigItem{}).TableName()
-	case strings.HasPrefix(sourceEvent, "component."):
-		table = (&models.Component{}).TableName()
-	case strings.HasPrefix(sourceEvent, "check."):
-		table = (&models.Check{}).TableName()
-	case strings.HasPrefix(sourceEvent, "canary."):
-		table = (&models.Canary{}).TableName()
-	default:
-		return true, nil
-	}
-
-	var count int64
-	if err := ctx.DB().Table(table).Where("id = ?", resourceID).Count(&count).Error; err != nil {
-		return false, err
-	}
-	return count > 0, nil
 }
 
 func isKubernetesConfigItem(ctx context.Context, configID string) (bool, error) {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -755,13 +755,14 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 
 		ginkgo.BeforeAll(func() {
 			n = models.Notification{
-				ID:             uuid.New(),
-				Name:           "missing-resource-test",
-				Events:         pq.StringArray([]string{"config.unhealthy"}),
-				Source:         models.SourceCRD,
-				Title:          "Dummy",
-				Template:       "dummy",
-				CustomServices: types.JSON(customReceiverJson),
+				ID:                     uuid.New(),
+				Name:                   "missing-resource-test",
+				Events:                 pq.StringArray([]string{"config.unhealthy"}),
+				Source:                 models.SourceCRD,
+				Title:                  "Dummy",
+				Template:               "dummy",
+				CustomServices:         types.JSON(customReceiverJson),
+				FallbackCustomServices: types.JSON(customReceiverJson),
 			}
 			Expect(DefaultContext.DB().Create(&n).Error).To(BeNil())
 		})
@@ -788,7 +789,47 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 				var got models.NotificationSendHistory
 				g.Expect(DefaultContext.DB().Where("id = ?", sendHistory.ID).First(&got).Error).To(BeNil())
 				g.Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
-				g.Expect(lo.FromPtr(got.Error)).To(Equal("resource no longer exists"))
+				g.Expect(lo.FromPtr(got.Error)).To(Equal(notification.ResourceNoLongerExistsReason))
+
+				var fallbackCount int64
+				g.Expect(DefaultContext.DB().Model(&models.NotificationSendHistory{}).Where("parent_id = ?", got.ID).Count(&fallbackCount).Error).To(BeNil())
+				g.Expect(fallbackCount).To(BeZero())
+			}, "10s", "200ms").Should(Succeed())
+		})
+
+		ginkgo.It("should skip immediate notification.send when the resource no longer exists", func() {
+			resourceID := uuid.New()
+			payload := notification.NotificationEventPayload{
+				ResourceID:     resourceID,
+				EventID:        uuid.New(),
+				EventName:      api.EventConfigUnhealthy,
+				NotificationID: n.ID,
+				EventCreatedAt: time.Now(),
+				CustomService:  &api.NotificationConfig{URL: "http://example.com"},
+			}
+
+			event := models.Event{
+				Name:       api.EventNotificationSend,
+				EventID:    payload.GenerateEventID(),
+				Properties: payload.AsMap(),
+			}
+			Expect(DefaultContext.DB().Create(&event).Error).To(BeNil())
+
+			events.ConsumeAll(DefaultContext)
+
+			Eventually(func(g Gomega) {
+				var got models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).
+					Where("resource_id = ?", resourceID).
+					Where("source_event = ?", api.EventConfigUnhealthy).
+					Order("created_at DESC").
+					First(&got).Error).To(BeNil())
+				g.Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
+				g.Expect(lo.FromPtr(got.Error)).To(Equal(notification.ResourceNoLongerExistsReason))
+
+				var fallbackCount int64
+				g.Expect(DefaultContext.DB().Model(&models.NotificationSendHistory{}).Where("parent_id = ?", got.ID).Count(&fallbackCount).Error).To(BeNil())
+				g.Expect(fallbackCount).To(BeZero())
 			}, "10s", "200ms").Should(Succeed())
 		})
 	})

--- a/notification/resource.go
+++ b/notification/resource.go
@@ -1,0 +1,46 @@
+package notification
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+)
+
+const ResourceNoLongerExistsReason = "resource no longer exists"
+
+var ErrStaleResourceEvent = errors.New(ResourceNoLongerExistsReason)
+
+func IsStaleResourceEventError(err error) bool {
+	return errors.Is(err, ErrStaleResourceEvent)
+}
+
+// ResourceExists reports whether the resource referenced by a notification
+// still exists in the database.
+func ResourceExists(ctx context.Context, sourceEvent string, resourceID uuid.UUID) (bool, error) {
+	if resourceID == uuid.Nil {
+		return true, nil
+	}
+
+	var table string
+	switch {
+	case strings.HasPrefix(sourceEvent, "config."):
+		table = (&models.ConfigItem{}).TableName()
+	case strings.HasPrefix(sourceEvent, "component."):
+		table = (&models.Component{}).TableName()
+	case strings.HasPrefix(sourceEvent, "check."):
+		table = (&models.Check{}).TableName()
+	case strings.HasPrefix(sourceEvent, "canary."):
+		table = (&models.Canary{}).TableName()
+	default:
+		return true, nil
+	}
+
+	var count int64
+	if err := ctx.DB().Table(table).Where("id = ?", resourceID).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of notifications for deleted resources: notifications are now marked as skipped with a clear reason instead of failing when the target resource no longer exists, enhancing notification history visibility and preventing false send failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->