### PR TITLE
feat: add stable event handler event metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ func RegisterEvents(ctx context.Context) {
     events.RegisterSyncHandler(handleStatusChange, api.EventStatusGroup...)
 
     // Asynchronous — processed in batches with configurable consumers
-    events.RegisterAsyncHandler(sendNotifications, 1, 5, api.EventNotificationSend)
+    events.RegisterAsyncHandler("notification.sendNotifications", sendNotifications, 1, 5, api.EventNotificationSend)
     // args: handler func, batchSize, numConsumers, event names...
 }
 ```

--- a/events/event_queue.go
+++ b/events/event_queue.go
@@ -18,8 +18,10 @@ type syncHandlerData struct {
 }
 
 type asyncHandlerData struct {
+	// name is a stable, human-readable label use for metrics
+	name string
+
 	fn           func(ctx context.Context, e models.Events) models.Events
-	handlerName  string
 	batchSize    int
 	numConsumers int
 }
@@ -43,23 +45,15 @@ func Register(fn func(ctx context.Context)) {
 	registers = append(registers, fn)
 }
 
-func RegisterAsyncHandler(fn func(ctx context.Context, e models.Events) models.Events, batchSize int, consumers int, events ...string) {
-	RegisterAsyncHandlerNamed(getHandlerName(fn), fn, batchSize, consumers, events...)
-}
-
-func RegisterAsyncHandlerNamed(name string, fn func(ctx context.Context, e models.Events) models.Events, batchSize int, consumers int, events ...string) {
+func RegisterAsyncHandler(name string, fn func(ctx context.Context, e models.Events) models.Events, batchSize int, consumers int, events ...string) {
 	for _, event := range events {
 		AsyncHandlers.Append(event, asyncHandlerData{
 			fn:           fn,
-			handlerName:  name,
+			name:         name,
 			batchSize:    batchSize,
 			numConsumers: consumers,
 		})
 	}
-}
-
-func RegisterSyncHandler(fn postq.SyncEventHandlerFunc, events ...string) {
-	RegisterSyncHandlerNamed(getHandlerName(fn), fn, events...)
 }
 
 func RegisterSyncHandlerNamed(name string, fn postq.SyncEventHandlerFunc, events ...string) {
@@ -94,8 +88,7 @@ func StartConsumers(ctx context.Context) {
 		log.Tracef("Registering %d sync event handlers for %s", len(handlers), event)
 
 		wrappedHandlers := make([]postq.SyncEventHandlerFunc, 0, len(handlers))
-		for _, handler := range handlers {
-			h := handler
+		for _, h := range handlers {
 			wrappedHandlers = append(wrappedHandlers, func(ctx context.Context, e models.Event) error {
 				start := time.Now()
 				err := h.fn(ctx, e)
@@ -130,8 +123,6 @@ func StartConsumers(ctx context.Context) {
 	AsyncHandlers.Each(func(event string, handlers []asyncHandlerData) {
 		log.Tracef("Registering %d async event handlers for %v", len(handlers), event)
 		for _, handler := range handlers {
-			h := handler.fn
-			handlerName := handler.handlerName
 			batchSize := ctx.Properties().Int(event+".batchSize", handler.batchSize)
 
 			consumer := postq.AsyncEventConsumer{
@@ -147,15 +138,15 @@ func StartConsumers(ctx context.Context) {
 					}
 
 					start := time.Now()
-					failedEvents := h(c, e)
+					failedEvents := handler.fn(c, e)
 					failedCount := len(failedEvents)
 					processedCount := len(e) - failedCount
 					if processedCount < 0 {
 						processedCount = 0
 					}
 
-					recordEventHandlerDuration(event, handlerName, failedCount == 0, time.Since(start))
-					recordEventHandlerEvents(event, handlerName, processedCount, failedCount)
+					recordEventHandlerDuration(event, handler.name, failedCount == 0, time.Since(start))
+					recordEventHandlerEvents(event, handler.name, processedCount, failedCount)
 					return failedEvents
 				},
 				ConsumerOption: &postq.ConsumerOption{

--- a/events/event_queue.go
+++ b/events/event_queue.go
@@ -12,8 +12,14 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+type syncHandlerData struct {
+	fn          postq.SyncEventHandlerFunc
+	handlerName string
+}
+
 type asyncHandlerData struct {
 	fn           func(ctx context.Context, e models.Events) models.Events
+	handlerName  string
 	batchSize    int
 	numConsumers int
 }
@@ -27,7 +33,7 @@ const (
 	DefaultEventLogSize = 20
 )
 
-var SyncHandlers = utils.SyncedMap[string, postq.SyncEventHandlerFunc]{}
+var SyncHandlers = utils.SyncedMap[string, syncHandlerData]{}
 var AsyncHandlers = utils.SyncedMap[string, asyncHandlerData]{}
 
 var consumers []*postq.PGConsumer
@@ -38,9 +44,14 @@ func Register(fn func(ctx context.Context)) {
 }
 
 func RegisterAsyncHandler(fn func(ctx context.Context, e models.Events) models.Events, batchSize int, consumers int, events ...string) {
+	RegisterAsyncHandlerNamed(getHandlerName(fn), fn, batchSize, consumers, events...)
+}
+
+func RegisterAsyncHandlerNamed(name string, fn func(ctx context.Context, e models.Events) models.Events, batchSize int, consumers int, events ...string) {
 	for _, event := range events {
 		AsyncHandlers.Append(event, asyncHandlerData{
 			fn:           fn,
+			handlerName:  name,
 			batchSize:    batchSize,
 			numConsumers: consumers,
 		})
@@ -48,8 +59,15 @@ func RegisterAsyncHandler(fn func(ctx context.Context, e models.Events) models.E
 }
 
 func RegisterSyncHandler(fn postq.SyncEventHandlerFunc, events ...string) {
+	RegisterSyncHandlerNamed(getHandlerName(fn), fn, events...)
+}
+
+func RegisterSyncHandlerNamed(name string, fn postq.SyncEventHandlerFunc, events ...string) {
 	for _, event := range events {
-		SyncHandlers.Append(event, fn)
+		SyncHandlers.Append(event, syncHandlerData{
+			fn:          fn,
+			handlerName: name,
+		})
 	}
 }
 
@@ -72,11 +90,29 @@ func StartConsumers(ctx context.Context) {
 	notifyRouter := pg.NewNotifyRouter()
 	go notifyRouter.Run(ctx, eventQueueUpdateChannel)
 
-	SyncHandlers.Each(func(event string, handlers []postq.SyncEventHandlerFunc) {
+	SyncHandlers.Each(func(event string, handlers []syncHandlerData) {
 		log.Tracef("Registering %d sync event handlers for %s", len(handlers), event)
+
+		wrappedHandlers := make([]postq.SyncEventHandlerFunc, 0, len(handlers))
+		for _, handler := range handlers {
+			h := handler
+			wrappedHandlers = append(wrappedHandlers, func(ctx context.Context, e models.Event) error {
+				start := time.Now()
+				err := h.fn(ctx, e)
+				success := err == nil
+				recordEventHandlerDuration(event, h.handlerName, success, time.Since(start))
+				if success {
+					recordEventHandlerEvents(event, h.handlerName, 1, 0)
+				} else {
+					recordEventHandlerEvents(event, h.handlerName, 0, 1)
+				}
+				return err
+			})
+		}
+
 		consumer := postq.SyncEventConsumer{
 			WatchEvents: []string{event},
-			Consumers:   handlers,
+			Consumers:   wrappedHandlers,
 			ConsumerOption: &postq.ConsumerOption{
 				ErrorHandler: defaultLoggerErrorHandler,
 			},
@@ -95,6 +131,7 @@ func StartConsumers(ctx context.Context) {
 		log.Tracef("Registering %d async event handlers for %v", len(handlers), event)
 		for _, handler := range handlers {
 			h := handler.fn
+			handlerName := handler.handlerName
 			batchSize := ctx.Properties().Int(event+".batchSize", handler.batchSize)
 
 			consumer := postq.AsyncEventConsumer{
@@ -108,7 +145,18 @@ func StartConsumers(ctx context.Context) {
 					if ctx.Properties().Off(event+".debug", false) {
 						c = c.WithDebug()
 					}
-					return h(c, e)
+
+					start := time.Now()
+					failedEvents := h(c, e)
+					failedCount := len(failedEvents)
+					processedCount := len(e) - failedCount
+					if processedCount < 0 {
+						processedCount = 0
+					}
+
+					recordEventHandlerDuration(event, handlerName, failedCount == 0, time.Since(start))
+					recordEventHandlerEvents(event, handlerName, processedCount, failedCount)
+					return failedEvents
 				},
 				ConsumerOption: &postq.ConsumerOption{
 					NumConsumers: handler.numConsumers,

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -1,9 +1,6 @@
 package events
 
 import (
-	"reflect"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,26 +45,4 @@ func recordEventHandlerEvents(event, handler string, processed, failed int) {
 	if failed > 0 {
 		eventHandlerEventsTotal.WithLabelValues(event, handler, "failed").Add(float64(failed))
 	}
-}
-
-func getHandlerName(fn any) string {
-	if fn == nil {
-		return "unknown"
-	}
-
-	fnValue := reflect.ValueOf(fn)
-	if !fnValue.IsValid() || fnValue.Kind() != reflect.Func {
-		return "unknown"
-	}
-
-	rf := runtime.FuncForPC(fnValue.Pointer())
-	if rf == nil {
-		return "unknown"
-	}
-
-	name := rf.Name()
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		name = name[idx+1:]
-	}
-	return strings.TrimSuffix(name, "-fm")
 }

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -1,0 +1,73 @@
+package events
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	eventHandlerEventsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_handler_events_total",
+			Help: "Total number of events processed by event handlers.",
+		},
+		[]string{"event", "handler", "status"},
+	)
+
+	eventHandlerDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "event_handler_duration_seconds",
+			Help:    "Duration of event handler invocations in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"event", "handler", "status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(eventHandlerEventsTotal, eventHandlerDurationSeconds)
+}
+
+func recordEventHandlerDuration(event, handler string, success bool, duration time.Duration) {
+	status := "success"
+	if !success {
+		status = "fail"
+	}
+
+	eventHandlerDurationSeconds.WithLabelValues(event, handler, status).Observe(duration.Seconds())
+}
+
+func recordEventHandlerEvents(event, handler string, processed, failed int) {
+	if processed > 0 {
+		eventHandlerEventsTotal.WithLabelValues(event, handler, "success").Add(float64(processed))
+	}
+	if failed > 0 {
+		eventHandlerEventsTotal.WithLabelValues(event, handler, "failed").Add(float64(failed))
+	}
+}
+
+func getHandlerName(fn any) string {
+	if fn == nil {
+		return "unknown"
+	}
+
+	fnValue := reflect.ValueOf(fn)
+	if !fnValue.IsValid() || fnValue.Kind() != reflect.Func {
+		return "unknown"
+	}
+
+	rf := runtime.FuncForPC(fnValue.Pointer())
+	if rf == nil {
+		return "unknown"
+	}
+
+	name := rf.Name()
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return strings.TrimSuffix(name, "-fm")
+}

--- a/notification/events.go
+++ b/notification/events.go
@@ -51,7 +51,7 @@ func RegisterEvents(ctx context.Context) {
 	nh := notificationHandler{Ring: EventRing}
 	events.RegisterSyncHandlerNamed("notification.addNotificationEvent", nh.addNotificationEvent, append(api.EventStatusGroup, api.EventIncidentGroup...)...)
 
-	events.RegisterAsyncHandlerNamed("notification.sendNotifications", sendNotifications, 1, 5, api.EventNotificationSend)
+	events.RegisterAsyncHandler("notification.sendNotifications", sendNotifications, 1, 5, api.EventNotificationSend)
 }
 
 func getOrCreateRateLimiter(ctx context.Context, notificationID string) (*sw.Limiter, error) {

--- a/notification/events.go
+++ b/notification/events.go
@@ -49,9 +49,9 @@ func init() {
 func RegisterEvents(ctx context.Context) {
 	EventRing = events.NewEventRing(ctx.Properties().Int("events.audit.size", events.DefaultEventLogSize))
 	nh := notificationHandler{Ring: EventRing}
-	events.RegisterSyncHandler(nh.addNotificationEvent, append(api.EventStatusGroup, api.EventIncidentGroup...)...)
+	events.RegisterSyncHandlerNamed("notification.addNotificationEvent", nh.addNotificationEvent, append(api.EventStatusGroup, api.EventIncidentGroup...)...)
 
-	events.RegisterAsyncHandler(sendNotifications, 1, 5, api.EventNotificationSend)
+	events.RegisterAsyncHandlerNamed("notification.sendNotifications", sendNotifications, 1, 5, api.EventNotificationSend)
 }
 
 func getOrCreateRateLimiter(ctx context.Context, notificationID string) (*sw.Limiter, error) {

--- a/playbook/events.go
+++ b/playbook/events.go
@@ -69,11 +69,11 @@ func init() {
 func RegisterEvents(ctx context.Context) {
 	EventRing = events.NewEventRing(ctx.Properties().Int("events.audit.size", events.DefaultEventLogSize))
 	ps := playbookScheduler{Ring: EventRing}
-	events.RegisterSyncHandler(ps.Handle, api.EventStatusGroup...)
+	events.RegisterSyncHandlerNamed("playbook.Handle", ps.Handle, api.EventStatusGroup...)
 
-	events.RegisterSyncHandler(onNewRun, api.EventPlaybookRun)
-	events.RegisterSyncHandler(onApprovalUpdated, api.EventPlaybookSpecApprovalUpdated)
-	events.RegisterSyncHandler(onPlaybookRunNewApproval, api.EventPlaybookApprovalInserted)
+	events.RegisterSyncHandlerNamed("playbook.onNewRun", onNewRun, api.EventPlaybookRun)
+	events.RegisterSyncHandlerNamed("playbook.onApprovalUpdated", onApprovalUpdated, api.EventPlaybookSpecApprovalUpdated)
+	events.RegisterSyncHandlerNamed("playbook.onPlaybookRunNewApproval", onPlaybookRunNewApproval, api.EventPlaybookApprovalInserted)
 
 	go func() {
 		logs.IfError(StartPlaybookConsumers(ctx), "error starting playbook consumers")


### PR DESCRIPTION
add event handler metrics for event-level status and duration.

when event queue keeps piling up, this helps us diagnose whether the events are being processed or not and how long each it's taking to process each events.

```
# HELP event_handler_events_total Total number of events processed by event handlers.
# TYPE event_handler_events_total counter
event_handler_events_total{event="config.changed",handler="notification.addNotificationEvent",status="success"} 287
event_handler_events_total{event="config.changed",handler="playbook.Handle",status="success"} 287
event_handler_events_total{event="config.healthy",handler="notification.addNotificationEvent",status="success"} 1
event_handler_events_total{event="config.healthy",handler="playbook.Handle",status="success"} 1
event_handler_events_total{event="config.unknown",handler="notification.addNotificationEvent",status="success"} 1
event_handler_events_total{event="config.unknown",handler="playbook.Handle",status="success"} 1
event_handler_events_total{event="config.updated",handler="notification.addNotificationEvent",status="success"} 55
event_handler_events_total{event="config.updated",handler="playbook.Handle",status="success"} 55
```