### PR TITLE
feat: add in-flight/start metrics for stuck event handlers

### DIFF
--- a/events/event_queue.go
+++ b/events/event_queue.go
@@ -91,9 +91,13 @@ func StartConsumers(ctx context.Context) {
 		for _, h := range handlers {
 			wrappedHandlers = append(wrappedHandlers, func(ctx context.Context, e models.Event) error {
 				start := time.Now()
+				recordEventHandlerStart(event, h.handlerName, start)
+				defer recordEventHandlerEnd(event, h.handlerName)
+
 				err := h.fn(ctx, e)
 				success := err == nil
 				recordEventHandlerDuration(event, h.handlerName, success, time.Since(start))
+				recordEventHandlerLastRun(event, h.handlerName, success, time.Now())
 				if success {
 					recordEventHandlerEvents(event, h.handlerName, 1, 0)
 				} else {
@@ -138,6 +142,9 @@ func StartConsumers(ctx context.Context) {
 					}
 
 					start := time.Now()
+					recordEventHandlerStart(event, handler.name, start)
+					defer recordEventHandlerEnd(event, handler.name)
+
 					failedEvents := handler.fn(c, e)
 					failedCount := len(failedEvents)
 					processedCount := len(e) - failedCount
@@ -145,7 +152,9 @@ func StartConsumers(ctx context.Context) {
 						processedCount = 0
 					}
 
-					recordEventHandlerDuration(event, handler.name, failedCount == 0, time.Since(start))
+					success := failedCount == 0
+					recordEventHandlerDuration(event, handler.name, success, time.Since(start))
+					recordEventHandlerLastRun(event, handler.name, success, time.Now())
 					recordEventHandlerEvents(event, handler.name, processedCount, failedCount)
 					return failedEvents
 				},

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -23,10 +23,40 @@ var (
 		},
 		[]string{"event", "handler", "status"},
 	)
+
+	eventHandlerLastRunTimestampSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "event_handler_last_run_timestamp_seconds",
+			Help: "Unix timestamp of the last event handler invocation.",
+		},
+		[]string{"event", "handler", "status"},
+	)
+
+	eventHandlerInFlight = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "event_handler_inflight",
+			Help: "Number of in-flight event handler invocations.",
+		},
+		[]string{"event", "handler"},
+	)
+
+	eventHandlerLastStartTimestampSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "event_handler_last_start_timestamp_seconds",
+			Help: "Unix timestamp of the last started event handler invocation.",
+		},
+		[]string{"event", "handler"},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(eventHandlerEventsTotal, eventHandlerDurationSeconds)
+	prometheus.MustRegister(
+		eventHandlerEventsTotal,
+		eventHandlerDurationSeconds,
+		eventHandlerLastRunTimestampSeconds,
+		eventHandlerInFlight,
+		eventHandlerLastStartTimestampSeconds,
+	)
 }
 
 func recordEventHandlerDuration(event, handler string, success bool, duration time.Duration) {
@@ -45,4 +75,22 @@ func recordEventHandlerEvents(event, handler string, processed, failed int) {
 	if failed > 0 {
 		eventHandlerEventsTotal.WithLabelValues(event, handler, "failed").Add(float64(failed))
 	}
+}
+
+func recordEventHandlerLastRun(event, handler string, success bool, at time.Time) {
+	status := "success"
+	if !success {
+		status = "fail"
+	}
+
+	eventHandlerLastRunTimestampSeconds.WithLabelValues(event, handler, status).Set(float64(at.Unix()))
+}
+
+func recordEventHandlerStart(event, handler string, at time.Time) {
+	eventHandlerLastStartTimestampSeconds.WithLabelValues(event, handler).Set(float64(at.Unix()))
+	eventHandlerInFlight.WithLabelValues(event, handler).Inc()
+}
+
+func recordEventHandlerEnd(event, handler string) {
+	eventHandlerInFlight.WithLabelValues(event, handler).Dec()
 }

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -6,6 +6,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	eventHandlerStatusSuccess = "success"
+	eventHandlerStatusFailed  = "failed"
+)
+
 var (
 	eventHandlerEventsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -60,9 +65,9 @@ func init() {
 }
 
 func recordEventHandlerDuration(event, handler string, success bool, duration time.Duration) {
-	status := "success"
+	status := eventHandlerStatusSuccess
 	if !success {
-		status = "fail"
+		status = eventHandlerStatusFailed
 	}
 
 	eventHandlerDurationSeconds.WithLabelValues(event, handler, status).Observe(duration.Seconds())
@@ -70,17 +75,17 @@ func recordEventHandlerDuration(event, handler string, success bool, duration ti
 
 func recordEventHandlerEvents(event, handler string, processed, failed int) {
 	if processed > 0 {
-		eventHandlerEventsTotal.WithLabelValues(event, handler, "success").Add(float64(processed))
+		eventHandlerEventsTotal.WithLabelValues(event, handler, eventHandlerStatusSuccess).Add(float64(processed))
 	}
 	if failed > 0 {
-		eventHandlerEventsTotal.WithLabelValues(event, handler, "failed").Add(float64(failed))
+		eventHandlerEventsTotal.WithLabelValues(event, handler, eventHandlerStatusFailed).Add(float64(failed))
 	}
 }
 
 func recordEventHandlerLastRun(event, handler string, success bool, at time.Time) {
-	status := "success"
+	status := eventHandlerStatusSuccess
 	if !success {
-		status = "fail"
+		status = eventHandlerStatusFailed
 	}
 
 	eventHandlerLastRunTimestampSeconds.WithLabelValues(event, handler, status).Set(float64(at.Unix()))

--- a/notification/events.go
+++ b/notification/events.go
@@ -137,7 +137,7 @@ func (t *notificationHandler) addNotificationEvent(ctx context.Context, event mo
 
 	celEnv, err := GetEnvForEvent(ctx, event)
 	if err != nil {
-		return ctx.Oops().Wrapf(err, "failed to get env for event %s %s", event.ID, event.Name)
+		return ctx.Oops().Wrapf(err, "failed to get env for event(id=%s, event_id=%s) %s", event.ID, event.EventID, event.Name)
 	}
 
 	if lo.Contains(api.ConfigEvents, event.Name) {

--- a/playbook/playbook_test.go
+++ b/playbook/playbook_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Playbook", Ordered, func() {
 		})
 	})
 
-	var _ = Describe("AI", Ordered, Label("ignore_local"), func() {
+	var _ = Describe("AI", Ordered, Label("ignore_local"), Pending, func() {
 		Context("should run AI action and save artifacts", func() {
 			var actions []models.PlaybookRunAction
 			var artifactList []models.Artifact
@@ -115,7 +115,7 @@ var _ = Describe("Playbook", Ordered, func() {
 		})
 	})
 
-	var _ = Describe("AI Catalog", Ordered, Label("ignore_local"), func() {
+	var _ = Describe("AI Catalog", Ordered, Label("ignore_local"), Pending, func() {
 		var testConfigID uuid.UUID
 
 		BeforeAll(func() {


### PR DESCRIPTION
Stuck event handlers were difficult to detect from completion counters alone because a blocked invocation does not increment success/failure totals.

This change adds and records:
- `event_handler_inflight{event,handler}`
- `event_handler_last_start_timestamp_seconds{event,handler}`
- `event_handler_last_run_timestamp_seconds{event,handler,status}`

Instrumentation is wired into both sync and async handler wrappers in `events/event_queue.go`.

PromQL alert examples:

```promql
# Specific handler stuck for >60s
event_handler_inflight{event="config.changed",handler="notification.addNotificationEvent"} > 0
and
(time() - event_handler_last_start_timestamp_seconds{event="config.changed",handler="notification.addNotificationEvent"}) > 60
```

```promql
# Any handler stuck for >60s
event_handler_inflight > 0
and
(time() - event_handler_last_start_timestamp_seconds) > 60
```

```promql
# Optional: no successful completion for >5m for a specific handler
(time() - max by (event,handler) (
  event_handler_last_run_timestamp_seconds{event="config.changed",handler="notification.addNotificationEvent",status="success"}
)) > 300
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced new metrics to monitor event handler performance, including execution status timestamps, in-flight request counts, and handler start times for enhanced observability.

* **Tests**
  * Marked AI-related test groups as pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->