### PR TITLE
fix: fail notification dispatch when start history log cannot be created

### DIFF
--- a/notification/events.go
+++ b/notification/events.go
@@ -619,7 +619,9 @@ func sendPendingNotification(ctx context.Context, history models.NotificationSen
 		}
 	}
 
-	logs.IfError(notificationContext.EndLog(), "error persisting end of notification send history")
+	if endLogErr := notificationContext.EndLog(); endLogErr != nil {
+		logNotificationEndLogError(notificationContext, err, endLogErr)
+	}
 	if IsStaleResourceEventError(err) {
 		return nil
 	}
@@ -694,7 +696,9 @@ func sendNotification(ctx context.Context, payload NotificationEventPayload) err
 	notificationContext.WithSource(payload.EventName, payload.ResourceID)
 	notificationContext.WithGroupID(payload.GroupID)
 
-	logs.IfError(notificationContext.StartLog(), "error persisting start of notification send history")
+	if err := notificationContext.StartLog(); err != nil {
+		return fmt.Errorf("failed to create notification send history before dispatch: %w", err)
+	}
 
 	err := _sendNotification(notificationContext, payload)
 	if err != nil {
@@ -706,11 +710,36 @@ func sendNotification(ctx context.Context, payload NotificationEventPayload) err
 		}
 	}
 
-	logs.IfError(notificationContext.EndLog(), "error persisting end of notification send history")
+	if endLogErr := notificationContext.EndLog(); endLogErr != nil {
+		logNotificationEndLogError(notificationContext, err, endLogErr)
+	}
 	if IsStaleResourceEventError(err) {
 		return nil
 	}
 	return err
+}
+
+func logNotificationEndLogError(ctx *Context, sendErr, endLogErr error) {
+	if ctx == nil || ctx.log == nil {
+		logs.IfError(endLogErr, "error persisting end of notification send history")
+		return
+	}
+
+	sendErrMsg := ""
+	if sendErr != nil {
+		sendErrMsg = sendErr.Error()
+	}
+
+	ctx.Errorf(
+		"error persisting end of notification send history: history_id=%s notification_id=%s source_event=%s resource_id=%s status=%s send_error=%q error=%v",
+		ctx.log.ID,
+		ctx.log.NotificationID,
+		ctx.log.SourceEvent,
+		ctx.log.ResourceID,
+		ctx.log.Status,
+		sendErrMsg,
+		endLogErr,
+	)
 }
 
 func _sendNotification(ctx *Context, payload NotificationEventPayload) error {


### PR DESCRIPTION
- We were seeing notifications delivered to Slack while no corresponding notification history records were persisted; silences also didn’t work reliably in those cases.
- Notification sending now returns an error immediately when StartLog() fails, instead of continuing dispatch without a persisted history row.
- End-log persistence failures are now logged with richer context (history id, notification id, source event, resource id, status, and send error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for notification delivery: structured diagnostics now include history ID, notification ID, resource ID, status, and both the send error and any end-log persistence error.
  * Notification processing now aborts immediately if initial logging setup fails, preventing partial execution.
  * Logging now gracefully falls back when the logging context is unavailable, ensuring errors are still reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->