### PR TITLE
feat: Add a reference to the notification rule in the permalink

### DIFF
--- a/notification/cel.go
+++ b/notification/cel.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"time"
 
@@ -59,6 +60,28 @@ func (t *celVariables) SetSilenceURL(frontendURL string) {
 	case t.Canary != nil:
 		t.SilenceURL = fmt.Sprintf("%s?canary_id=%s", baseURL, t.Canary.ID.String())
 	}
+}
+
+func (t celVariables) WithNotificationRef(notificationID string) celVariables {
+	t.Permalink = appendRefNotification(t.Permalink, notificationID)
+	return t
+}
+
+func appendRefNotification(rawURL string, notificationID string) string {
+	if rawURL == "" || notificationID == "" {
+		return rawURL
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	query := u.Query()
+	query.Set("refNotification", notificationID)
+	u.RawQuery = query.Encode()
+
+	return u.String()
 }
 
 type ResourceHealthRow struct {

--- a/notification/events.go
+++ b/notification/events.go
@@ -169,7 +169,8 @@ func (t *notificationHandler) addNotificationEvent(ctx context.Context, event mo
 	}
 
 	for _, id := range notificationIDs {
-		if err := addNotificationEvent(ctx, id, celEnv, event, matchingSilences); err != nil {
+		notificationEnv := celEnv.WithNotificationRef(id)
+		if err := addNotificationEvent(ctx, id, &notificationEnv, event, matchingSilences); err != nil {
 			return ctx.Oops().Wrapf(err, "failed to add notification.send event for event=%s notification=%s", event.Name, id)
 		}
 	}
@@ -780,6 +781,8 @@ func _sendNotification(ctx *Context, payload NotificationEventPayload) error {
 	if err != nil {
 		return fmt.Errorf("failed to get cel env: %w", err)
 	}
+	notificationEnv := celEnv.WithNotificationRef(payload.NotificationID.String())
+	celEnv = &notificationEnv
 
 	if payload.GroupID != nil {
 		celEnv.GroupedResources, err = db.GetGroupedResources(ctx.Context, *payload.GroupID, payload.ResourceID.String())


### PR DESCRIPTION
When notifications are being received but there's no record in the send history, this will help us identify the notification rule that sent this notificaiton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification permalinks now include a notification reference query parameter so links can be tied to a specific notification.
  * Notification processing now consistently uses notification-specific contexts so each notification is evaluated and prepared with its own scoped settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->