### PR TITLE
fix: GetEnvForEvent poisons query cache

### DIFF
--- a/notification/events.go
+++ b/notification/events.go
@@ -825,6 +825,7 @@ func GetEnvForEvent(ctx context.Context, event models.Event) (*celVariables, err
 		} else if check == nil {
 			return nil, fmt.Errorf("check(id=%s) not found", checkID)
 		}
+		check = new(check.Clone())
 
 		canary, err := query.FindCachedCanary(ctx, check.CanaryID.String())
 		if err != nil {
@@ -940,6 +941,7 @@ func GetEnvForEvent(ctx context.Context, event models.Event) (*celVariables, err
 		} else if component == nil {
 			return nil, fmt.Errorf("component(id=%s) not found", componentID)
 		}
+		component = new(component.Clone())
 
 		agent, err := query.FindCachedAgent(ctx, component.AgentID.String())
 		if err != nil {
@@ -969,6 +971,7 @@ func GetEnvForEvent(ctx context.Context, event models.Event) (*celVariables, err
 		} else if config == nil {
 			return nil, fmt.Errorf("config(id=%s) not found", configID)
 		}
+		config = new(config.Clone())
 
 		agent, err := query.FindCachedAgent(ctx, config.AgentID.String())
 		if err != nil {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/types"
+	"github.com/flanksource/gomplate/v3"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,72 @@ import (
 	_ "github.com/flanksource/incident-commander/playbook"
 	_ "github.com/flanksource/incident-commander/upstream"
 )
+
+var _ = ginkgo.Describe("GetEnvForEvent", func() {
+	ginkgo.It("uses the config event snapshot when evaluating notification filters", func() {
+		query.FlushGettersCache()
+
+		config := models.ConfigItem{
+			ID:          uuid.New(),
+			Name:        lo.ToPtr("daemonset-rolling-out"),
+			ConfigClass: "DaemonSet",
+			Type:        lo.ToPtr("Kubernetes::DaemonSet"),
+			Health:      lo.ToPtr(models.HealthHealthy),
+			Status:      lo.ToPtr("Pending"),
+		}
+		Expect(DefaultContext.DB().Create(&config).Error).To(BeNil())
+		ginkgo.DeferCleanup(func() {
+			Expect(DefaultContext.DB().Delete(&config).Error).To(BeNil())
+			query.FlushGettersCache()
+		})
+
+		rollingOutEnv, err := notification.GetEnvForEvent(DefaultContext, models.Event{
+			Name:    api.EventConfigWarning,
+			EventID: config.ID,
+			Properties: types.JSONStringMap{
+				"status":      "Rolling Out",
+				"description": "DaemonSet is rolling out",
+			},
+		})
+		Expect(err).To(BeNil())
+
+		// Regression: cached config items must not be mutated in-place. A later Running
+		// event must not make the earlier Rolling Out event pass this notification filter.
+		runningEnv, err := notification.GetEnvForEvent(DefaultContext, models.Event{
+			Name:    api.EventConfigWarning,
+			EventID: config.ID,
+			Properties: types.JSONStringMap{
+				"status":      "Running",
+				"description": "DaemonSet is running",
+			},
+		})
+		Expect(err).To(BeNil())
+
+		Expect(rollingOutEnv.ConfigItem.Status).NotTo(BeNil())
+		Expect(runningEnv.ConfigItem.Status).NotTo(BeNil())
+		Expect(*rollingOutEnv.ConfigItem.Status).To(Equal("Rolling Out"))
+		Expect(*runningEnv.ConfigItem.Status).To(Equal("Running"))
+
+		rollingOutMap := rollingOutEnv.AsMap(DefaultContext)
+		runningMap := runningEnv.AsMap(DefaultContext)
+		Expect(rollingOutMap).To(HaveKeyWithValue("status", "Rolling Out"))
+		Expect(runningMap).To(HaveKeyWithValue("status", "Running"))
+		Expect(rollingOutMap["config"]).To(HaveKeyWithValue("status", "Rolling Out"))
+		Expect(runningMap["config"]).To(HaveKeyWithValue("status", "Running"))
+
+		matchesDaemonSetFilter, err := DefaultContext.RunTemplateBool(gomplate.Template{
+			Expression: `config.type == "Kubernetes::DaemonSet" && config.status != "Rolling Out"`,
+		}, rollingOutMap)
+		Expect(err).To(BeNil())
+		Expect(matchesDaemonSetFilter).To(BeFalse())
+
+		matchesDaemonSetFilter, err = DefaultContext.RunTemplateBool(gomplate.Template{
+			Expression: `config.type == "Kubernetes::DaemonSet" && config.status != "Rolling Out"`,
+		}, runningMap)
+		Expect(err).To(BeNil())
+		Expect(matchesDaemonSetFilter).To(BeTrue())
+	})
+})
 
 var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3), func() {
 	var customReceiverJson []byte


### PR DESCRIPTION
dependsOn: https://github.com/flanksource/duty/pull/1929


 `GetEnvForEvent` was applying event-time fields like `health`, `status`, and `description` directly onto config objects returned from the query cache.

   Because those cached objects are shared, processing a later event could mutate the CEL/template environment for an earlier event. This could make
 notification filters evaluate against the wrong status.