### PR TITLE
fix: restore original event properties for pending notifications

### DIFF
--- a/notification/events.go
+++ b/notification/events.go
@@ -749,11 +749,9 @@ func _sendNotification(ctx *Context, payload NotificationEventPayload) error {
 		return ErrStaleResourceEvent
 	}
 
-	originalEvent := payload.ParentEvent()
-	if len(payload.Properties) > 0 {
-		if err := json.Unmarshal(payload.Properties, &originalEvent.Properties); err != nil {
-			return fmt.Errorf("failed to unmarshal properties: %w", err)
-		}
+	originalEvent, err := payload.originalEvent()
+	if err != nil {
+		return err
 	}
 
 	celEnv, err := GetEnvForEvent(ctx.Context, originalEvent)

--- a/notification/events.go
+++ b/notification/events.go
@@ -487,6 +487,28 @@ func processNotificationConstraints(ctx context.Context,
 	return nil, nil
 }
 
+func shouldSkipNotificationDueToFilter(ctx context.Context, notif NotificationWithSpec, currentHistory models.NotificationSendHistory, celEnv *celVariables) (bool, error) {
+	if notif.Filter == "" {
+		return false, nil
+	}
+
+	valid, err := ctx.RunTemplateBool(gomplate.Template{Expression: notif.Filter}, celEnv.AsMap(ctx, celVarGetLatestHealthStatus))
+	if err != nil {
+		return false, ctx.Oops().Wrapf(err, "failed to validate notification filter for notification:%s", notif.ID)
+	}
+
+	if valid {
+		return false, nil
+	}
+
+	traceLog("NotificationID=%s HistoryID=%s Resource=[%s/%s] Filter no longer matches, skipping", notif.ID, currentHistory.ID, currentHistory.SourceEvent, currentHistory.ResourceID)
+	if err := db.SkipNotificationSendHistory(ctx, currentHistory.ID); err != nil {
+		return false, fmt.Errorf("failed to skip notification send history (%s): %w", currentHistory.ID, err)
+	}
+
+	return true, nil
+}
+
 func checkInhibition(ctx context.Context, notif NotificationWithSpec, resource types.ResourceSelectable) (*uuid.UUID, error) {
 	// Note: we use the repeat interval as the inhibition window.
 	inhibitionWindow := notif.RepeatInterval

--- a/notification/job.go
+++ b/notification/job.go
@@ -431,6 +431,12 @@ func processPendingNotification(ctx context.Context, currentHistory models.Notif
 		return fmt.Errorf("failed to get cel env: %w", err)
 	}
 
+	if skipNotif, err := shouldSkipNotificationDueToFilter(ctx, *notif, currentHistory, celEnv); err != nil {
+		return fmt.Errorf("failed to check notification filter: %w", err)
+	} else if skipNotif {
+		return nil
+	}
+
 	silencedResource := getSilencedResourceFromCelEnv(celEnv)
 	matchingSilences, err := db.GetMatchingNotificationSilences(ctx, silencedResource)
 	if err != nil {

--- a/notification/job.go
+++ b/notification/job.go
@@ -321,11 +321,9 @@ func shouldSkipNotificationDueToHealth(ctx context.Context, notif NotificationWi
 	var payload NotificationEventPayload
 	payload.FromMap(currentHistory.Payload)
 
-	originalEvent := models.Event{Name: payload.EventName, EventID: payload.EventID, CreatedAt: payload.EventCreatedAt}
-	if len(payload.Properties) > 0 {
-		if err := json.Unmarshal(payload.Properties, &originalEvent.Properties); err != nil {
-			return false, fmt.Errorf("failed to unmarshal properties: %w", err)
-		}
+	originalEvent, err := payload.originalEvent()
+	if err != nil {
+		return false, err
 	}
 
 	celEnv, err := GetEnvForEvent(ctx, originalEvent)
@@ -423,7 +421,12 @@ func processPendingNotification(ctx context.Context, currentHistory models.Notif
 	var payload NotificationEventPayload
 	payload.FromMap(currentHistory.Payload)
 
-	celEnv, err := GetEnvForEvent(ctx, payload.ParentEvent())
+	originalEvent, err := payload.originalEvent()
+	if err != nil {
+		return err
+	}
+
+	celEnv, err := GetEnvForEvent(ctx, originalEvent)
 	if err != nil {
 		return fmt.Errorf("failed to get cel env: %w", err)
 	}

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1179,7 +1179,7 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 				Title:          "Dummy",
 				Template:       "dummy",
 				CustomServices: types.JSON(customReceiverJson),
-				WaitFor:        new(time.Millisecond),
+				WaitFor:        lo.ToPtr(time.Millisecond),
 			}
 			Expect(DefaultContext.DB().Create(&n).Error).To(BeNil())
 
@@ -1255,6 +1255,88 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 				g.Expect(got.Status).To(Equal(models.NotificationStatusSilenced))
 				g.Expect(got.SilencedBy).ToNot(BeNil())
 				g.Expect(*got.SilencedBy).To(Equal(silence.ID))
+			}, "10s", "200ms").Should(Succeed())
+		})
+	})
+
+	var _ = ginkgo.Describe("pending notification filter re-evaluation", func() {
+		var n models.Notification
+		var config models.ConfigItem
+
+		ginkgo.BeforeAll(func() {
+			n = models.Notification{
+				ID:             uuid.New(),
+				Name:           "pending-filter-reevaluation-test",
+				Events:         pq.StringArray([]string{"config.unhealthy"}),
+				Source:         models.SourceCRD,
+				Title:          "Dummy",
+				Template:       "dummy",
+				CustomServices: types.JSON(customReceiverJson),
+				WaitFor:        lo.ToPtr(time.Millisecond),
+				Filter:         ".status == 'CrashLoopBackOff'",
+			}
+			Expect(DefaultContext.DB().Create(&n).Error).To(BeNil())
+
+			config = models.ConfigItem{
+				ID:          uuid.New(),
+				Name:        lo.ToPtr("worker"),
+				ConfigClass: models.ConfigClassDeployment,
+				Health:      lo.ToPtr(models.HealthHealthy),
+				Description: lo.ToPtr("deployment/worker is running"),
+				Status:      lo.ToPtr("Running"),
+				Config:      lo.ToPtr(`{"namespace":"prod","name":"worker"}`),
+				Type:        lo.ToPtr("Kubernetes::Deployment"),
+			}
+			Expect(DefaultContext.DB().Create(&config).Error).To(BeNil())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+			events.ConsumeAll(DefaultContext)
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).
+				Where("id = ?", config.ID).
+				Updates(map[string]any{
+					"health":      models.HealthUnhealthy,
+					"status":      "CrashLoopBackOff",
+					"description": "deployment/worker has crashing pods",
+				}).Error).To(BeNil())
+
+			events.ConsumeAll(DefaultContext)
+			Eventually(func(g Gomega) {
+				var pending models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).
+					Where("resource_id = ?", config.ID).
+					Where("source_event = ?", "config.unhealthy").
+					Where("status = ?", models.NotificationStatusPending).
+					First(&pending).Error).To(BeNil())
+			}, "10s", "200ms").Should(Succeed())
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).
+				Where("id = ?", config.ID).
+				Updates(map[string]any{
+					"status":      "ImagePullBackOff",
+					"description": "deployment/worker is now failing with ImagePullBackOff",
+				}).Error).To(BeNil())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+		})
+
+		ginkgo.AfterAll(func() {
+			Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).Delete(&models.NotificationSendHistory{}).Error).To(BeNil())
+			Expect(DefaultContext.DB().Delete(&config).Error).To(BeNil())
+			Expect(DefaultContext.DB().Delete(&n).Error).To(BeNil())
+			notification.PurgeCache(n.ID.String())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+		})
+
+		ginkgo.It("skips pending notifications when the filter no longer matches", func() {
+			Eventually(func(g Gomega) {
+				_, err := notification.ProcessPendingNotifications(DefaultContext)
+				g.Expect(err).To(BeNil())
+
+				var got models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).
+					Where("resource_id = ?", config.ID).
+					Where("source_event = ?", "config.unhealthy").
+					First(&got).Error).To(BeNil())
+				g.Expect(got.Status).To(Equal(models.NotificationStatusSkipped))
 			}, "10s", "200ms").Should(Succeed())
 		})
 	})

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1165,6 +1165,100 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 		})
 	})
 
+	var _ = ginkgo.Describe("pending notification event snapshot", func() {
+		var n models.Notification
+		var config models.ConfigItem
+		var silence models.NotificationSilence
+
+		ginkgo.BeforeAll(func() {
+			n = models.Notification{
+				ID:             uuid.MustParse("3e2d6a19-2222-4444-9999-aabbccddeeff"),
+				Name:           "pending-event-snapshot-test",
+				Events:         pq.StringArray([]string{"config.unhealthy"}),
+				Source:         models.SourceCRD,
+				Title:          "Dummy",
+				Template:       "dummy",
+				CustomServices: types.JSON(customReceiverJson),
+				WaitFor:        new(time.Millisecond),
+			}
+			Expect(DefaultContext.DB().Create(&n).Error).To(BeNil())
+
+			config = models.ConfigItem{
+				ID:          uuid.MustParse("9b7f2a8e-1111-4444-8888-4e28c2f6d901"),
+				Name:        lo.ToPtr("api"),
+				ConfigClass: models.ConfigClassDeployment,
+				Health:      lo.ToPtr(models.HealthHealthy),
+				Description: lo.ToPtr("deployment/api in namespace prod is running"),
+				Status:      lo.ToPtr("Running"),
+				Config:      lo.ToPtr(`{"namespace":"prod","name":"api"}`),
+				Type:        lo.ToPtr("Kubernetes::Deployment"),
+			}
+			Expect(DefaultContext.DB().Create(&config).Error).To(BeNil())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+			events.ConsumeAll(DefaultContext)
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).
+				Where("id = ?", config.ID).
+				Updates(map[string]any{
+					"health":      models.HealthUnhealthy,
+					"status":      "CrashLoopBackOff",
+					"description": "deployment/api in namespace prod has 3 crashing pods",
+				}).Error).To(BeNil())
+
+			events.ConsumeAll(DefaultContext)
+			Eventually(func(g Gomega) {
+				var pending models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).
+					Where("resource_id = ?", config.ID).
+					Where("source_event = ?", "config.unhealthy").
+					Where("status = ?", models.NotificationStatusPending).
+					First(&pending).Error).To(BeNil())
+			}, "10s", "200ms").Should(Succeed())
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).
+				Where("id = ?", config.ID).
+				Updates(map[string]any{
+					"status":      "ImagePullBackOff",
+					"description": "deployment/api in namespace prod is now failing with ImagePullBackOff",
+				}).Error).To(BeNil())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+
+			silence = models.NotificationSilence{
+				NotificationSilenceResource: models.NotificationSilenceResource{ConfigID: lo.ToPtr(config.ID.String())},
+				ID:                          uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+				Name:                        "silence-crashloopbackoff-api",
+				Source:                      models.SourceCRD,
+				Filter:                      ".status == 'CrashLoopBackOff'",
+			}
+			Expect(DefaultContext.DB().Create(&silence).Error).To(BeNil())
+		})
+
+		ginkgo.AfterAll(func() {
+			Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).Delete(&models.NotificationSendHistory{}).Error).To(BeNil())
+			Expect(DefaultContext.DB().Delete(&silence).Error).To(BeNil())
+			Expect(DefaultContext.DB().Delete(&config).Error).To(BeNil())
+			Expect(DefaultContext.DB().Delete(&n).Error).To(BeNil())
+			notification.PurgeCache(n.ID.String())
+			Expect(query.FlushConfigCache(DefaultContext)).To(BeNil())
+		})
+
+		ginkgo.It("uses the original config event status when evaluating pending-path silences", func() {
+			Eventually(func(g Gomega) {
+				_, err := notification.ProcessPendingNotifications(DefaultContext)
+				g.Expect(err).To(BeNil())
+
+				var got models.NotificationSendHistory
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID).
+					Where("resource_id = ?", config.ID).
+					Where("source_event = ?", "config.unhealthy").
+					First(&got).Error).To(BeNil())
+				g.Expect(got.Status).To(Equal(models.NotificationStatusSilenced))
+				g.Expect(got.SilencedBy).ToNot(BeNil())
+				g.Expect(*got.SilencedBy).To(Equal(silence.ID))
+			}, "10s", "200ms").Should(Succeed())
+		})
+	})
+
 	var _ = ginkgo.Describe("group notifications", func() {
 		var n models.Notification
 		var config1, config2, config3, config4 models.ConfigItem

--- a/notification/send.go
+++ b/notification/send.go
@@ -147,6 +147,17 @@ func (t NotificationEventPayload) ParentEvent() models.Event {
 	return event
 }
 
+func (t NotificationEventPayload) originalEvent() (models.Event, error) {
+	event := t.ParentEvent()
+	if len(t.Properties) > 0 {
+		if err := json.Unmarshal(t.Properties, &event.Properties); err != nil {
+			return models.Event{}, fmt.Errorf("failed to unmarshal properties: %w", err)
+		}
+	}
+
+	return event, nil
+}
+
 func (t *NotificationEventPayload) FromMap(m map[string]string) {
 	b, _ := json.Marshal(m)
 	_ = json.Unmarshal(b, &t)

--- a/notification/send_test.go
+++ b/notification/send_test.go
@@ -1,0 +1,48 @@
+package notification
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("NotificationEventPayload original event", func() {
+	ginkgo.It("restores serialized event properties", func() {
+		eventID := uuid.MustParse("9b7f2a8e-1111-4444-8888-4e28c2f6d901")
+		resourceID := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+		createdAt := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+
+		payload := NotificationEventPayload{
+			EventID:        eventID,
+			EventName:      "config.unhealthy",
+			ResourceID:     resourceID,
+			EventCreatedAt: createdAt,
+			Properties:     []byte(`{"status":"CrashLoopBackOff","description":"deployment/api in namespace prod has 3 crashing pods","namespace":"prod","name":"api"}`),
+		}
+
+		event, err := payload.originalEvent()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(event.Name).To(Equal("config.unhealthy"))
+		Expect(event.EventID).To(Equal(eventID))
+		Expect(event.CreatedAt).To(Equal(createdAt))
+		Expect(event.Properties).To(HaveKeyWithValue("status", "CrashLoopBackOff"))
+		Expect(event.Properties).To(HaveKeyWithValue("description", "deployment/api in namespace prod has 3 crashing pods"))
+		Expect(event.Properties).To(HaveKeyWithValue("namespace", "prod"))
+		Expect(event.Properties).To(HaveKeyWithValue("name", "api"))
+	})
+
+	ginkgo.It("returns an error for invalid serialized properties", func() {
+		payload := NotificationEventPayload{
+			EventID:    uuid.MustParse("9b7f2a8e-1111-4444-8888-4e28c2f6d901"),
+			EventName:  "config.unhealthy",
+			Properties: []byte(`{"status":`),
+		}
+
+		_, err := payload.originalEvent()
+
+		Expect(err).To(MatchError(ContainSubstring("failed to unmarshal properties")))
+	})
+})


### PR DESCRIPTION
When a notification goes into `pending` state, we preserve the resource state from the time of the event in `notification_send_history`.

```sql
SELECT * FROM notification_send_history
```

```sh
 -[ RECORD 1 ]-------------------------
 id | 019dcfa5-c204-0ee8-c954-955e0514a8e3
 notification_id | 3e2d6a19-2222-4444-9999-aabbccddeeff
 body | dummy
 body_payload | <null>
 status | pending
 not_before | 2026-04-27 21:39:00.068923+05:45
 retries | 0
 payload | {event_id: 9b7f2a8e-1111-4444-8888-4e28c2f6d901, event_name: config.unhealthy, properties: eyJkZXNjcmlwdGlvbiI6ImRlcGxveW1lbnQvYXBpIGluIG5hbWVzcGFjZSBwcm9kIGhhcyAzIGNyYXNoaW5>
 count                       | 1
 first_observed              | 2026-04-27 21:39:00.068027+05:45
 source_event                | config.unhealthy
 resource_id                 | 9b7f2a8e-1111-4444-8888-4e28c2f6d901
 resource_health             | unhealthy
 resource_status             | CrashLoopBackOff
 resource_health_description | deployment/api in namespace prod has 3 crashing pods
 person_id                   | <null>
 team_id                     | <null>
 connection_id               | <null>
 silenced_by                 | <null>
 playbook_run_id             | <null>
 error                       | <null>
 duration_millis             | 0
 created_at                  | 2026-04-27 21:39:00.068069+05:45
 group_id                    | <null>
 parent_id                   | <null>
```

```sh
printf 'eyJkZXNjcmlwdGlvbiI6ImRlcGxveW1lbnQvYXBpIGluIG5hbWVzcGFjZSBwcm9kIGhhcyAzIGNyYXNoaW5nIHBvZHMiLCJzdGF0dXMiOiJDcmFzaExvb3BCYWNrT2ZmIn0=' | base64 -d | jq
 {
   description: deployment/api in namespace prod has 3 crashing pods,
   status: CrashLoopBackOff
 }
```

Later, when processing that pending notification, we rebuild the CEL environment from the original event so checks like silences, constraints,
 grouping, and filters see the config state from the time of the event.

The bug was that pending processing rebuilt the original event without restoring those saved properties. As a result, env.config.status and
 env.config.description could be empty or different from the values preserved in the pending notification payload.

This fix restores the saved event properties before building the CEL environment for pending notifications, matching the immediate send path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Notifications can now be skipped based on filter conditions during processing.

* **Bug Fixes**
  * Notification processing now uses the event state captured when the notification was created, rather than the current state, ensuring consistent filter and silence matching.

* **Tests**
  * Added test coverage for notification processing with event snapshots and filter re-evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->