### PR TITLE
fix: refresh nested resource status aliases in notification CEL env

### DIFF
--- a/notification/cel.go
+++ b/notification/cel.go
@@ -132,11 +132,31 @@ func (t *celVariables) AsMap(ctx context.Context, opts ...celAsMapOption) map[st
 	resourceContext := duty.GetResourceContext(ctx, t.SelectableResource())
 	if ctx.DB() != nil && slices.Contains(opts, celVarGetLatestHealthStatus) {
 		if r, err := t.GetResourceCurrentHealthStatus(ctx); err == nil {
-			resourceContext["health"] = r.Health
-			resourceContext["status"] = r.Status
+			t.setResourceCurrentHealthStatus(resourceContext, output, r)
 		}
 	}
 	return collections.MergeMap(resourceContext, output)
+}
+
+func (t *celVariables) setResourceCurrentHealthStatus(resourceContext, output map[string]any, r ResourceHealthRow) {
+	resourceContext["health"] = r.Health
+	resourceContext["status"] = r.Status
+
+	switch {
+	case t.ConfigItem != nil:
+		setResourceMapCurrentHealthStatus(output, "config", r)
+	case t.Component != nil:
+		setResourceMapCurrentHealthStatus(output, "component", r)
+	case t.Check != nil:
+		setResourceMapCurrentHealthStatus(output, "check", r)
+	}
+}
+
+func setResourceMapCurrentHealthStatus(output map[string]any, key string, r ResourceHealthRow) {
+	if resourceMap, ok := output[key].(map[string]any); ok {
+		resourceMap["health"] = r.Health
+		resourceMap["status"] = r.Status
+	}
 }
 
 func (t *celVariables) SelectableResource() types.ResourceSelectable {

--- a/notification/cel_test.go
+++ b/notification/cel_test.go
@@ -5,9 +5,12 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/gomplate/v3"
+	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 var _ = ginkgo.Describe("CelVariable", func() {
@@ -76,5 +79,81 @@ var _ = ginkgo.Describe("CelVariable", func() {
 
 		Expect(env["labels"]).To(HaveKeyWithValue("app", "podinfo"))
 		Expect(env["tags"]).To(HaveKeyWithValue("namespace", "default"))
+	})
+
+	ginkgo.It("should refresh nested selected resource health and status", func() {
+		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(db.Exec(`CREATE TABLE config_items (id text PRIMARY KEY, health text, status text, deleted_at datetime, updated_at datetime)`).Error).To(Succeed())
+		Expect(db.Exec(`CREATE TABLE components (id text PRIMARY KEY, health text, status text, deleted_at datetime, updated_at datetime)`).Error).To(Succeed())
+		Expect(db.Exec(`CREATE TABLE checks (id text PRIMARY KEY, status text, deleted_at datetime, updated_at datetime)`).Error).To(Succeed())
+
+		ctx := context.New().WithDB(db, nil)
+
+		configID := uuid.New()
+		componentID := uuid.New()
+		checkID := uuid.New()
+		staleHealth := models.HealthHealthy
+		latestHealth := models.HealthUnhealthy
+
+		Expect(db.Exec(`INSERT INTO config_items (id, health, status) VALUES (?, ?, ?)`, configID.String(), latestHealth, "Terminated").Error).To(Succeed())
+		Expect(db.Exec(`INSERT INTO components (id, health, status) VALUES (?, ?, ?)`, componentID.String(), latestHealth, "Stopped").Error).To(Succeed())
+		Expect(db.Exec(`INSERT INTO checks (id, status) VALUES (?, ?)`, checkID.String(), models.CheckStatusUnhealthy).Error).To(Succeed())
+
+		tests := []struct {
+			name         string
+			vars         celVariables
+			nestedKey    string
+			latestHealth models.Health
+			latestStatus string
+		}{
+			{
+				name: "config",
+				vars: celVariables{ConfigItem: &models.ConfigItem{
+					ID:     configID,
+					Name:   lo.ToPtr("podinfo"),
+					Health: lo.ToPtr(staleHealth),
+					Status: lo.ToPtr("Running"),
+				}},
+				nestedKey:    "config",
+				latestHealth: latestHealth,
+				latestStatus: "Terminated",
+			},
+			{
+				name: "component",
+				vars: celVariables{Component: &models.Component{
+					ID:     componentID,
+					Name:   "frontend",
+					Health: lo.ToPtr(staleHealth),
+					Status: "Running",
+				}},
+				nestedKey:    "component",
+				latestHealth: latestHealth,
+				latestStatus: "Stopped",
+			},
+			{
+				name: "check",
+				vars: celVariables{Check: &models.Check{
+					ID:     checkID,
+					Name:   "http-check",
+					Status: models.CheckStatusHealthy,
+				}},
+				nestedKey:    "check",
+				latestHealth: models.HealthUnhealthy,
+				latestStatus: models.CheckStatusUnhealthy,
+			},
+		}
+
+		for _, tt := range tests {
+			celEnv := tt.vars.AsMap(ctx, celVarGetLatestHealthStatus)
+			Expect(celEnv).To(HaveKeyWithValue("health", tt.latestHealth), tt.name)
+			Expect(celEnv).To(HaveKeyWithValue("status", tt.latestStatus), tt.name)
+
+			nested, ok := celEnv[tt.nestedKey].(map[string]any)
+			Expect(ok).To(BeTrue(), tt.name)
+			Expect(nested).To(HaveKeyWithValue("health", tt.latestHealth), tt.name)
+			Expect(nested).To(HaveKeyWithValue("status", tt.latestStatus), tt.name)
+		}
 	})
 })


### PR DESCRIPTION
Fixes #3025.

Notification filters can evaluate CEL environments in latest resource state mode for current-state checks.

Previously, `celVarGetLatestHealthStatus` refreshed only top-level `status` and `health`, while nested selected-resource aliases like `config.status`, `component.status`, and `check.status` still came from the event snapshot.

Update the selected nested resource map alongside the top-level aliases so equivalent filters see consistent current health/status values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health and status propagation in notifications now also mirrors latest values into the corresponding config, component, and check sections when present.

* **Tests**
  * Added test with in-memory DB to verify latest health/status update and propagation into root and nested resource maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->