### PR TITLE
feat(notification): skip waitFor notifications from stale generations

### DIFF
--- a/notification/generation.go
+++ b/notification/generation.go
@@ -1,0 +1,65 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/flanksource/duty/models"
+)
+
+const staleGenerationReason = "resource generation changed before waitFor elapsed"
+
+func getConfigGeneration(config *models.ConfigItem) string {
+	if config == nil || config.Config == nil || *config.Config == "" {
+		return ""
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(*config.Config), &obj); err != nil {
+		return ""
+	}
+
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	return generationToString(metadata["generation"])
+}
+
+func generationToString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case float64:
+		return strconv.FormatInt(int64(t), 10)
+	case float32:
+		return strconv.FormatInt(int64(t), 10)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case int32:
+		return strconv.FormatInt(int64(t), 10)
+	case json.Number:
+		return t.String()
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func shouldSkipDueToGeneration(payload NotificationEventPayload, celEnv *celVariables) bool {
+	if payload.ResourceGeneration == "" || celEnv == nil || celEnv.ConfigItem == nil {
+		return false
+	}
+
+	currentGeneration := getConfigGeneration(celEnv.ConfigItem)
+	return currentGeneration != "" && currentGeneration != payload.ResourceGeneration
+}
+
+func generationChangedMessage(payload NotificationEventPayload, celEnv *celVariables) string {
+	return fmt.Sprintf("%s: previous=%s current=%s", staleGenerationReason, payload.ResourceGeneration, getConfigGeneration(celEnv.ConfigItem))
+}

--- a/notification/job.go
+++ b/notification/job.go
@@ -437,6 +437,21 @@ func processPendingNotification(ctx context.Context, currentHistory models.Notif
 		return nil
 	}
 
+	if shouldSkipDueToGeneration(payload, celEnv) {
+		reason := generationChangedMessage(payload, celEnv)
+		ctx.Logger.V(6).Infof("skipping notification[%s] as resource generation changed", notif.ID)
+		traceLog("NotificationID=%s HistoryID=%s Resource=[%s/%s] %s Skipping", notif.ID, currentHistory.ID, payload.EventName, payload.ResourceID, reason)
+
+		if dberr := ctx.DB().Model(&models.NotificationSendHistory{}).Where("id = ?", currentHistory.ID).UpdateColumns(map[string]any{
+			"status": models.NotificationStatusSkipped,
+			"error":  reason,
+		}).Error; dberr != nil {
+			return fmt.Errorf("failed to mark notification as skipped: %w", dberr)
+		}
+
+		return nil
+	}
+
 	silencedResource := getSilencedResourceFromCelEnv(celEnv)
 	matchingSilences, err := db.GetMatchingNotificationSilences(ctx, silencedResource)
 	if err != nil {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1033,6 +1033,49 @@ var _ = ginkgo.Describe("Notifications", ginkgo.Ordered, ginkgo.FlakeAttempts(3)
 				return len(sendHistory)
 			}, "15s", "1s").Should(Equal(1))
 		})
+
+		ginkgo.It("should skip pending notification when resource generation changes", func() {
+			generationConfig := models.ConfigItem{
+				ID:          uuid.New(),
+				Name:        lo.ToPtr("generation-test"),
+				ConfigClass: models.ConfigClassDeployment,
+				Health:      lo.ToPtr(models.HealthHealthy),
+				Config:      lo.ToPtr(`{"metadata":{"generation":1}}`),
+				Type:        lo.ToPtr("Kubernetes::Deployment"),
+			}
+			Expect(DefaultContext.DB().Create(&generationConfig).Error).To(BeNil())
+			defer DefaultContext.DB().Delete(&generationConfig)
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).Where("id = ?", generationConfig.ID).Update("health", models.HealthUnhealthy).Error).To(BeNil())
+			events.ConsumeAll(DefaultContext)
+
+			var history models.NotificationSendHistory
+			Eventually(func(g Gomega) {
+				g.Expect(DefaultContext.DB().Where("notification_id = ?", n.ID.String()).
+					Where("resource_id = ?", generationConfig.ID.String()).
+					Where("status = ?", models.NotificationStatusPending).
+					First(&history).Error).To(BeNil())
+			}, "5s", "1s").Should(Succeed())
+
+			var payload notification.NotificationEventPayload
+			payload.FromMap(history.Payload)
+			Expect(payload.ResourceGeneration).To(Equal("1"))
+
+			Expect(DefaultContext.DB().Model(&models.ConfigItem{}).Where("id = ?", generationConfig.ID).Updates(map[string]any{
+				"config": `{"metadata":{"generation":2}}`,
+				"health": models.HealthUnhealthy,
+			}).Error).To(BeNil())
+			query.InvalidateCacheByID[models.ConfigItem](generationConfig.ID.String())
+
+			Expect(DefaultContext.DB().Model(&models.NotificationSendHistory{}).Where("id = ?", history.ID).Update("not_before", time.Now().Add(-time.Minute)).Error).To(BeNil())
+			_, err := notification.ProcessPendingNotifications(DefaultContext)
+			Expect(err).To(BeNil())
+
+			var updated models.NotificationSendHistory
+			Expect(DefaultContext.DB().Where("id = ?", history.ID).First(&updated).Error).To(BeNil())
+			Expect(updated.Status).To(Equal(models.NotificationStatusSkipped))
+			Expect(lo.FromPtr(updated.Error)).To(ContainSubstring("resource generation changed"))
+		})
 	})
 
 	var _ = ginkgo.Describe("recent events", ginkgo.Ordered, func() {

--- a/notification/send.go
+++ b/notification/send.go
@@ -66,6 +66,7 @@ type NotificationEventPayload struct {
 	ResourceHealth            models.Health `json:"resource_health"`
 	ResourceStatus            string        `json:"resource_status"`
 	ResourceHealthDescription string        `json:"resource_health_description"`
+	ResourceGeneration        string        `json:"resource_generation,omitempty"`
 
 	EventID        uuid.UUID  `json:"event_id"`                  // The id of the original event this notification is for.
 	EventName      string     `json:"event_name"`                // The name of the original event this notification is for.
@@ -531,7 +532,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 		}
 	}
 
-	var resourceHealth, resourceStatus, resourceHealthDescription string
+	var resourceHealth, resourceStatus, resourceHealthDescription, resourceGeneration string
 	if resource != nil {
 		var err error
 		resourceHealth, err = resource.GetHealth()
@@ -548,6 +549,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 			resourceHealthDescription = dd.GetHealthDescription()
 		}
 	}
+	resourceGeneration = getConfigGeneration(celEnv.ConfigItem)
 
 	if n.PlaybookID != nil {
 		payload := NotificationEventPayload{
@@ -557,6 +559,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 			ResourceHealth:            models.Health(resourceHealth),
 			ResourceStatus:            resourceStatus,
 			ResourceHealthDescription: resourceHealthDescription,
+			ResourceGeneration:        resourceGeneration,
 			ResourceID:                resourceID,
 			PlaybookID:                n.PlaybookID,
 			EventCreatedAt:            event.CreatedAt,
@@ -574,6 +577,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 			NotificationID:            n.ID,
 			ResourceHealth:            models.Health(resourceHealth),
 			ResourceHealthDescription: resourceHealthDescription,
+			ResourceGeneration:        resourceGeneration,
 			ResourceStatus:            resourceStatus,
 			ResourceID:                resourceID,
 			PersonID:                  n.PersonID,
@@ -607,6 +611,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 				NotificationID:            n.ID,
 				ResourceHealth:            models.Health(resourceHealth),
 				ResourceHealthDescription: resourceHealthDescription,
+				ResourceGeneration:        resourceGeneration,
 				ResourceStatus:            resourceStatus,
 				ResourceID:                resourceID,
 				TeamID:                    n.TeamID,
@@ -636,6 +641,7 @@ func CreateNotificationSendPayloads(ctx context.Context, event models.Event, n *
 			NotificationID:            n.ID,
 			ResourceHealth:            models.Health(resourceHealth),
 			ResourceHealthDescription: resourceHealthDescription,
+			ResourceGeneration:        resourceGeneration,
 			ResourceStatus:            resourceStatus,
 			CustomService:             cn.DeepCopy(),
 			ResourceID:                resourceID,


### PR DESCRIPTION
Pending `waitFor` notifications can remain pending while a Kubernetes resource moves on to a newer rollout generation.

Store the config `metadata.generation` in the notification payload when the pending notification is created. During pending processing, compare it with the current resource generation.

If the generation changed, treat the pending notification as stale and mark it skipped instead of sending it for the newer rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications are now skipped when resource generation changes before the notification waiting period elapses, with a clear message indicating the generation change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->