### PR TITLE
chore(mcp): use markdown response unless Accept header asks json

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -24,7 +24,7 @@ import (
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 )
 
-var jsonHeader = http.Header{echo.HeaderContentType: []string{echo.MIMEApplicationJSON}}
+var jsonHeader = http.Header{echo.HeaderAccept: []string{echo.MIMEApplicationJSON}}
 
 func checkResultInMCPResponse(toolResult any, results []string) {
 	Expect(toolResult).ToNot(BeNil())

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -216,7 +216,7 @@ func structToMCPResponse(req mcp.CallToolRequest, s ...any) *mcp.CallToolResult 
 		return mcp.NewToolResultText("")
 	}
 
-	if req.Header.Get(echo.HeaderAccept) == echo.MIMEApplicationJSON {
+	if strings.HasPrefix(req.Header.Get(echo.HeaderAccept), echo.MIMEApplicationJSON) {
 		var data any = s
 		if len(s) == 1 {
 			data = s[0]

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -216,7 +216,7 @@ func structToMCPResponse(req mcp.CallToolRequest, s ...any) *mcp.CallToolResult 
 		return mcp.NewToolResultText("")
 	}
 
-	if req.Header.Get(echo.HeaderContentType) == echo.MIMEApplicationJSON {
+	if req.Header.Get(echo.HeaderAccept) == echo.MIMEApplicationJSON {
 		var data any = s
 		if len(s) == 1 {
 			data = s[0]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP header handling to properly use the `Accept` header for determining response format instead of the `Content-Type` header, improving standards compliance and client compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->