### PR TITLE
refactor(auth): split OIDC login interfaces

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -195,7 +195,7 @@ func LookupPersonByUsername(ctx context.Context, username string) (string, error
 	return person.ID.String(), nil
 }
 
-// HtpasswdChecker wraps htpasswd.File to implement oidc.CredentialChecker.
+// HtpasswdChecker wraps htpasswd.File for password-based OIDC login.
 type HtpasswdChecker struct {
 	file *htpasswd.File
 }

--- a/auth/kratos.go
+++ b/auth/kratos.go
@@ -231,19 +231,13 @@ func (k *kratosMiddleware) Session(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
-// KratosCredentialChecker validates credentials via Kratos API,
-// implementing oidc.CredentialChecker for the OIDC login flow.
+// KratosCredentialChecker validates Kratos browser sessions for the OIDC login flow.
 type KratosCredentialChecker struct {
 	middleware *kratosMiddleware
 }
 
 func NewKratosCredentialChecker(m *kratosMiddleware) *KratosCredentialChecker {
 	return &KratosCredentialChecker{middleware: m}
-}
-
-func (k *KratosCredentialChecker) Match(ctx context.Context, user, pass string) error {
-	_, err := k.middleware.kratosLoginWithCache(ctx, user, pass)
-	return err
 }
 
 func (k *KratosCredentialChecker) LoginRedirectURL(authRequestID string) (string, error) {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -106,7 +106,7 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 				if err != nil {
 					return fmt.Errorf("failed to load htpasswd file: %w", err)
 				}
-				if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, htpasswdChecker, LookupPersonByUsername); err != nil {
+				if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, htpasswdChecker, nil, LookupPersonByUsername); err != nil {
 					return fmt.Errorf("failed to mount OIDC routes: %w", err)
 				}
 				logger.Infof("OIDC provider enabled at %s", api.FrontendURL)
@@ -128,7 +128,7 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 
 		if OIDCEnabled {
 			kratosChecker := NewKratosCredentialChecker(kratosMiddleware)
-			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, kratosChecker, LookupKratosPersonByUsername); err != nil {
+			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, nil, kratosChecker, nil); err != nil {
 				return fmt.Errorf("failed to mount OIDC routes: %w", err)
 			}
 			logger.Infof("OIDC provider enabled at %s (Kratos auth)", api.FrontendURL)

--- a/auth/oidc/login.go
+++ b/auth/oidc/login.go
@@ -12,34 +12,41 @@ import (
 )
 
 type LoginHandler struct {
-	storage      *Storage
-	provider     op.OpenIDProvider
-	checker      CredentialChecker
-	PersonLookup PersonLookup
-	issuerURL    string
+	storage               *Storage
+	provider              op.OpenIDProvider
+	passwordLoginChecker  PasswordLoginChecker
+	externalLoginProvider ExternalLoginProvider
+	PersonLookup          PersonLookup
+	issuerURL             string
 }
 
-type CredentialChecker interface {
+type PasswordLoginChecker interface {
 	Match(ctx context.Context, user, pass string) error
 }
 
-type LoginRedirector interface {
+type ExternalLoginProvider interface {
 	LoginRedirectURL(authRequestID string) (string, error)
-}
-
-type CallbackSubjectResolver interface {
 	CallbackSubject(c echo.Context) (string, error)
 }
 
 type PersonLookup func(ctx context.Context, user string) (personID string, err error)
 
-func NewLoginHandler(storage *Storage, provider op.OpenIDProvider, checker CredentialChecker, lookup PersonLookup, issuerURL string) *LoginHandler {
+func NewPasswordLoginHandler(storage *Storage, provider op.OpenIDProvider, checker PasswordLoginChecker, lookup PersonLookup, issuerURL string) *LoginHandler {
 	return &LoginHandler{
-		storage:      storage,
-		provider:     provider,
-		checker:      checker,
-		PersonLookup: lookup,
-		issuerURL:    issuerURL,
+		storage:              storage,
+		provider:             provider,
+		passwordLoginChecker: checker,
+		PersonLookup:         lookup,
+		issuerURL:            issuerURL,
+	}
+}
+
+func NewExternalLoginHandler(storage *Storage, provider op.OpenIDProvider, loginProvider ExternalLoginProvider, issuerURL string) *LoginHandler {
+	return &LoginHandler{
+		storage:               storage,
+		provider:              provider,
+		externalLoginProvider: loginProvider,
+		issuerURL:             issuerURL,
 	}
 }
 
@@ -49,12 +56,16 @@ func (h *LoginHandler) ShowForm(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "missing auth_request_id")
 	}
 
-	if redirector, ok := h.checker.(LoginRedirector); ok {
-		redirectURL, err := redirector.LoginRedirectURL(id)
+	if h.externalLoginProvider != nil {
+		redirectURL, err := h.externalLoginProvider.LoginRedirectURL(id)
 		if err != nil {
 			return c.String(http.StatusInternalServerError, "failed to build login redirect")
 		}
 		return c.Redirect(http.StatusFound, redirectURL)
+	}
+
+	if h.passwordLoginChecker == nil {
+		return c.String(http.StatusNotFound, "password login is not configured")
 	}
 
 	return c.HTML(http.StatusOK, fmt.Sprintf(static.LoginHTML, html.EscapeString(id), ""))
@@ -76,7 +87,11 @@ func (h *LoginHandler) HandleSubmit(c echo.Context) error {
 		return renderForm("All fields required")
 	}
 
-	if err := h.checker.Match(ctx, username, password); err != nil {
+	if h.passwordLoginChecker == nil || h.PersonLookup == nil {
+		return c.String(http.StatusNotFound, "password login is not configured")
+	}
+
+	if err := h.passwordLoginChecker.Match(ctx, username, password); err != nil {
 		return renderForm(fmt.Sprintf("Invalid credentials: %v", err))
 	}
 
@@ -100,12 +115,11 @@ func (h *LoginHandler) HandleExternalCallback(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "missing auth_request_id")
 	}
 
-	resolver, ok := h.checker.(CallbackSubjectResolver)
-	if !ok {
+	if h.externalLoginProvider == nil {
 		return c.String(http.StatusNotFound, "external callback is not configured")
 	}
 
-	personID, err := resolver.CallbackSubject(c)
+	personID, err := h.externalLoginProvider.CallbackSubject(c)
 	if err != nil {
 		return c.String(http.StatusUnauthorized, "authorization failed")
 	}

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -14,14 +14,19 @@ import (
 // The OIDC provider is mounted under /oidc/ with the issuer set to {issuerURL}/oidc
 // so that discovery at /oidc/.well-known/openid-configuration returns correct endpoint URLs.
 // A convenience redirect from /.well-known/openid-configuration is provided for standard discovery.
-func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath string, checker CredentialChecker, lookup PersonLookup) error {
+func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath string, passwordChecker PasswordLoginChecker, externalProvider ExternalLoginProvider, lookup PersonLookup) error {
 	oidcIssuer := strings.TrimRight(issuerURL, "/")
 	provider, err := NewProvider(ctx, oidcIssuer, signingKeyPath)
 	if err != nil {
 		return err
 	}
 
-	loginHandler := NewLoginHandler(provider.Storage, provider.OpenIDProvider, checker, lookup, oidcIssuer)
+	var loginHandler *LoginHandler
+	if externalProvider != nil {
+		loginHandler = NewExternalLoginHandler(provider.Storage, provider.OpenIDProvider, externalProvider, oidcIssuer)
+	} else {
+		loginHandler = NewPasswordLoginHandler(provider.Storage, provider.OpenIDProvider, passwordChecker, lookup, oidcIssuer)
+	}
 
 	// Custom login form (not part of the standard OIDC protocol paths).
 	e.GET("/oidc/login", loginHandler.ShowForm)

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -400,7 +400,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 
 	ginkgo.Describe("LoginHandler", func() {
 		ginkgo.It("renders login form with auth_request_id", func() {
-			login := oidc.NewLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{}, mockLookup, "http://localhost:8080")
+			login := oidc.NewPasswordLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{}, mockLookup, "http://localhost:8080")
 			e := newEchoInstance(DefaultContext)
 			req := httptest.NewRequest(http.MethodGet, "/oidc/login?auth_request_id=test-123", nil)
 			req = req.WithContext(DefaultContext.Wrap(req.Context()))
@@ -414,7 +414,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 		})
 
 		ginkgo.It("returns 400 when auth_request_id is missing", func() {
-			login := oidc.NewLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{}, mockLookup, "http://localhost:8080")
+			login := oidc.NewPasswordLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{}, mockLookup, "http://localhost:8080")
 			e := newEchoInstance(DefaultContext)
 			req := httptest.NewRequest(http.MethodGet, "/oidc/login", nil)
 			req = req.WithContext(DefaultContext.Wrap(req.Context()))
@@ -426,7 +426,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 		})
 
 		ginkgo.It("redirects to external login when checker supports login redirect", func() {
-			login := oidc.NewLoginHandler(provider.Storage, provider.OpenIDProvider, &redirectChecker{}, mockLookup, "http://localhost:8080")
+			login := oidc.NewExternalLoginHandler(provider.Storage, provider.OpenIDProvider, &redirectChecker{}, "http://localhost:8080")
 			e := newEchoInstance(DefaultContext)
 			req := httptest.NewRequest(http.MethodGet, "/oidc/login?auth_request_id=req-123", nil)
 			req = req.WithContext(DefaultContext.Wrap(req.Context()))
@@ -448,7 +448,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 			ar, err := provider.Storage.CreateAuthRequest(gocontext.TODO(), req, "")
 			Expect(err).ToNot(HaveOccurred())
 
-			login := oidc.NewLoginHandler(provider.Storage, provider.OpenIDProvider, &callbackChecker{subjectID: person.ID.String()}, mockLookup, "http://localhost:8080")
+			login := oidc.NewExternalLoginHandler(provider.Storage, provider.OpenIDProvider, &callbackChecker{subjectID: person.ID.String()}, "http://localhost:8080")
 			e := newEchoInstance(DefaultContext)
 			httpReq := httptest.NewRequest(http.MethodGet, "/oidc/kratos/callback?auth_request_id="+ar.GetID(), nil)
 			httpReq = httpReq.WithContext(DefaultContext.Wrap(httpReq.Context()))
@@ -465,7 +465,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 		})
 
 		ginkgo.It("rejects invalid credentials", func() {
-			login := oidc.NewLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{valid: false}, mockLookup, "http://localhost:8080")
+			login := oidc.NewPasswordLoginHandler(provider.Storage, provider.OpenIDProvider, &mockChecker{valid: false}, mockLookup, "http://localhost:8080")
 			e := newEchoInstance(DefaultContext)
 
 			form := url.Values{
@@ -595,20 +595,20 @@ func (m *mockChecker) Match(_ dutyContext.Context, _, _ string) error {
 
 type redirectChecker struct{}
 
-func (r *redirectChecker) Match(_ dutyContext.Context, _, _ string) error {
-	return nil
-}
-
 func (r *redirectChecker) LoginRedirectURL(authRequestID string) (string, error) {
 	return "http://localhost:3000/login?return_to=%2Foidc%2Fkratos%2Fcallback%3Fauth_request_id%3D" + authRequestID, nil
+}
+
+func (r *redirectChecker) CallbackSubject(_ echo.Context) (string, error) {
+	return "", nil
 }
 
 type callbackChecker struct {
 	subjectID string
 }
 
-func (r *callbackChecker) Match(_ dutyContext.Context, _, _ string) error {
-	return nil
+func (r *callbackChecker) LoginRedirectURL(string) (string, error) {
+	return "", nil
 }
 
 func (r *callbackChecker) CallbackSubject(_ echo.Context) (string, error) {


### PR DESCRIPTION
OIDC login currently uses one credential-checker interface for both embedded password login and external browser-login flows.

Split the login handler into explicit password and external login paths. Basic auth now wires a password login checker, while Kratos wires an external login provider that redirects through the frontend and resolves the subject on callback.

This preserves existing behavior while avoiding fake password-check implementations for redirect-based providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the authentication system to separately handle password-based login and external login flows for improved maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->