### PR TITLE
feat(auth): enable OIDC for Clerk

### DIFF
--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/rbac"
 	"github.com/flanksource/duty/rbac/policy"
+	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/patrickmn/go-cache"
@@ -80,6 +83,18 @@ func (h ClerkHandler) Session(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		ctx := c.Request().Context().(context.Context)
+
+		if OIDCEnabled {
+			if token, ok := extractBearerAuthToken(c.Request().Header); ok {
+				if authenticated, err := authenticateOIDCToken(c, token); err != nil {
+					return c.JSON(http.StatusInternalServerError, map[string]string{
+						"error": err.Error(),
+					})
+				} else if authenticated {
+					return next(c)
+				}
+			}
+		}
 
 		// Agents use basic auth with `token:<access_token>` format
 		authResult, err := h.authenticateRequest(ctx, c)
@@ -244,6 +259,7 @@ func (h ClerkHandler) authenticateBasicAuth(ctx context.Context, c echo.Context)
 func (h ClerkHandler) authenticateBearerOrCookie(ctx context.Context, c echo.Context) (AuthResult, error) {
 	sessionToken := h.extractSessionToken(c)
 	if sessionToken == "" {
+		setWWWAuthenticate(c)
 		return AuthResult{}, c.String(http.StatusUnauthorized, "Unauthorized")
 	}
 
@@ -302,4 +318,48 @@ func (h ClerkHandler) extractSessionToken(c echo.Context) string {
 	}
 
 	return ""
+}
+
+var _ oidc.ExternalLoginProvider = (*ClerkCredentialChecker)(nil)
+
+// ClerkCredentialChecker validates Clerk browser sessions for the OIDC login flow.
+type ClerkCredentialChecker struct {
+	handler *ClerkHandler
+}
+
+func NewClerkCredentialChecker(h *ClerkHandler) *ClerkCredentialChecker {
+	return &ClerkCredentialChecker{handler: h}
+}
+
+func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string, error) {
+	frontendURL := strings.TrimRight(api.FrontendURL, "/")
+	if frontendURL == "" {
+		return "", fmt.Errorf("frontend URL is not configured")
+	}
+
+	q := url.Values{}
+	q.Set("return_to", "/oidc/clerk/callback?auth_request_id="+authRequestID)
+	return frontendURL + "/login?" + q.Encode(), nil
+}
+
+func (c *ClerkCredentialChecker) CallbackSubject(ec echo.Context) (string, error) {
+	ctx := ec.Request().Context().(context.Context)
+
+	sessionToken := c.handler.extractSessionToken(ec)
+	if sessionToken == "" {
+		return "", fmt.Errorf("no Clerk session token found")
+	}
+	if strings.Count(sessionToken, ".") == 4 {
+		return "", fmt.Errorf("access tokens cannot complete Clerk browser login")
+	}
+
+	authResult, err := c.handler.getUserFromSessionToken(ctx, sessionToken)
+	if err != nil {
+		return "", err
+	}
+	if authResult.User == nil {
+		return "", fmt.Errorf("user is not authenticated")
+	}
+
+	return authResult.User.ID.String(), nil
 }

--- a/auth/kratos.go
+++ b/auth/kratos.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	incAPI "github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/flanksource/incident-commander/db"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -230,6 +231,8 @@ func (k *kratosMiddleware) Session(next echo.HandlerFunc) echo.HandlerFunc {
 		return next(c)
 	}
 }
+
+var _ oidc.ExternalLoginProvider = (*KratosCredentialChecker)(nil)
 
 // KratosCredentialChecker validates Kratos browser sessions for the OIDC login flow.
 type KratosCredentialChecker struct {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -141,6 +141,14 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 		}
 		e.Use(clerkHandler.Session)
 
+		if OIDCEnabled {
+			clerkChecker := NewClerkCredentialChecker(clerkHandler)
+			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, nil, clerkChecker, nil); err != nil {
+				return fmt.Errorf("failed to mount OIDC routes: %w", err)
+			}
+			logger.Infof("OIDC provider enabled at %s (Clerk auth)", api.FrontendURL)
+		}
+
 		// We also need to disable "settings.users" feature in database
 		// to hide the menu from UI
 		if err := context.UpdateProperty(ctx, "settings.user.disabled", "true"); err != nil {

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -32,6 +32,7 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath st
 	e.GET("/oidc/login", loginHandler.ShowForm)
 	e.POST("/oidc/login", loginHandler.HandleSubmit)
 	e.GET("/oidc/kratos/callback", loginHandler.HandleExternalCallback)
+	e.GET("/oidc/clerk/callback", loginHandler.HandleExternalCallback)
 
 	// MCP Clients need OAuth well-known discovery endpoints (not just OIDC discovery).
 	mountOAuthRoutes(e, oidcIssuer)


### PR DESCRIPTION
Enable the embedded Mission Control OIDC provider when auth mode is Clerk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect (OIDC) authentication support with Clerk as an external identity provider.
  * Implemented Bearer token extraction and validation for OIDC flows.
  * Added a dedicated callback endpoint to handle Clerk OIDC authentication responses.
  * OIDC authentication is conditionally enabled and mounted based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->