### PR TITLE
fix: propagate deny permissions to RLS payload

### DIFF
--- a/auth/impersonation.go
+++ b/auth/impersonation.go
@@ -78,6 +78,7 @@ func intersectScope(a, b rls.Scope) (rls.Scope, bool) {
 		}
 	}
 
+	result.Deny = a.Deny || b.Deny
 	return result, true
 }
 
@@ -100,15 +101,36 @@ func intersectScopeList(real, impersonated []rls.Scope) []rls.Scope {
 	return result
 }
 
+func splitScopeList(scopes []rls.Scope) (allow, deny []rls.Scope) {
+	for _, scope := range scopes {
+		if scope.Deny {
+			deny = append(deny, scope)
+		} else {
+			allow = append(allow, scope)
+		}
+	}
+	return allow, deny
+}
+
+func intersectPermissionedScopeList(real, impersonated []rls.Scope) []rls.Scope {
+	realAllow, realDeny := splitScopeList(real)
+	impersonatedAllow, impersonatedDeny := splitScopeList(impersonated)
+
+	result := intersectScopeList(realAllow, impersonatedAllow)
+	result = append(result, realDeny...)
+	result = append(result, impersonatedDeny...)
+	return result
+}
+
 // intersectPayload computes the intersection of two RLS payloads across all
 // resource types.
 func intersectPayload(real, impersonated *rls.Payload) *rls.Payload {
 	result := &rls.Payload{
-		Config:    intersectScopeList(real.Config, impersonated.Config),
-		Component: intersectScopeList(real.Component, impersonated.Component),
-		Playbook:  intersectScopeList(real.Playbook, impersonated.Playbook),
-		Canary:    intersectScopeList(real.Canary, impersonated.Canary),
-		View:      intersectScopeList(real.View, impersonated.View),
+		Config:    intersectPermissionedScopeList(real.Config, impersonated.Config),
+		Component: intersectPermissionedScopeList(real.Component, impersonated.Component),
+		Playbook:  intersectPermissionedScopeList(real.Playbook, impersonated.Playbook),
+		Canary:    intersectPermissionedScopeList(real.Canary, impersonated.Canary),
+		View:      intersectPermissionedScopeList(real.View, impersonated.View),
 		Scopes:    lo.Intersect(real.Scopes, impersonated.Scopes),
 	}
 	return result

--- a/auth/rls.go
+++ b/auth/rls.go
@@ -133,19 +133,19 @@ func buildRLSPayloadFromScopes(ctx context.Context) (*rls.Payload, error) {
 
 	for _, perm := range permissions {
 		if perm.ConfigID != nil {
-			payload.Config = append(payload.Config, rls.Scope{ID: perm.ConfigID.String()})
+			addConfigScope(payload, rls.Scope{ID: perm.ConfigID.String()}, perm.Deny)
 		}
 
 		if perm.ComponentID != nil {
-			payload.Component = append(payload.Component, rls.Scope{ID: perm.ComponentID.String()})
+			addComponentScope(payload, rls.Scope{ID: perm.ComponentID.String()}, perm.Deny)
 		}
 
 		if perm.PlaybookID != nil {
-			payload.Playbook = append(payload.Playbook, rls.Scope{ID: perm.PlaybookID.String()})
+			addPlaybookScope(payload, rls.Scope{ID: perm.PlaybookID.String()}, perm.Deny)
 		}
 
 		if perm.CanaryID != nil {
-			payload.Canary = append(payload.Canary, rls.Scope{ID: perm.CanaryID.String()})
+			addCanaryScope(payload, rls.Scope{ID: perm.CanaryID.String()}, perm.Deny)
 		}
 
 		if len(perm.ObjectSelector) == 0 {
@@ -160,7 +160,7 @@ func buildRLSPayloadFromScopes(ctx context.Context) (*rls.Payload, error) {
 
 		// Process scope references (indirect permissions)
 		if len(selectors.Scopes) > 0 {
-			if err := processScopeRefs(ctx, selectors.Scopes, payload); err != nil {
+			if err := processScopeRefs(ctx, selectors.Scopes, payload, perm.Deny); err != nil {
 				return nil, err
 			}
 		}
@@ -169,25 +169,25 @@ func buildRLSPayloadFromScopes(ctx context.Context) (*rls.Payload, error) {
 		// Only use tags, name, and agent_id as per requirements
 		if len(selectors.Configs) > 0 {
 			for _, selector := range selectors.Configs {
-				payload.Config = append(payload.Config, convertResourceSelectorToRLSScope(selector))
+				addConfigScope(payload, convertResourceSelectorToRLSScope(selector), perm.Deny)
 			}
 		}
 
 		if len(selectors.Components) > 0 {
 			for _, selector := range selectors.Components {
-				payload.Component = append(payload.Component, convertResourceSelectorToRLSScope(selector))
+				addComponentScope(payload, convertResourceSelectorToRLSScope(selector), perm.Deny)
 			}
 		}
 
 		if len(selectors.Playbooks) > 0 {
 			for _, selector := range selectors.Playbooks {
-				payload.Playbook = append(payload.Playbook, convertResourceSelectorToRLSScope(selector))
+				addPlaybookScope(payload, convertResourceSelectorToRLSScope(selector), perm.Deny)
 			}
 		}
 
 		if len(selectors.Views) > 0 {
 			for _, viewRef := range selectors.Views {
-				payload.View = append(payload.View, convertViewScopeRefToRLSScope(viewRef))
+				addViewScope(payload, convertViewScopeRefToRLSScope(viewRef), perm.Deny)
 			}
 		}
 
@@ -202,8 +202,33 @@ func buildRLSPayloadFromScopes(ctx context.Context) (*rls.Payload, error) {
 	return payload, nil
 }
 
+func addConfigScope(payload *rls.Payload, scope rls.Scope, deny bool) {
+	scope.Deny = deny
+	payload.Config = append(payload.Config, scope)
+}
+
+func addComponentScope(payload *rls.Payload, scope rls.Scope, deny bool) {
+	scope.Deny = deny
+	payload.Component = append(payload.Component, scope)
+}
+
+func addPlaybookScope(payload *rls.Payload, scope rls.Scope, deny bool) {
+	scope.Deny = deny
+	payload.Playbook = append(payload.Playbook, scope)
+}
+
+func addCanaryScope(payload *rls.Payload, scope rls.Scope, deny bool) {
+	scope.Deny = deny
+	payload.Canary = append(payload.Canary, scope)
+}
+
+func addViewScope(payload *rls.Payload, scope rls.Scope, deny bool) {
+	scope.Deny = deny
+	payload.View = append(payload.View, scope)
+}
+
 // processScopeRefs fetches scopes from database and adds their targets to the payload
-func processScopeRefs(ctx context.Context, scopeRefs []dutyRBAC.NamespacedNameIDSelector, payload *rls.Payload) error {
+func processScopeRefs(ctx context.Context, scopeRefs []dutyRBAC.NamespacedNameIDSelector, payload *rls.Payload, deny bool) error {
 	for _, ref := range scopeRefs {
 		var scope models.Scope
 		err := ctx.DB().
@@ -218,7 +243,9 @@ func processScopeRefs(ctx context.Context, scopeRefs []dutyRBAC.NamespacedNameID
 		}
 
 		// Add scope UUID for view row-level grants
-		payload.Scopes = append(payload.Scopes, scope.ID.String())
+		if !deny {
+			payload.Scopes = append(payload.Scopes, scope.ID.String())
+		}
 
 		var targets []v1.ScopeTarget
 		if err := json.Unmarshal([]byte(scope.Targets), &targets); err != nil {
@@ -228,32 +255,27 @@ func processScopeRefs(ctx context.Context, scopeRefs []dutyRBAC.NamespacedNameID
 
 		for _, target := range targets {
 			if target.Config != nil {
-				rlsScope := convertToRLSScope(target.Config)
-				payload.Config = append(payload.Config, rlsScope)
+				addConfigScope(payload, convertToRLSScope(target.Config), deny)
 			}
 			if target.Component != nil {
-				rlsScope := convertToRLSScope(target.Component)
-				payload.Component = append(payload.Component, rlsScope)
+				addComponentScope(payload, convertToRLSScope(target.Component), deny)
 			}
 			if target.Playbook != nil {
-				rlsScope := convertToRLSScope(target.Playbook)
-				payload.Playbook = append(payload.Playbook, rlsScope)
+				addPlaybookScope(payload, convertToRLSScope(target.Playbook), deny)
 			}
 			if target.Canary != nil {
-				rlsScope := convertToRLSScope(target.Canary)
-				payload.Canary = append(payload.Canary, rlsScope)
+				addCanaryScope(payload, convertToRLSScope(target.Canary), deny)
 			}
 			if target.View != nil {
-				rlsScope := convertToRLSScope(target.View)
-				payload.View = append(payload.View, rlsScope)
+				addViewScope(payload, convertToRLSScope(target.View), deny)
 			}
 			if target.Global != nil {
 				rlsScope := convertToRLSScope(target.Global)
-				payload.Config = append(payload.Config, rlsScope)
-				payload.Component = append(payload.Component, rlsScope)
-				payload.Playbook = append(payload.Playbook, rlsScope)
-				payload.Canary = append(payload.Canary, rlsScope)
-				payload.View = append(payload.View, rlsScope)
+				addConfigScope(payload, rlsScope, deny)
+				addComponentScope(payload, rlsScope, deny)
+				addPlaybookScope(payload, rlsScope, deny)
+				addCanaryScope(payload, rlsScope, deny)
+				addViewScope(payload, rlsScope, deny)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.34.0 // indirect
 	github.com/flanksource/commons v1.51.3
-	github.com/flanksource/duty v1.0.1299
+	github.com/flanksource/duty v1.0.1301
 	github.com/flanksource/gomplate/v3 v3.24.79
 	github.com/flanksource/kopper v1.0.21
 	github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFE
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
 github.com/flanksource/deps v1.0.28 h1:mm7l7WjzLbkj2aFrgnlMaRizp+j+0x22TvtwXzRlFtE=
 github.com/flanksource/deps v1.0.28/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
-github.com/flanksource/duty v1.0.1299 h1:8v2yXVvXo6zhKiglVe0bYz/3EZsIMG3VX3K84kN6CYo=
-github.com/flanksource/duty v1.0.1299/go.mod h1:zCwUjUfcClnO07UkslSblSv8F0mpZm3McWVILndCeD4=
+github.com/flanksource/duty v1.0.1301 h1:RfuBlJ5G+NMLR0erw4Y/axAzjM4Rr7YM151tljmWs3s=
+github.com/flanksource/duty v1.0.1301/go.mod h1:aH4xdGF3brwBiOKUEFsspgu8U7tBiJOZDXrEqB3OMtc=
 github.com/flanksource/gomplate/v3 v3.24.79 h1:T5Ls0tjsnDhcV/dQWjrm2UpHiwOhytDLmYDSF0O6p3Q=
 github.com/flanksource/gomplate/v3 v3.24.79/go.mod h1:RzIg+YwNQI0eUV61LtqmhNN2Qw8ebm1cGa6IhNQmkWE=
 github.com/flanksource/is-healthy v1.0.87 h1:wSK9wI9tu//gdKO9JxyZe8ZQ5H7MCpwG17KdbWaiMeM=

--- a/tests/permissions/permissions_test.go
+++ b/tests/permissions/permissions_test.go
@@ -280,7 +280,7 @@ var _ = Describe("Permissions", Ordered, ContinueOnFailure, func() {
 			Expect(payload.View).To(BeEmpty(), "view scope should be empty for guest user with no permissions")
 		})
 
-		It("should not include deny permissions with object selectors in RLS payload", func() {
+		It("should mark deny permissions with object selectors in RLS payload", func() {
 			denyOnlyUser := setup.CreateUserWithRole(DefaultContext, "Deny Only User", "deny-only@test.com", policy.RoleGuest)
 			DeferCleanup(func() {
 				auth.InvalidateRLSCacheForUser(denyOnlyUser.ID.String())
@@ -306,7 +306,8 @@ var _ = Describe("Permissions", Ordered, ContinueOnFailure, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload).ToNot(BeNil())
 			Expect(payload.Disable).To(BeFalse())
-			Expect(payload.Playbook).To(BeEmpty(), "deny permissions must not become allowed RLS playbook scopes")
+			Expect(payload.Playbook).To(ContainElement(rls.Scope{Names: []string{"echo-config"}, Deny: true}), "deny permissions must be marked as deny RLS playbook scopes")
+			Expect(payload.Playbook).ToNot(ContainElement(rls.Scope{Names: []string{"echo-config"}}), "deny permissions must not become unmarked allowed RLS playbook scopes")
 		})
 
 		It("should include direct ID-based permissions in RLS payload", func() {

--- a/tests/permissions/permissions_test.go
+++ b/tests/permissions/permissions_test.go
@@ -280,6 +280,35 @@ var _ = Describe("Permissions", Ordered, ContinueOnFailure, func() {
 			Expect(payload.View).To(BeEmpty(), "view scope should be empty for guest user with no permissions")
 		})
 
+		It("should not include deny permissions with object selectors in RLS payload", func() {
+			denyOnlyUser := setup.CreateUserWithRole(DefaultContext, "Deny Only User", "deny-only@test.com", policy.RoleGuest)
+			DeferCleanup(func() {
+				auth.InvalidateRLSCacheForUser(denyOnlyUser.ID.String())
+				Expect(DefaultContext.DB().Delete(denyOnlyUser).Error).ToNot(HaveOccurred())
+			})
+
+			denyPermission := &models.Permission{
+				ID:             uuid.New(),
+				Name:           "deny-only-echo-config-playbook-read",
+				Namespace:      "default",
+				Action:         policy.ActionRead,
+				Subject:        denyOnlyUser.ID.String(),
+				SubjectType:    models.PermissionSubjectTypePerson,
+				Deny:           true,
+				ObjectSelector: []byte(`{"playbooks":[{"name":"echo-config","namespace":"mc"}]}`),
+			}
+			Expect(DefaultContext.DB().Create(denyPermission).Error).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(DefaultContext.DB().Delete(denyPermission).Error).ToNot(HaveOccurred())
+			})
+
+			payload, err := auth.GetRLSPayload(DefaultContext.WithUser(denyOnlyUser))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payload).ToNot(BeNil())
+			Expect(payload.Disable).To(BeFalse())
+			Expect(payload.Playbook).To(BeEmpty(), "deny permissions must not become allowed RLS playbook scopes")
+		})
+
 		It("should include direct ID-based permissions in RLS payload", func() {
 			ctx := DefaultContext.WithUser(guestUserDirectPerms)
 

--- a/tests/permissions/permissions_test.go
+++ b/tests/permissions/permissions_test.go
@@ -980,6 +980,50 @@ var _ = Describe("Permissions", Ordered, ContinueOnFailure, func() {
 			Expect(count).To(Equal(totalPlaybooks), "admin user should see all playbooks")
 		})
 
+		It("should apply deny playbook selector over wildcard allow in RLS filtering", func() {
+			user := setup.CreateUserWithRole(DefaultContext, "Allow All Deny Echo User", "allow-all-deny-echo@test.com", policy.RoleGuest)
+			DeferCleanup(func() {
+				auth.InvalidateRLSCacheForUser(user.ID.String())
+				Expect(DefaultContext.DB().Delete(user).Error).ToNot(HaveOccurred())
+			})
+
+			allowAll := &models.Permission{
+				ID:             uuid.New(),
+				Name:           "allow-all-playbooks-read",
+				Namespace:      "default",
+				Action:         policy.ActionRead,
+				Subject:        user.ID.String(),
+				SubjectType:    models.PermissionSubjectTypePerson,
+				ObjectSelector: []byte(`{"playbooks":[{"name":"*"}]}`),
+			}
+			denyEcho := &models.Permission{
+				ID:             uuid.New(),
+				Name:           "deny-echo-config-playbook-read",
+				Namespace:      "default",
+				Action:         policy.ActionRead,
+				Subject:        user.ID.String(),
+				SubjectType:    models.PermissionSubjectTypePerson,
+				Deny:           true,
+				ObjectSelector: []byte(`{"playbooks":[{"name":"echo-config","namespace":"mc"}]}`),
+			}
+			Expect(DefaultContext.DB().Create([]*models.Permission{allowAll, denyEcho}).Error).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(DefaultContext.DB().Delete([]*models.Permission{allowAll, denyEcho}).Error).ToNot(HaveOccurred())
+			})
+
+			payload, err := auth.GetRLSPayload(DefaultContext.WithUser(user))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(payload.SetPostgresSessionRLS(tx)).To(BeNil())
+
+			var echoCount int64
+			Expect(tx.Model(&models.Playbook{}).Where("id = ?", dummy.EchoConfig.ID).Count(&echoCount).Error).To(BeNil())
+			Expect(echoCount).To(Equal(int64(0)), "deny selector should hide echo-config despite wildcard allow")
+
+			var restartCount int64
+			Expect(tx.Model(&models.Playbook{}).Where("id = ?", dummy.RestartPod.ID).Count(&restartCount).Error).To(BeNil())
+			Expect(restartCount).To(Equal(int64(1)), "wildcard allow should still permit non-denied playbooks")
+		})
+
 		// Direct ID permissions tests
 		It("should include direct ID-based playbook permission in RLS filtering", func() {
 			ctx := DefaultContext.WithUser(guestUserDirectPerms)


### PR DESCRIPTION
Fixes #3044.\n\nPermission-to-RLS conversion now preserves deny semantics by marking generated scopes with `deny: true` instead of treating every read selector as an allow scope. This allows explicit deny selectors to override broader allow scopes when enforced by duty RLS.\n\nDepends on flanksource/duty#1950.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deny permissions in resource access control, ensuring deny-scoped entries are correctly processed during permission intersection.
  * Fixed permission propagation logic to properly apply deny selectors when filtering user access to resources.

* **Tests**
  * Added test cases validating deny permission functionality and resource filtering behavior with deny selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->