### PR TITLE
fix: advertise OIDC endpoints on public backend URL

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -129,7 +129,7 @@ func validateBasicAuth(c echo.Context, user, pass string) (bool, error) {
 // OIDC provider and initiate the authorization flow.
 func setWWWAuthenticate(c echo.Context) {
 	if OIDCEnabled {
-		resourceMetadataURL := strings.TrimRight(incAPI.FrontendURL, "/") + "/.well-known/oauth-protected-resource"
+		resourceMetadataURL := strings.TrimRight(incAPI.PublicURL, "/") + "/.well-known/oauth-protected-resource"
 		c.Response().Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
 	}
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -108,10 +108,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 				if err != nil {
 					return fmt.Errorf("failed to load htpasswd file: %w", err)
 				}
-				if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, htpasswdChecker, nil, LookupPersonByUsername); err != nil {
+				if err := oidc.MountRoutes(e, ctx, api.PublicURL, OIDCSigningKeyPath, htpasswdChecker, nil, LookupPersonByUsername); err != nil {
 					return fmt.Errorf("failed to mount OIDC routes: %w", err)
 				}
-				logger.Infof("OIDC provider enabled at %s", api.FrontendURL)
+				logger.Infof("OIDC provider enabled at %s", api.PublicURL)
 			}
 		}
 	case Kratos:
@@ -133,10 +133,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 
 		if OIDCEnabled {
 			kratosChecker := NewKratosCredentialChecker(kratosMiddleware)
-			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, nil, kratosChecker, nil); err != nil {
+			if err := oidc.MountRoutes(e, ctx, api.PublicURL, OIDCSigningKeyPath, nil, kratosChecker, nil); err != nil {
 				return fmt.Errorf("failed to mount OIDC routes: %w", err)
 			}
-			logger.Infof("OIDC provider enabled at %s (Kratos auth)", api.FrontendURL)
+			logger.Infof("OIDC provider enabled at %s (Kratos auth)", api.PublicURL)
 		}
 
 	case Clerk:
@@ -148,10 +148,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 
 		if OIDCEnabled {
 			clerkChecker := NewClerkCredentialChecker(clerkHandler)
-			if err := oidc.MountRoutes(e, ctx, api.FrontendURL, OIDCSigningKeyPath, nil, clerkChecker, nil); err != nil {
+			if err := oidc.MountRoutes(e, ctx, api.PublicURL, OIDCSigningKeyPath, nil, clerkChecker, nil); err != nil {
 				return fmt.Errorf("failed to mount OIDC routes: %w", err)
 			}
-			logger.Infof("OIDC provider enabled at %s (Clerk auth)", api.FrontendURL)
+			logger.Infof("OIDC provider enabled at %s (Clerk auth)", api.PublicURL)
 		}
 
 		// We also need to disable "settings.users" feature in database

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -270,9 +270,9 @@ var _ = ginkgo.Describe("OIDC", func() {
 			// Clear the cache so it reloads from DB
 			oidcPublicKeyCache.Flush()
 
-			savedPublicURL := api.FrontendURL
-			api.FrontendURL = "http://localhost:8080"
-			defer func() { api.FrontendURL = savedPublicURL }()
+			savedPublicURL := api.PublicURL
+			api.PublicURL = "http://localhost:8080"
+			defer func() { api.PublicURL = savedPublicURL }()
 
 			claims := jwt.MapClaims{
 				"iss": "http://localhost:8080",
@@ -296,9 +296,9 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			oidcPublicKeyCache.Flush()
-			savedPublicURL := api.FrontendURL
-			api.FrontendURL = "http://localhost:8080"
-			defer func() { api.FrontendURL = savedPublicURL }()
+			savedPublicURL := api.PublicURL
+			api.PublicURL = "http://localhost:8080"
+			defer func() { api.PublicURL = savedPublicURL }()
 
 			claims := jwt.MapClaims{
 				"iss": "http://localhost:8080",
@@ -323,9 +323,9 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			oidcPublicKeyCache.Flush()
-			savedPublicURL := api.FrontendURL
-			api.FrontendURL = "http://localhost:8080"
-			defer func() { api.FrontendURL = savedPublicURL }()
+			savedPublicURL := api.PublicURL
+			api.PublicURL = "http://localhost:8080"
+			defer func() { api.PublicURL = savedPublicURL }()
 
 			claims := jwt.MapClaims{
 				"iss": "http://localhost:8080",
@@ -350,9 +350,9 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			oidcPublicKeyCache.Flush()
-			savedPublicURL := api.FrontendURL
-			api.FrontendURL = "http://localhost:8080"
-			defer func() { api.FrontendURL = savedPublicURL }()
+			savedPublicURL := api.PublicURL
+			api.PublicURL = "http://localhost:8080"
+			defer func() { api.PublicURL = savedPublicURL }()
 
 			claims := jwt.MapClaims{
 				"iss": "http://localhost:8080",
@@ -377,9 +377,9 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			oidcPublicKeyCache.Flush()
-			savedPublicURL := api.FrontendURL
-			api.FrontendURL = "http://localhost:8080"
-			defer func() { api.FrontendURL = savedPublicURL }()
+			savedPublicURL := api.PublicURL
+			api.PublicURL = "http://localhost:8080"
+			defer func() { api.PublicURL = savedPublicURL }()
 
 			claims := jwt.MapClaims{
 				"iss": "http://localhost:8080",

--- a/auth/oidc_validate.go
+++ b/auth/oidc_validate.go
@@ -35,7 +35,7 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 		return false, nil
 	}
 
-	issuer := strings.TrimRight(api.FrontendURL, "/")
+	issuer := strings.TrimRight(api.PublicURL, "/")
 
 	var lastErr error
 	for _, pub := range keys {

--- a/tests/e2e/oidc/suite_test.go
+++ b/tests/e2e/oidc/suite_test.go
@@ -73,6 +73,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		"--htpasswd-file", htpasswdPath,
 		"--oidc",
 		"--frontend-url", serverURL,
+		"--public-endpoint", serverURL,
 		"--httpPort", strconv.Itoa(serverPort),
 		"--disable-postgrest",
 		"--postgrest-uri", "",


### PR DESCRIPTION
MCP/OAuth clients discover OIDC metadata from the tenant backend.

The provider was advertising endpoints using the shared frontend URL, which made clients call frontend-hosted `/authorize` and token routes without tenant context.

Use the backend public endpoint for OIDC issuer, protected resource metadata, and token issuer validation so clients interact with the tenant backend directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC discovery metadata and token issuer validation now use the configured public endpoint, fixing endpoint mismatches for OIDC clients.
  * OIDC provider route announcements/log messages now report the public endpoint consistently.

* **Tests**
  * End-to-end OIDC tests updated to start the server with an explicit public endpoint for more accurate validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->