### PR TITLE
fix: Clerk redirect back to the backend after sign in

### DIFF
--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -337,8 +337,17 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 		return "", fmt.Errorf("frontend URL is not configured")
 	}
 
+	publicURL := strings.TrimRight(api.PublicURL, "/")
+	if publicURL == "" {
+		return "", fmt.Errorf("public URL is not configured")
+	}
+
+	// Clerk login happens on the shared frontend, but this OIDC flow was started by the tenant backend.
+	// After the user signs in, we must send the browser back to the backend callback,
+	// not a relative /oidc/... path on app.flanksource.com.
 	q := url.Values{}
-	q.Set("return_to", "/oidc/clerk/callback?auth_request_id="+authRequestID)
+	q.Set("return_to", publicURL+"/oidc/clerk/callback?auth_request_id="+authRequestID)
+
 	return frontendURL + "/login?" + q.Encode(), nil
 }
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -518,6 +518,27 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 	})
+
+	ginkgo.Describe("ClerkCredentialChecker", func() {
+		ginkgo.It("returns to the backend OIDC callback after frontend login", func() {
+			savedFrontendURL := api.FrontendURL
+			savedPublicURL := api.PublicURL
+			api.FrontendURL = "https://app.example.com"
+			api.PublicURL = "https://mc.example.com"
+			defer func() {
+				api.FrontendURL = savedFrontendURL
+				api.PublicURL = savedPublicURL
+			}()
+
+			redirectURL, err := NewClerkCredentialChecker(nil).LoginRedirectURL("req-123")
+			Expect(err).ToNot(HaveOccurred())
+
+			parsed, err := url.Parse(redirectURL)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsed.Scheme + "://" + parsed.Host + parsed.Path).To(Equal("https://app.example.com/login"))
+			Expect(parsed.Query().Get("return_to")).To(Equal("https://mc.example.com/oidc/clerk/callback?auth_request_id=req-123"))
+		})
+	})
 })
 
 // ensureOIDCTables creates the OIDC tables if they don't exist.


### PR DESCRIPTION
fixes 

<img width="534" height="317" alt="image" src="https://github.com/user-attachments/assets/6ed57dba-ec89-44f4-9ad0-ea099e19c1cd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clerk OIDC authentication redirect now uses the configured public URL for callback handling, ensuring correct redirect behavior across different hosts.

* **Tests**
  * Added test coverage for Clerk authentication redirect URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->