### PR TITLE
fix: relay Clerk OIDC callback through frontend

### DIFF
--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -346,6 +346,9 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 	if err != nil {
 		return "", fmt.Errorf("invalid public URL: %w", err)
 	}
+	backendCallbackQuery := callbackURL.Query()
+	backendCallbackQuery.Set("auth_request_id", authRequestID)
+	callbackURL.RawQuery = backendCallbackQuery.Encode()
 
 	returnTo := url.URL{Path: "/oidc/clerk/callback"}
 	callbackQuery := returnTo.Query()

--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -342,19 +342,39 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 		return "", fmt.Errorf("public URL is not configured")
 	}
 
-	// Clerk login happens on the shared frontend, but this OIDC flow was started by the tenant backend.
-	// After the user signs in, we must send the browser back to the backend callback,
-	// not a relative /oidc/... path on app.flanksource.com.
-	q := url.Values{}
-	q.Set("return_to", publicURL+"/oidc/clerk/callback?auth_request_id="+authRequestID)
+	callbackURL, err := url.Parse(publicURL + "/oidc/clerk/callback")
+	if err != nil {
+		return "", fmt.Errorf("invalid public URL: %w", err)
+	}
 
-	return frontendURL + "/login?" + q.Encode(), nil
+	returnTo := url.URL{Path: "/oidc/clerk/callback"}
+	callbackQuery := returnTo.Query()
+	callbackQuery.Set("auth_request_id", authRequestID)
+	callbackQuery.Set("backend_callback", callbackURL.String())
+	returnTo.RawQuery = callbackQuery.Encode()
+
+	loginURL, err := url.Parse(frontendURL + "/login")
+	if err != nil {
+		return "", fmt.Errorf("invalid frontend URL: %w", err)
+	}
+
+	q := loginURL.Query()
+	// Clerk login happens on the shared frontend, but this OIDC flow was started by the tenant backend.
+	// The auth_request_id is stored in the backend's OIDC storage, so after the user signs in the
+	// frontend callback must relay the Clerk session token back to the backend callback.
+	q.Set("return_to", returnTo.String())
+	loginURL.RawQuery = q.Encode()
+
+	return loginURL.String(), nil
 }
 
 func (c *ClerkCredentialChecker) CallbackSubject(ec echo.Context) (string, error) {
 	ctx := ec.Request().Context().(context.Context)
 
 	sessionToken := c.handler.extractSessionToken(ec)
+	if sessionToken == "" {
+		sessionToken = ec.FormValue("clerk_session_token")
+	}
 	if sessionToken == "" {
 		return "", fmt.Errorf("no Clerk session token found")
 	}

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -33,6 +33,7 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath st
 	e.POST("/oidc/login", loginHandler.HandleSubmit)
 	e.GET("/oidc/kratos/callback", loginHandler.HandleExternalCallback)
 	e.GET("/oidc/clerk/callback", loginHandler.HandleExternalCallback)
+	e.POST("/oidc/clerk/callback", loginHandler.HandleExternalCallback)
 
 	// MCP Clients need OAuth well-known discovery endpoints (not just OIDC discovery).
 	mountOAuthRoutes(e, oidcIssuer)

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -536,7 +536,12 @@ var _ = ginkgo.Describe("OIDC", func() {
 			parsed, err := url.Parse(redirectURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(parsed.Scheme + "://" + parsed.Host + parsed.Path).To(Equal("https://app.example.com/login"))
-			Expect(parsed.Query().Get("return_to")).To(Equal("https://mc.example.com/oidc/clerk/callback?auth_request_id=req-123"))
+
+			returnTo, err := url.Parse(parsed.Query().Get("return_to"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnTo.Path).To(Equal("/oidc/clerk/callback"))
+			Expect(returnTo.Query().Get("auth_request_id")).To(Equal("req-123"))
+			Expect(returnTo.Query().Get("backend_callback")).To(Equal("https://mc.example.com/oidc/clerk/callback"))
 		})
 	})
 })

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -541,7 +541,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(returnTo.Path).To(Equal("/oidc/clerk/callback"))
 			Expect(returnTo.Query().Get("auth_request_id")).To(Equal("req-123"))
-			Expect(returnTo.Query().Get("backend_callback")).To(Equal("https://mc.example.com/oidc/clerk/callback"))
+			Expect(returnTo.Query().Get("backend_callback")).To(Equal("https://mc.example.com/oidc/clerk/callback?auth_request_id=req-123"))
 		})
 	})
 })


### PR DESCRIPTION
MCP OAuth login starts on the tenant backend, but Clerk login happens on the shared frontend.

A direct browser redirect back to the tenant backend loses the frontend-scoped Clerk session, so the backend cannot resolve the logged-in Clerk user.

Route Clerk login back through a frontend relay callback, then accept a posted Clerk session token on the backend callback so Mission Control can validate Clerk and complete the OIDC authorization request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clerk authentication callback endpoint now accepts POST requests alongside GET requests, enabling more flexible integration patterns.
  * Session token validation now supports reading credentials from form submissions for improved workflow compatibility.

* **Bug Fixes**
  * Enhanced URL validation in the Clerk login flow with more descriptive error handling for misconfigured URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->