### PR TITLE
fix: remove Clerk backend callback parameter

### DIFF
--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -337,23 +337,9 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 		return "", fmt.Errorf("frontend URL is not configured")
 	}
 
-	publicURL := strings.TrimRight(api.PublicURL, "/")
-	if publicURL == "" {
-		return "", fmt.Errorf("public URL is not configured")
-	}
-
-	callbackURL, err := url.Parse(publicURL + "/oidc/clerk/callback")
-	if err != nil {
-		return "", fmt.Errorf("invalid public URL: %w", err)
-	}
-	backendCallbackQuery := callbackURL.Query()
-	backendCallbackQuery.Set("auth_request_id", authRequestID)
-	callbackURL.RawQuery = backendCallbackQuery.Encode()
-
 	returnTo := url.URL{Path: "/oidc/clerk/callback"}
 	callbackQuery := returnTo.Query()
 	callbackQuery.Set("auth_request_id", authRequestID)
-	callbackQuery.Set("backend_callback", callbackURL.String())
 	returnTo.RawQuery = callbackQuery.Encode()
 
 	loginURL, err := url.Parse(frontendURL + "/login")
@@ -364,7 +350,7 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 	q := loginURL.Query()
 	// Clerk login happens on the shared frontend, but this OIDC flow was started by the tenant backend.
 	// The auth_request_id is stored in the backend's OIDC storage, so after the user signs in the
-	// frontend callback must relay the Clerk session token back to the backend callback.
+	// frontend callback relays the Clerk session token to the active org backend from Clerk metadata.
 	q.Set("return_to", returnTo.String())
 	loginURL.RawQuery = q.Encode()
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -520,14 +520,11 @@ var _ = ginkgo.Describe("OIDC", func() {
 	})
 
 	ginkgo.Describe("ClerkCredentialChecker", func() {
-		ginkgo.It("returns to the backend OIDC callback after frontend login", func() {
+		ginkgo.It("returns to the frontend OIDC callback after frontend login", func() {
 			savedFrontendURL := api.FrontendURL
-			savedPublicURL := api.PublicURL
 			api.FrontendURL = "https://app.example.com"
-			api.PublicURL = "https://mc.example.com"
 			defer func() {
 				api.FrontendURL = savedFrontendURL
-				api.PublicURL = savedPublicURL
 			}()
 
 			redirectURL, err := NewClerkCredentialChecker(nil).LoginRedirectURL("req-123")
@@ -541,7 +538,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(returnTo.Path).To(Equal("/oidc/clerk/callback"))
 			Expect(returnTo.Query().Get("auth_request_id")).To(Equal("req-123"))
-			Expect(returnTo.Query().Get("backend_callback")).To(Equal("https://mc.example.com/oidc/clerk/callback?auth_request_id=req-123"))
+			Expect(returnTo.Query().Has("backend_callback")).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
The Clerk OIDC login redirect was still including a backend_callback query parameter with the tenant backend URL.\n\nThe frontend relay now derives the trusted backend URL from Clerk org metadata, so the browser flow only needs auth_request_id. Remove backend_callback from return_to and update the assertion accordingly.