### PR TITLE
test(application): disable flaky facet render tests

### DIFF
--- a/application/render_facet_test.go
+++ b/application/render_facet_test.go
@@ -31,6 +31,8 @@ func testApp() *icapi.Application {
 
 var _ = ginkgo.Describe("RenderFacetHTML", ginkgo.Label("ignore_local"), func() {
 	ginkgo.It("should render HTML output", func() {
+		ginkgo.Skip("disabled: facet integration test is flaky in CI")
+
 		if _, err := exec.LookPath("facet"); err != nil {
 			ginkgo.Skip("facet not on PATH; skipping facet-html integration test")
 		}
@@ -43,6 +45,8 @@ var _ = ginkgo.Describe("RenderFacetHTML", ginkgo.Label("ignore_local"), func() 
 
 var _ = ginkgo.Describe("RenderFacetPDF", ginkgo.Label("ignore_local"), func() {
 	ginkgo.It("should render PDF output", func() {
+		ginkgo.Skip("disabled: facet integration test is flaky in CI")
+
 		if _, err := exec.LookPath("facet"); err != nil {
 			ginkgo.Skip("facet not on PATH; skipping facet-pdf integration test")
 		}


### PR DESCRIPTION
Facet render integration specs intermittently fail in CI when Vite/esbuild hits `ETXTBSY` while spawning esbuild from the facet cache.

Skip the HTML and PDF facet render specs for now to keep CI stable while the underlying facet cache issue is tracked separately.