### PR TITLE
feat(plugin): add plugin SDK

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/flanksource/incident-commander/sdk"
+	"github.com/spf13/cobra"
+)
+
+// pluginParams accumulates repeated --param key=value flags.
+type pluginParams struct {
+	values map[string]string
+}
+
+func (p *pluginParams) String() string {
+	parts := make([]string, 0, len(p.values))
+	for k, v := range p.values {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (p *pluginParams) Set(v string) error {
+	if p.values == nil {
+		p.values = map[string]string{}
+	}
+	idx := strings.IndexByte(v, '=')
+	if idx <= 0 {
+		return fmt.Errorf("expected key=value, got %q", v)
+	}
+	p.values[v[:idx]] = v[idx+1:]
+	return nil
+}
+
+func (p *pluginParams) Type() string { return "key=value" }
+
+type pluginOptions struct {
+	ConfigID string
+	RawJSON  bool
+	Params   pluginParams
+}
+
+var pluginOpts pluginOptions
+
+// PluginCmd invokes operations exposed by plugins running in Mission Control.
+var PluginCmd = &cobra.Command{
+	Use:               "plugin <name> <operation>",
+	Short:             "Invoke an operation exposed by a Mission Control plugin",
+	Long:              "Invoke an operation exposed by a plugin through the running Mission Control HTTP API. Uses the current CLI context for the server. Auth uses the context token, or PLUGIN_SERVER_AUTH for basic auth when set.",
+	Args:              cobra.ExactArgs(2),
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
+	RunE:              runPluginOp,
+}
+
+func init() {
+	PluginCmd.Flags().StringVar(&pluginOpts.ConfigID, "config-id", "", "Catalog/config item id passed to the operation")
+	PluginCmd.Flags().BoolVar(&pluginOpts.RawJSON, "json", false, "Emit raw response instead of pretty-printing JSON")
+	PluginCmd.Flags().Var(&pluginOpts.Params, "param", "Key=value parameters (repeatable)")
+	Root.AddCommand(PluginCmd)
+}
+
+func runPluginOp(cmd *cobra.Command, args []string) error {
+	server, authHeader, err := pluginServerAndAuth()
+	if err != nil {
+		return err
+	}
+
+	params := pluginOpts.Params.values
+	if params == nil {
+		params = map[string]string{}
+	}
+	body, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	client := sdk.NewWithAuthHeader(server, authHeader)
+	respBody, err := client.InvokePluginOperation(args[0], args[1], pluginOpts.ConfigID, body)
+	if err != nil {
+		return err
+	}
+
+	if pluginOpts.RawJSON {
+		_, err = cmd.OutOrStdout().Write(respBody)
+		return err
+	}
+
+	var pretty any
+	if err := json.Unmarshal(respBody, &pretty); err == nil {
+		out, err := json.MarshalIndent(pretty, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	}
+
+	_, err = cmd.OutOrStdout().Write(respBody)
+	return err
+}
+
+func pluginServerAndAuth() (string, string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return "", "", err
+	}
+
+	mcCtx := cfg.CurrentMCContext()
+	if mcCtx == nil || mcCtx.Server == "" {
+		return "", "", fmt.Errorf("no Mission Control server configured; select a context with server")
+	}
+	server := mcCtx.Server
+
+	if _, err := url.ParseRequestURI(server); err != nil {
+		return "", "", fmt.Errorf("invalid Mission Control server URL %q: %w", server, err)
+	}
+
+	if mcCtx.Token != "" {
+		return server, "Bearer " + mcCtx.Token, nil
+	}
+
+	basicAuth := strings.TrimSpace(os.Getenv("PLUGIN_SERVER_AUTH"))
+	if strings.HasPrefix(strings.ToLower(basicAuth), "basic ") {
+		basicAuth = strings.TrimSpace(basicAuth[len("basic "):])
+	}
+	if basicAuth == "" {
+		return server, "", nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(basicAuth)
+	if err != nil {
+		return "", "", fmt.Errorf("PLUGIN_SERVER_AUTH must be base64(username:password): %w", err)
+	}
+	if !strings.Contains(string(decoded), ":") {
+		return "", "", fmt.Errorf("PLUGIN_SERVER_AUTH must decode to username:password")
+	}
+
+	return server, "Basic " + basicAuth, nil
+}

--- a/plugin/proto/conversions.go
+++ b/plugin/proto/conversions.go
@@ -34,6 +34,27 @@ func (x *ResourceSelector) ToDuty() types.ResourceSelector {
 	}
 }
 
+// ResourceSelectorFromDuty converts duty's ResourceSelector into its protobuf representation.
+func ResourceSelectorFromDuty(selector types.ResourceSelector) *ResourceSelector {
+	return &ResourceSelector{
+		Agent:          selector.Agent,
+		Scope:          selector.Scope,
+		Cache:          selector.Cache,
+		Search:         selector.Search,
+		Limit:          int32(selector.Limit),
+		IncludeDeleted: selector.IncludeDeleted,
+		Id:             selector.ID,
+		Name:           selector.Name,
+		Namespace:      selector.Namespace,
+		TagSelector:    selector.TagSelector,
+		LabelSelector:  selector.LabelSelector,
+		FieldSelector:  selector.FieldSelector,
+		Health:         string(selector.Health),
+		Types:          []string(selector.Types),
+		Statuses:       []string(selector.Statuses),
+	}
+}
+
 func FromConfigItem(item models.ConfigItem) (*ConfigItem, error) {
 	out := &ConfigItem{
 		Id: item.ID.String(),

--- a/plugin/sdk/clicky.go
+++ b/plugin/sdk/clicky.go
@@ -1,0 +1,28 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ClickyResultMimeType is the content-type plugins should use for operation
+// results that contain clicky-renderable output.
+const ClickyResultMimeType = "application/clicky+json"
+
+// ClickyResult marshals an operation result for transport. Plugin handlers can
+// return JSON-serializable values or json.RawMessage for already-encoded data.
+func ClickyResult(v any) ([]byte, error) {
+	if v == nil {
+		return []byte("null"), nil
+	}
+
+	if raw, ok := v.(json.RawMessage); ok {
+		return []byte(raw), nil
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("clicky result marshal: %w", err)
+	}
+	return b, nil
+}

--- a/plugin/sdk/host_client.go
+++ b/plugin/sdk/host_client.go
@@ -1,0 +1,90 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/flanksource/duty/types"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+)
+
+// HostClient is the plugin-side handle to call back into the mission-control
+// host. It is created by the SDK after the host opens the reverse-channel
+// during RegisterPlugin and made available on every InvokeCtx.
+type HostClient interface {
+	// GetConfigItem fetches a single config item by id.
+	GetConfigItem(ctx context.Context, id string) (*pluginpb.ConfigItem, error)
+
+	// ListConfigs returns config items matching the given ResourceSelector.
+	ListConfigs(ctx context.Context, selector types.ResourceSelector, limit int) (*pluginpb.ConfigItemList, error)
+
+	// GetConnection resolves a connection of the given type. typ is one of
+	// "aws", "kubernetes", "gcp", "azure", or "sql".
+	GetConnection(ctx context.Context, typ, configItemID string) (*pluginpb.ResolvedConnection, error)
+
+	// Log forwards a structured log entry to the host's logger.
+	Log(ctx context.Context, level, message string, fields map[string]string) error
+
+	// WriteArtifact persists raw bytes via the host's artifact store and returns a reference.
+	WriteArtifact(ctx context.Context, a *pluginpb.Artifact) (*pluginpb.ArtifactRef, error)
+
+	// ReadArtifact retrieves an artifact previously written via the host.
+	ReadArtifact(ctx context.Context, ref *pluginpb.ArtifactRef) (*pluginpb.Artifact, error)
+}
+
+type hostClient struct {
+	c pluginpb.HostServiceClient
+}
+
+func newHostClient(conn *grpc.ClientConn) HostClient {
+	return &hostClient{c: pluginpb.NewHostServiceClient(conn)}
+}
+
+func (h *hostClient) GetConfigItem(ctx context.Context, id string) (*pluginpb.ConfigItem, error) {
+	return h.c.GetConfigItem(ctx, &pluginpb.GetConfigItemRequest{Id: id})
+}
+
+func (h *hostClient) ListConfigs(ctx context.Context, selector types.ResourceSelector, limit int) (*pluginpb.ConfigItemList, error) {
+	return h.c.ListConfigs(ctx, &pluginpb.ListConfigsRequest{
+		Selector: pluginpb.ResourceSelectorFromDuty(selector),
+		Limit:    int32(limit),
+	})
+}
+
+func (h *hostClient) GetConnection(ctx context.Context, typ, configItemID string) (*pluginpb.ResolvedConnection, error) {
+	return h.c.GetConnection(ctx, &pluginpb.GetConnectionRequest{Type: typ, ConfigItemId: configItemID})
+}
+
+func (h *hostClient) Log(ctx context.Context, level, message string, fields map[string]string) error {
+	_, err := h.c.Log(ctx, &pluginpb.LogEntry{Level: level, Message: message, Fields: fields})
+	return err
+}
+
+func (h *hostClient) WriteArtifact(ctx context.Context, a *pluginpb.Artifact) (*pluginpb.ArtifactRef, error) {
+	return h.c.WriteArtifact(ctx, a)
+}
+
+func (h *hostClient) ReadArtifact(ctx context.Context, ref *pluginpb.ArtifactRef) (*pluginpb.Artifact, error) {
+	return h.c.ReadArtifact(ctx, ref)
+}
+
+// settingsFromStruct decodes a *structpb.Struct into a JSON-shaped map[string]any.
+// Used when passing CRD spec.properties through Configure().
+func settingsFromStruct(s *structpb.Struct) (map[string]any, error) {
+	if s == nil {
+		return map[string]any{}, nil
+	}
+	b, err := s.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("encode settings: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("decode settings: %w", err)
+	}
+	return out, nil
+}

--- a/plugin/sdk/sdk.go
+++ b/plugin/sdk/sdk.go
@@ -1,0 +1,53 @@
+// Package sdk is what plugin authors import to build a mission-control plugin.
+//
+// A minimal plugin looks like:
+//
+//	func main() {
+//	    sdk.Serve(&MyPlugin{})
+//	}
+//
+// Plugin authors implement the Plugin interface; the SDK handles the go-plugin
+// handshake, gRPC server setup, operation dispatch, and the reverse channel
+// back to the mission-control host.
+package sdk
+
+import (
+	"context"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+)
+
+// Plugin is the interface plugin authors implement. All methods are called by
+// the SDK in response to host RPCs.
+type Plugin interface {
+	// Manifest returns the plugin's static manifest: name, version, and the
+	// operations it exposes. Called once on startup in response to RegisterPlugin.
+	Manifest() *pluginpb.PluginManifest
+
+	// Configure applies host-pushed configuration. settings is the merged CRD
+	// spec.properties + any host-side overrides as a JSON-decoded map.
+	Configure(ctx context.Context, settings map[string]any) error
+
+	// Operations returns the runtime handlers for the operations declared in
+	// Manifest(). The Def field on each Operation should match a name in
+	// Manifest().Operations.
+	Operations() []Operation
+}
+
+// Operation is a runtime handler for a named operation declared in the
+// plugin's manifest. Handler returns either a JSON-serializable value or raw
+// bytes for advanced cases.
+type Operation struct {
+	Def     *pluginpb.OperationDef
+	Handler func(ctx context.Context, req InvokeCtx) (any, error)
+}
+
+// InvokeCtx is passed to operation handlers. It exposes the request payload,
+// the calling user's identity/permissions, and a HostClient for callbacks.
+type InvokeCtx struct {
+	Operation    string
+	ParamsJSON   []byte
+	ConfigItemID string
+	Caller       *pluginpb.CallerContext
+	Host         HostClient
+}

--- a/plugin/sdk/serve.go
+++ b/plugin/sdk/serve.go
@@ -1,0 +1,28 @@
+package sdk
+
+import (
+	"fmt"
+	"os"
+
+	goplugin "github.com/hashicorp/go-plugin"
+
+	"github.com/flanksource/incident-commander/plugin/adapter"
+)
+
+// Serve is the entry point for plugin binaries. It starts the go-plugin gRPC
+// server and blocks until the host disconnects.
+func Serve(impl Plugin) {
+	if m := impl.Manifest(); m != nil {
+		fmt.Fprintf(os.Stderr, "plugin %s loading: version=%s\n", m.Name, m.Version)
+	}
+
+	srv := newPluginServer(impl)
+
+	goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: adapter.Handshake,
+		Plugins: map[string]goplugin.Plugin{
+			adapter.PluginName: &grpcAdapter{srv: srv},
+		},
+		GRPCServer: adapter.GRPCServerFactory,
+	})
+}

--- a/plugin/sdk/server.go
+++ b/plugin/sdk/server.go
@@ -1,0 +1,156 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+)
+
+// pluginServer adapts the user's Plugin interface onto the generated
+// pluginpb.PluginServiceServer. It also owns the back-channel connection
+// to the host (HostClient) so InvokeCtx can hand it to operation handlers.
+type pluginServer struct {
+	pluginpb.UnimplementedPluginServiceServer
+
+	impl    Plugin
+	mu      sync.Mutex
+	host    HostClient
+	hostBrk *goplugin.GRPCBroker
+	ops     map[string]Operation
+}
+
+func newPluginServer(impl Plugin) *pluginServer {
+	ops := map[string]Operation{}
+	for _, op := range impl.Operations() {
+		if op.Def != nil {
+			ops[op.Def.Name] = op
+		}
+	}
+	return &pluginServer{impl: impl, ops: ops}
+}
+
+func (s *pluginServer) RegisterPlugin(ctx context.Context, req *pluginpb.RegisterRequest) (*pluginpb.PluginManifest, error) {
+	if s.hostBrk != nil && req.HostBrokerId != 0 {
+		conn, err := s.hostBrk.Dial(req.HostBrokerId)
+		if err != nil {
+			return nil, fmt.Errorf("dial host broker: %w", err)
+		}
+		s.mu.Lock()
+		s.host = newHostClient(conn)
+		s.mu.Unlock()
+	}
+
+	manifest := s.impl.Manifest()
+	if manifest == nil {
+		return nil, fmt.Errorf("plugin Manifest() returned nil")
+	}
+	if manifest.Name == "" {
+		return nil, fmt.Errorf("plugin Manifest().Name is required")
+	}
+	if manifest.Version == "" {
+		return nil, fmt.Errorf("plugin %s Manifest().Version is required (build with -ldflags '-X main.Version=...')", manifest.Name)
+	}
+	// Materialize operations from the live registry so a plugin doesn't have
+	// to declare them twice.
+	if len(manifest.Operations) == 0 {
+		for _, op := range s.ops {
+			manifest.Operations = append(manifest.Operations, op.Def)
+		}
+	}
+	return manifest, nil
+}
+
+func (s *pluginServer) Configure(ctx context.Context, req *pluginpb.ConfigureRequest) (*pluginpb.ConfigureResponse, error) {
+	settings, err := settingsFromStruct(req.Settings)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.impl.Configure(ctx, settings); err != nil {
+		return nil, err
+	}
+	return &pluginpb.ConfigureResponse{}, nil
+}
+
+func (s *pluginServer) ListOperations(ctx context.Context, _ *pluginpb.Empty) (*pluginpb.OperationList, error) {
+	out := &pluginpb.OperationList{}
+	for _, op := range s.ops {
+		out.Operations = append(out.Operations, op.Def)
+	}
+	return out, nil
+}
+
+func (s *pluginServer) Invoke(ctx context.Context, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
+	op, ok := s.ops[req.Operation]
+	if !ok {
+		return &pluginpb.InvokeResponse{
+			ErrorCode:    "UNKNOWN_OPERATION",
+			ErrorMessage: fmt.Sprintf("unknown operation %q", req.Operation),
+		}, nil
+	}
+
+	if req.Deadline != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, req.Deadline.AsTime())
+		defer cancel()
+	}
+
+	s.mu.Lock()
+	host := s.host
+	s.mu.Unlock()
+
+	res, err := op.Handler(ctx, InvokeCtx{
+		Operation:    req.Operation,
+		ParamsJSON:   req.ParamsJson,
+		ConfigItemID: req.ConfigItemId,
+		Caller:       req.Caller,
+		Host:         host,
+	})
+	if err != nil {
+		return &pluginpb.InvokeResponse{
+			ErrorCode:    "HANDLER_ERROR",
+			ErrorMessage: err.Error(),
+		}, nil
+	}
+
+	body, err := ClickyResult(res)
+	if err != nil {
+		return nil, err
+	}
+
+	mime := op.Def.ResultMime
+	if mime == "" {
+		mime = ClickyResultMimeType
+	}
+	return &pluginpb.InvokeResponse{Result: body, Mime: mime}, nil
+}
+
+func (s *pluginServer) Health(ctx context.Context, _ *pluginpb.Empty) (*pluginpb.HealthStatus, error) {
+	return &pluginpb.HealthStatus{Ok: true}, nil
+}
+
+func (s *pluginServer) Shutdown(ctx context.Context, _ *pluginpb.Empty) (*pluginpb.Empty, error) {
+	return &pluginpb.Empty{}, nil
+}
+
+// grpcAdapter wires pluginServer into the goplugin GRPCPlugin so we can grab
+// the broker that the host uses for its back-channel.
+type grpcAdapter struct {
+	goplugin.Plugin
+	srv *pluginServer
+}
+
+func (a *grpcAdapter) GRPCServer(broker *goplugin.GRPCBroker, s *grpc.Server) error {
+	a.srv.hostBrk = broker
+	pluginpb.RegisterPluginServiceServer(s, a.srv)
+	return nil
+}
+
+func (a *grpcAdapter) GRPCClient(ctx context.Context, broker *goplugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
+	// Plugins never act as a client of themselves.
+	return nil, nil
+}

--- a/plugin/sdk/suite_test.go
+++ b/plugin/sdk/suite_test.go
@@ -1,0 +1,13 @@
+package sdk
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSDK(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "SDK")
+}

--- a/plugin/sdk/version.go
+++ b/plugin/sdk/version.go
@@ -1,0 +1,10 @@
+package sdk
+
+// FormatVersion produces the canonical version string embedded in the gRPC
+// manifest: "<version> built <buildDate>". Empty build dates are omitted.
+func FormatVersion(version, buildDate string) string {
+	if buildDate == "" {
+		return version
+	}
+	return version + " built " + buildDate
+}

--- a/plugin/sdk/version_test.go
+++ b/plugin/sdk/version_test.go
@@ -1,0 +1,60 @@
+package sdk
+
+import (
+	"context"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+)
+
+var _ = ginkgo.Describe("FormatVersion", func() {
+	ginkgo.It("includes version and build date", func() {
+		got := FormatVersion("1.2.3", "2026-05-03 12:00:00")
+		Expect(got).To(Equal("1.2.3 built 2026-05-03 12:00:00"))
+	})
+
+	ginkgo.It("omits the build date when not provided", func() {
+		got := FormatVersion("1.2.3", "")
+		Expect(got).To(Equal("1.2.3"))
+	})
+})
+
+type stubPlugin struct {
+	manifest *pluginpb.PluginManifest
+}
+
+func (s stubPlugin) Manifest() *pluginpb.PluginManifest            { return s.manifest }
+func (stubPlugin) Configure(context.Context, map[string]any) error { return nil }
+func (stubPlugin) Operations() []Operation                         { return nil }
+
+var _ = ginkgo.Describe("RegisterPlugin version guard", func() {
+	ginkgo.It("rejects an empty Version", func() {
+		srv := newPluginServer(stubPlugin{
+			manifest: &pluginpb.PluginManifest{Name: "demo", Version: ""},
+		})
+		_, err := srv.RegisterPlugin(context.Background(), &pluginpb.RegisterRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Manifest().Version is required"))
+	})
+
+	ginkgo.It("rejects an empty Name", func() {
+		srv := newPluginServer(stubPlugin{
+			manifest: &pluginpb.PluginManifest{Name: "", Version: "1.0.0"},
+		})
+		_, err := srv.RegisterPlugin(context.Background(), &pluginpb.RegisterRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Manifest().Name is required"))
+	})
+
+	ginkgo.It("accepts a populated manifest", func() {
+		srv := newPluginServer(stubPlugin{
+			manifest: &pluginpb.PluginManifest{Name: "demo", Version: "1.0.0"},
+		})
+		got, err := srv.RegisterPlugin(context.Background(), &pluginpb.RegisterRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Name).To(Equal("demo"))
+		Expect(got.Version).To(Equal("1.0.0"))
+	})
+})

--- a/plugins/kubernetes-logs/Makefile
+++ b/plugins/kubernetes-logs/Makefile
@@ -1,0 +1,17 @@
+PLUGIN_NAME := kubernetes-logs
+PLUGIN_PATH ?= $(MISSION_CONTROL_PLUGIN_PATH)
+VERSION ?= dev
+BUILD_DATE := $(shell date "+%Y-%m-%d %H:%M:%S")
+
+.PHONY: build
+build:
+	@test -n "$(PLUGIN_PATH)" || (echo "MISSION_CONTROL_PLUGIN_PATH is required"; exit 1)
+	mkdir -p "$(PLUGIN_PATH)"
+	go build \
+		-ldflags "-X 'main.Version=$(VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" \
+		-o "$(PLUGIN_PATH)/$(PLUGIN_NAME)" \
+		./plugins/kubernetes-logs
+
+.PHONY: install
+install: build
+	kubectl apply -f plugins/kubernetes-logs/Plugin.yaml

--- a/plugins/kubernetes-logs/Plugin.yaml
+++ b/plugins/kubernetes-logs/Plugin.yaml
@@ -1,0 +1,23 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Plugin
+metadata:
+  name: kubernetes-logs
+spec:
+  source: kubernetes-logs
+  version: "0.1.0"
+  selector:
+    types:
+      - Kubernetes::Pod
+      - Kubernetes::Deployment
+      - Kubernetes::StatefulSet
+      - Kubernetes::DaemonSet
+      - Kubernetes::ReplicaSet
+      - Kubernetes::Job
+      - Kubernetes::CronJob
+  connections:
+    # When set, the host will use this connection to resolve a kubeconfig the
+    # plugin uses for its API calls. fromConfigItem causes the host to derive
+    # the kubeconfig from the catalog item being viewed (e.g. an EKS Cluster
+    # config item yields its own credentials).
+    fromConfigItem: ""
+    kubernetes: {}

--- a/plugins/kubernetes-logs/README.md
+++ b/plugins/kubernetes-logs/README.md
@@ -1,0 +1,48 @@
+# Kubernetes Logs Plugin
+
+Reference plugin: returns logs from a Pod, Deployment, StatefulSet, DaemonSet,
+ReplicaSet, Job, or CronJob, walking owner references to fan out across every
+matching pod.
+
+## What it shows the SDK author
+
+- Reading the catalog item (`Host.GetConfigItem`) to learn `kind / namespace / name`.
+- Resolving a Kubernetes connection by type (`Host.GetConnection(ctx, "kubernetes", configID)`).
+- Exposing operation handlers over the gRPC plugin contract (`tail`, `list-pods`).
+
+## Build & install
+
+```sh
+mkdir -p $MISSION_CONTROL_PLUGIN_PATH
+go build -o $MISSION_CONTROL_PLUGIN_PATH/kubernetes-logs ./plugins/kubernetes-logs
+kubectl apply -f plugins/kubernetes-logs/Plugin.yaml
+```
+
+## CLI
+
+```sh
+# Tail the last 100 lines from every pod owned by a Deployment:
+mission-control plugin kubernetes-logs tail \
+  --config-id <deployment-config-uuid> \
+  --param tailLines=100
+
+# Just resolve which pods a workload maps to:
+mission-control plugin kubernetes-logs list-pods --config-id <uuid>
+```
+
+## HTTP
+
+```sh
+curl -X POST -d '{"tailLines":50}' \
+  "$MISSION_CONTROL_URL/api/plugins/kubernetes-logs/operations/tail?config_id=<uuid>"
+```
+
+Returns `application/clicky+json` rows of `{pod, container, line}`.
+
+## Connection resolution
+
+The plugin's `connections.kubernetes` field is the same shape as the
+`exec` action's: it can be a kubeconfig env-var, a named `Connection`,
+`fromConfigItem` (derive credentials from the catalog item being viewed —
+the natural choice for an EKS / GKE / Kubernetes cluster config item), or
+left empty so the plugin falls back to its own in-cluster service account.

--- a/plugins/kubernetes-logs/client.go
+++ b/plugins/kubernetes-logs/client.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+// clientCache memoises the kubernetes.Interface keyed by config item id, so
+// repeated operations on the same catalog item don't re-parse the kubeconfig.
+type clientCache struct {
+	mu      sync.Mutex
+	entries map[string]kubernetes.Interface
+}
+
+// For returns a kubernetes client appropriate for the given context. The
+// host's GetConnection is preferred (the Plugin CRD's connection.kubernetes
+// is the source of truth). When the host is unavailable (e.g. CLI smoke tests)
+// or the connection didn't yield a kubeconfig, falls back to in-cluster.
+func (c *clientCache) For(ctx context.Context, host sdk.HostClient, configItemID string) (kubernetes.Interface, error) {
+	c.mu.Lock()
+	if c.entries == nil {
+		c.entries = map[string]kubernetes.Interface{}
+	}
+	c.mu.Unlock()
+
+	cacheKey := configItemID
+	if existing, ok := c.lookup(cacheKey); ok {
+		return existing, nil
+	}
+
+	cfg, err := buildRestConfig(ctx, host, configItemID)
+	if err != nil {
+		return nil, err
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+	c.store(cacheKey, cs)
+	return cs, nil
+}
+
+func (c *clientCache) lookup(k string) (kubernetes.Interface, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.entries[k]
+	return v, ok
+}
+
+func (c *clientCache) store(k string, v kubernetes.Interface) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[k] = v
+}
+
+// buildRestConfig prefers the host-resolved kubernetes connection; when it's
+// not available, falls back to in-cluster (so the plugin still works as a
+// sidecar in the same cluster).
+func buildRestConfig(ctx context.Context, host sdk.HostClient, configItemID string) (*rest.Config, error) {
+	if host != nil {
+		conn, err := host.GetConnection(ctx, "kubernetes", configItemID)
+		if err == nil && conn != nil && conn.Properties != nil {
+			if kc, ok := conn.Properties.AsMap()["kubeconfig"].(string); ok && kc != "" {
+				cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kc))
+				if err == nil {
+					return cfg, nil
+				}
+				// fall through: maybe it's a path, not contents.
+				cfg2, err2 := clientcmd.BuildConfigFromFlags("", kc)
+				if err2 == nil {
+					return cfg2, nil
+				}
+			}
+		}
+	}
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("no host kubernetes connection and no in-cluster config: %w", err)
+	}
+	return cfg, nil
+}

--- a/plugins/kubernetes-logs/logs.go
+++ b/plugins/kubernetes-logs/logs.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	dutylogs "github.com/flanksource/duty/logs"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// tailPod returns the last params.TailLines log lines from every container
+// in the pod (or just one if params.Container is set). Each returned LogLine
+// has FirstObserved set when the kubelet provided a timestamp, plus
+// pod/container labels so postProcessLogs can dedupe/filter on them.
+func tailPod(ctx context.Context, cli kubernetes.Interface, pod corev1.Pod, params TailParams) ([]*dutylogs.LogLine, error) {
+	containers := containerNames(pod, params.Container)
+	var out []*dutylogs.LogLine
+	for _, name := range containers {
+		opts := &corev1.PodLogOptions{
+			Container:  name,
+			TailLines:  &params.TailLines,
+			Previous:   params.Previous,
+			Timestamps: true,
+		}
+		req := cli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts)
+		stream, err := req.Stream(ctx)
+		if err != nil {
+			out = append(out, errorLine(pod, name, err.Error()))
+			continue
+		}
+		lines, err := readLines(stream)
+		_ = stream.Close()
+		if err != nil {
+			out = append(out, errorLine(pod, name, err.Error()))
+			continue
+		}
+		for _, ln := range lines {
+			out = append(out, parseKubeLogLine(pod, name, ln))
+		}
+	}
+	return out, nil
+}
+
+// parseKubeLogLine splits the leading RFC3339Nano timestamp produced by
+// PodLogOptions.Timestamps from the message body. If parsing fails, the
+// whole line is treated as the message and FirstObserved is left zero.
+func parseKubeLogLine(pod corev1.Pod, container, raw string) *dutylogs.LogLine {
+	line := &dutylogs.LogLine{
+		Host:   pod.Name,
+		Source: container,
+		Count:  1,
+		Labels: map[string]string{
+			"namespace": pod.Namespace,
+			"pod":       pod.Name,
+			"container": container,
+		},
+	}
+	if idx := strings.IndexByte(raw, ' '); idx > 0 {
+		if ts, err := time.Parse(time.RFC3339Nano, raw[:idx]); err == nil {
+			line.FirstObserved = ts
+			line.Message = raw[idx+1:]
+			line.SetHash()
+			return line
+		}
+	}
+	line.Message = raw
+	line.SetHash()
+	return line
+}
+
+func errorLine(pod corev1.Pod, container, msg string) *dutylogs.LogLine {
+	return &dutylogs.LogLine{
+		Host:     pod.Name,
+		Source:   container,
+		Severity: "error",
+		Message:  "ERROR: " + msg,
+		Count:    1,
+		Labels: map[string]string{
+			"namespace": pod.Namespace,
+			"pod":       pod.Name,
+			"container": container,
+		},
+	}
+}
+
+// containerNames returns the containers to pull logs from. When override is
+// empty, every container in the pod is included.
+func containerNames(pod corev1.Pod, override string) []string {
+	if override != "" {
+		return []string{override}
+	}
+	names := make([]string, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+func readLines(r io.Reader) ([]string, error) {
+	var out []string
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		out = append(out, strings.TrimRight(scanner.Text(), "\r"))
+	}
+	return out, scanner.Err()
+}

--- a/plugins/kubernetes-logs/main.go
+++ b/plugins/kubernetes-logs/main.go
@@ -1,0 +1,148 @@
+// Reference plugin: stream logs from a Kubernetes Pod (or its ancestor —
+// Deployment / StatefulSet / DaemonSet / ReplicaSet / Job / CronJob), using
+// the Plugin CRD's kubernetes connection.
+//
+// Build: go build -o $MISSION_CONTROL_PLUGIN_PATH/kubernetes-logs ./plugins/kubernetes-logs
+// Apply: kubectl apply -f plugins/kubernetes-logs/Plugin.yaml
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	dutyContext "github.com/flanksource/duty/context"
+	dutylogs "github.com/flanksource/duty/logs"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+// Version and BuildDate are injected at link time via the Taskfile's
+// build:plugin:kubernetes-logs target. Empty values trip the SDK's
+// RegisterPlugin guard, so dev binaries built without ldflags fail loudly.
+var (
+	Version   = ""
+	BuildDate = ""
+)
+
+func main() {
+	sdk.Serve(&KubernetesLogsPlugin{})
+}
+
+type KubernetesLogsPlugin struct {
+	clients clientCache
+}
+
+func (p *KubernetesLogsPlugin) Manifest() *pluginpb.PluginManifest {
+	return &pluginpb.PluginManifest{
+		Name:         "kubernetes-logs",
+		Version:      sdk.FormatVersion(Version, BuildDate),
+		Description:  "Stream logs from a Pod or any of its workload ancestors (Deployment / StatefulSet / DaemonSet / Job).",
+		Capabilities: []string{"operations"},
+	}
+}
+
+func (p *KubernetesLogsPlugin) Configure(_ context.Context, _ map[string]any) error {
+	return nil
+}
+
+func (p *KubernetesLogsPlugin) Operations() []sdk.Operation {
+	return []sdk.Operation{
+		{
+			Def: &pluginpb.OperationDef{
+				Name:        "tail",
+				Description: "Return the last N lines from a Pod (or every Pod owned by a workload).",
+				Scope:       "config",
+				ResultMime:  sdk.ClickyResultMimeType,
+			},
+			Handler: p.tail,
+		},
+		{
+			Def: &pluginpb.OperationDef{
+				Name:        "list-pods",
+				Description: "Resolve a config item to its Pods, walking workload ancestors.",
+				Scope:       "config",
+				ResultMime:  sdk.ClickyResultMimeType,
+			},
+			Handler: p.listPods,
+		},
+	}
+}
+
+// TailParams is the input shape for the `tail` operation. The CLI sends
+// these as JSON via --param/--json; the iframe sends them through the
+// `tail` button. PostProcess mirrors the playbook `logs` action shape so
+// CEL match expressions and dedup/window settings work the same way.
+type TailParams struct {
+	Container   string             `json:"container,omitempty"`
+	TailLines   int64              `json:"tailLines,omitempty"`
+	Previous    bool               `json:"previous,omitempty"`
+	PostProcess v1.LogsPostProcess `json:"postProcess,omitempty"`
+}
+
+func (p *KubernetesLogsPlugin) tail(ctx context.Context, req sdk.InvokeCtx) (any, error) {
+	var params TailParams
+	if len(req.ParamsJSON) > 0 {
+		if err := json.Unmarshal(req.ParamsJSON, &params); err != nil {
+			return nil, fmt.Errorf("decode params: %w", err)
+		}
+	}
+	if params.TailLines <= 0 {
+		params.TailLines = 200
+	}
+
+	cli, err := p.clients.For(ctx, req.Host, req.ConfigItemID)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := resolvePods(ctx, cli, req.Host, req.ConfigItemID)
+	if err != nil {
+		return nil, err
+	}
+
+	var lines []*dutylogs.LogLine
+	for _, pod := range pods {
+		podLines, err := tailPod(ctx, cli, pod, params)
+		if err != nil {
+			lines = append(lines, errorLine(pod, "", err.Error()))
+			continue
+		}
+		lines = append(lines, podLines...)
+	}
+
+	dctx := dutyContext.NewContext(ctx)
+	return postProcessLogs(dctx, lines, params.PostProcess), nil
+}
+
+func (p *KubernetesLogsPlugin) listPods(ctx context.Context, req sdk.InvokeCtx) (any, error) {
+	cli, err := p.clients.For(ctx, req.Host, req.ConfigItemID)
+	if err != nil {
+		return nil, err
+	}
+	pods, err := resolvePods(ctx, cli, req.Host, req.ConfigItemID)
+	if err != nil {
+		return nil, err
+	}
+	type Row struct {
+		Namespace string `json:"namespace"`
+		Pod       string `json:"pod"`
+		Phase     string `json:"phase"`
+		OwnedBy   string `json:"ownedBy,omitempty"`
+	}
+	out := make([]Row, 0, len(pods))
+	for _, pod := range pods {
+		owned := ""
+		if len(pod.OwnerReferences) > 0 {
+			owned = fmt.Sprintf("%s/%s", pod.OwnerReferences[0].Kind, pod.OwnerReferences[0].Name)
+		}
+		out = append(out, Row{
+			Namespace: pod.Namespace,
+			Pod:       pod.Name,
+			Phase:     string(pod.Status.Phase),
+			OwnedBy:   owned,
+		})
+	}
+	return out, nil
+}

--- a/plugins/kubernetes-logs/postprocess.go
+++ b/plugins/kubernetes-logs/postprocess.go
@@ -1,0 +1,167 @@
+// Mirror of postProcessLogs from playbook/actions/logs.go. Kept in-tree so
+// the plugin doesn't have to import the host's playbook/actions package
+// (which would pull most of the host server in via init() side effects).
+// If you change the algorithm, change both copies in lockstep.
+package main
+
+import (
+	"sort"
+	"time"
+
+	"github.com/flanksource/commons/duration"
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/logs"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/gomplate/v3"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+)
+
+func postProcessLogs(ctx dutyContext.Context, logLines []*logs.LogLine, postProcess v1.LogsPostProcess) []*logs.LogLine {
+	if postProcess.Empty() {
+		return logLines
+	}
+
+	var messageFields []string
+	if postProcess.Mapping != nil {
+		messageFields = postProcess.Mapping.Message
+	}
+
+	if postProcess.Parse != "" {
+		for _, line := range logLines {
+			logs.ParseMessage(line, postProcess.Parse)
+		}
+	}
+
+	matched := matchLogs(ctx, logLines, postProcess.Match, messageFields)
+	return dedupeLogs(matched, postProcess.Dedupe, messageFields)
+}
+
+func dedupeLogs(logLines []*logs.LogLine, dedupe *v1.LogDedupe, messageFields []string) []*logs.LogLine {
+	if dedupe == nil {
+		return logLines
+	}
+
+	sort.Slice(logLines, func(i, j int) bool {
+		return logLines[i].FirstObserved.Before(logLines[j].FirstObserved)
+	})
+
+	if dedupe.Window != "" {
+		window, err := duration.ParseDuration(dedupe.Window)
+		if err != nil {
+			return logLines
+		}
+
+		windowed := divideLogsByWindow(logLines, time.Duration(window))
+
+		out := make([]*logs.LogLine, 0, len(logLines))
+		for _, bucket := range windowed {
+			out = append(out, dedupeWindow(bucket, dedupe.Fields, messageFields)...)
+		}
+		return out
+	}
+
+	return dedupeWindow(logLines, dedupe.Fields, messageFields)
+}
+
+func divideLogsByWindow(logLines []*logs.LogLine, window time.Duration) [][]*logs.LogLine {
+	logsByWindow := make([][]*logs.LogLine, 0, len(logLines))
+
+	var currentWindowStart time.Time
+	var currentWindow []*logs.LogLine
+
+	for _, line := range logLines {
+		logWindow := line.FirstObserved.Truncate(window)
+		if currentWindowStart.IsZero() {
+			currentWindowStart = logWindow
+			currentWindow = append(currentWindow, line)
+			continue
+		}
+
+		if logWindow.Equal(currentWindowStart) {
+			currentWindow = append(currentWindow, line)
+			continue
+		}
+
+		logsByWindow = append(logsByWindow, currentWindow)
+		currentWindow = []*logs.LogLine{line}
+		currentWindowStart = logWindow
+	}
+
+	if len(currentWindow) > 0 {
+		logsByWindow = append(logsByWindow, currentWindow)
+	}
+
+	return logsByWindow
+}
+
+func dedupeWindow(logLines []*logs.LogLine, fields []string, messageFields []string) []*logs.LogLine {
+	out := make([]*logs.LogLine, 0, len(logLines))
+	seen := make(map[string]*logs.LogLine)
+
+	for _, line := range logLines {
+		key := line.GetFieldKey(fields, messageFields...)
+
+		previous, found := seen[key]
+		if !found {
+			seen[key] = line
+			out = append(out, line)
+			continue
+		}
+
+		previous.Count += line.Count
+		if line.FirstObserved.Before(previous.FirstObserved) {
+			previous.FirstObserved = line.FirstObserved
+		}
+
+		if line.LastObserved != nil {
+			if previous.LastObserved == nil || line.LastObserved.After(*previous.LastObserved) {
+				previous.LastObserved = line.LastObserved
+			}
+		} else if !line.FirstObserved.IsZero() {
+			previous.LastObserved = &line.FirstObserved
+		}
+
+		previous.Message = line.Message
+		previous.Host = line.Host
+		previous.Severity = line.Severity
+		previous.Source = line.Source
+	}
+
+	return out
+}
+
+func matchLogs(ctx dutyContext.Context, logLines []*logs.LogLine, matchExprs []types.MatchExpression, messageFields []string) []*logs.LogLine {
+	if len(matchExprs) == 0 {
+		return logLines
+	}
+
+	faulty := make(map[string]struct{})
+	var out []*logs.LogLine
+
+outer:
+	for _, line := range logLines {
+		env := line.TemplateContext(messageFields...)
+
+		for _, expr := range matchExprs {
+			if _, ok := faulty[string(expr)]; ok {
+				continue
+			}
+
+			tmpl := gomplate.Template{Expression: string(expr)}
+			ok, err := gomplate.RunTemplateBool(env, tmpl)
+			if err != nil {
+				ctx.Logger.V(4).Infof("failed to evaluate match expression '%s': %v", expr, err)
+				faulty[string(expr)] = struct{}{}
+				continue
+			}
+
+			if ok {
+				out = append(out, line)
+				continue outer
+			}
+		}
+	}
+
+	return out
+}

--- a/plugins/kubernetes-logs/resolve.go
+++ b/plugins/kubernetes-logs/resolve.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+// resolvePods turns a config item into the set of pods we should fetch logs
+// from. Mission-control tags Kubernetes resources with `name`, `namespace`,
+// and the resource Kind in tags/labels. We use the host's GetConfigItem
+// to read those, then walk down to pods according to the workload kind.
+//
+// Supported kinds (case-insensitive):
+//
+//   - Pod                 — itself
+//   - Deployment          — via ReplicaSet selector
+//   - StatefulSet         — via selector
+//   - DaemonSet           — via selector
+//   - ReplicaSet          — via selector
+//   - Job / CronJob       — via selector
+//
+// Any other kind falls back to "label match by app=<name> in <namespace>",
+// which covers the typical Helm chart layout without per-controller
+// custom logic.
+func resolvePods(ctx context.Context, cli kubernetes.Interface, host sdk.HostClient, configItemID string) ([]corev1.Pod, error) {
+	if host == nil || configItemID == "" {
+		return nil, fmt.Errorf("config_item_id is required")
+	}
+	item, err := host.GetConfigItem(ctx, configItemID)
+	if err != nil {
+		return nil, fmt.Errorf("get config item: %w", err)
+	}
+
+	kind, namespace, name := extractKubeRef(item)
+	if name == "" {
+		return nil, fmt.Errorf("config item %s has no Kubernetes name tag", configItemID)
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	switch strings.ToLower(kind) {
+	case "pod", "kubernetes::pod":
+		pod, err := cli.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return []corev1.Pod{*pod}, nil
+
+	case "deployment", "kubernetes::deployment":
+		dep, err := cli.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return podsBySelector(ctx, cli, namespace, dep.Spec.Selector.MatchLabels)
+
+	case "statefulset", "kubernetes::statefulset":
+		ss, err := cli.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return podsBySelector(ctx, cli, namespace, ss.Spec.Selector.MatchLabels)
+
+	case "daemonset", "kubernetes::daemonset":
+		ds, err := cli.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return podsBySelector(ctx, cli, namespace, ds.Spec.Selector.MatchLabels)
+
+	case "replicaset", "kubernetes::replicaset":
+		rs, err := cli.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return podsBySelector(ctx, cli, namespace, rs.Spec.Selector.MatchLabels)
+
+	case "job", "kubernetes::job":
+		job, err := cli.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return podsBySelector(ctx, cli, namespace, job.Spec.Selector.MatchLabels)
+
+	case "cronjob", "kubernetes::cronjob":
+		// Find every Job owned by the CronJob, then every Pod owned by those Jobs.
+		jobs, err := cli.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		} else if err != nil {
+			return nil, err
+		}
+		var pods []corev1.Pod
+		for _, j := range jobs.Items {
+			if !ownedBy(j.OwnerReferences, "CronJob", name) {
+				continue
+			}
+			ps, err := podsBySelector(ctx, cli, namespace, j.Spec.Selector.MatchLabels)
+			if err != nil {
+				continue
+			}
+			pods = append(pods, ps...)
+		}
+		return pods, nil
+	}
+
+	// Fallback: try `app=<name>` (the dominant Helm convention).
+	return podsBySelector(ctx, cli, namespace, map[string]string{"app": name})
+}
+
+// extractKubeRef pulls the Kubernetes kind / namespace / name from a config
+// item. Mission-control's Kubernetes scraper writes these as tags.
+func extractKubeRef(item *pluginpb.ConfigItem) (kind, namespace, name string) {
+	kind = item.Type
+	namespace = item.Tags["namespace"]
+	name = item.Name
+	return
+}
+
+func podsBySelector(ctx context.Context, cli kubernetes.Interface, namespace string, sel map[string]string) ([]corev1.Pod, error) {
+	if len(sel) == 0 {
+		return nil, fmt.Errorf("empty selector")
+	}
+	list, err := cli.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(sel).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func ownedBy(refs []metav1.OwnerReference, kind, name string) bool {
+	for _, r := range refs {
+		if r.Kind == kind && r.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -14,13 +15,19 @@ type Client struct {
 }
 
 func New(serverURL, token string) *Client {
-	return &Client{
-		Client: http.NewClient().
-			BaseURL(serverURL).
-			Header("Authorization", "Bearer "+token).
-			Header("Content-Type", "application/json").
-			UserAgent("mission-control-cli"),
+	return NewWithAuthHeader(serverURL, "Bearer "+token)
+}
+
+// NewWithAuthHeader returns a client using the provided Authorization header.
+func NewWithAuthHeader(serverURL, authHeader string) *Client {
+	client := http.NewClient().
+		BaseURL(serverURL).
+		Header("Content-Type", "application/json").
+		UserAgent("mission-control-cli")
+	if authHeader != "" {
+		client = client.Header("Authorization", authHeader)
 	}
+	return &Client{Client: client}
 }
 
 func (c *Client) GetConnection(name, namespace string) (*models.Connection, error) {
@@ -80,4 +87,26 @@ func (c *Client) TestConnection(id string) (*TestResult, error) {
 		return &result, err
 	}
 	return &result, nil
+}
+
+// InvokePluginOperation invokes a plugin operation through the Mission Control HTTP API.
+func (c *Client) InvokePluginOperation(name, operation, configID string, params json.RawMessage) ([]byte, error) {
+	req := c.R(context.Background())
+	if configID != "" {
+		req = req.QueryParam("config_id", configID)
+	}
+
+	r, err := req.Post("/api/plugins/"+url.PathEscape(name)+"/operations/"+url.PathEscape(operation), params)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := r.AsString()
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		return nil, fmt.Errorf("plugin %s/%s failed (%d): %s", name, operation, r.StatusCode, body)
+	}
+	return []byte(body), nil
 }


### PR DESCRIPTION
Adds the SDK for building Mission Control plugin binaries against the core plugin runtime.

The SDK wraps go-plugin serving, plugin registration/configuration, operation dispatch, host callback client, result marshaling, and version helpers.

This keeps the SDK operation-focused and excludes plugin UI/static asset serving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Plugin SDK framework enabling developers to create custom plugins with manifest definitions, configuration handling, and operation handlers.
  * Introduced Kubernetes Logs plugin supporting pod log streaming (`tail` operation) and pod listing (`list-pods` operation).
  * Added log post-processing capabilities including deduplication, filtering, and message extraction.
  * Added plugin hosting infrastructure with gRPC support and host callback mechanisms.

* **Tests**
  * Added test suite for Plugin SDK with version formatting and plugin validation tests.

* **Documentation**
  * Added Kubernetes Logs plugin documentation with build, installation, and usage examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3083)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->