### PR TITLE
fix: route plugin runtime by id

### DIFF
--- a/plugin/controller/controller.go
+++ b/plugin/controller/controller.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -78,7 +79,7 @@ func ListPlugins(c echo.Context) error {
 			continue
 		}
 		out = append(out, PluginListing{
-			Name:        e.Manifest.Name,
+			Name:        e.Name,
 			Description: e.Manifest.Description,
 			Version:     e.Manifest.Version,
 			Tabs:        e.Manifest.Tabs,
@@ -92,20 +93,22 @@ func ListPlugins(c echo.Context) error {
 // The plugin returns raw bytes plus a MIME type; we forward both verbatim.
 func InvokeOperation(c echo.Context) error {
 	ctx := c.Request().Context().(dutyContext.Context)
-	name := c.Param("name")
+	pluginRef := c.Param("name")
 	op := c.Param("op")
 
-	sup := supervisor.LookupSupervisor(name)
+	entry, err := resolvePlugin(ctx, pluginRef)
+	if err != nil {
+		return dutyAPI.WriteError(c, err)
+	}
+
+	sup := supervisor.LookupSupervisor(entry.ID)
 	if sup == nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", name))
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", pluginRef))
 	}
 
 	configID := c.QueryParam("config_id")
-	if configID != "" {
-		entry := registry.Default.Get(name)
-		if entry != nil && !selectorMatches(ctx, entry, configID) {
-			return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", name, configID))
-		}
+	if configID != "" && !selectorMatches(ctx, entry, configID) {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
 	}
 
 	body, err := io.ReadAll(c.Request().Body)
@@ -124,7 +127,7 @@ func InvokeOperation(c echo.Context) error {
 		Caller:       caller,
 	})
 	if err != nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "plugin %s/%s", name, op))
+		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "plugin %s/%s", pluginRef, op))
 	}
 	if resp.ErrorMessage != "" {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(resp.ErrorCode).Errorf("%s", resp.ErrorMessage))
@@ -136,6 +139,20 @@ func InvokeOperation(c echo.Context) error {
 	}
 	c.Response().Header().Set(echo.HeaderContentType, mime)
 	return c.Blob(http.StatusOK, mime, resp.Result)
+}
+
+func resolvePlugin(ctx dutyContext.Context, ref string) (*registry.Entry, error) {
+	entry, err := registry.Default.Resolve(ref)
+	if err != nil {
+		if errors.Is(err, registry.ErrAmbiguousPlugin) {
+			return nil, ctx.Oops().Code(dutyAPI.ECONFLICT).Wrap(err)
+		}
+		return nil, ctx.Oops().Wrap(err)
+	}
+	if entry == nil {
+		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", ref)
+	}
+	return entry, nil
 }
 
 // selectorMatches returns true when the given config id satisfies the plugin

--- a/plugin/controller/proxy.go
+++ b/plugin/controller/proxy.go
@@ -37,23 +37,26 @@ func registerProxyRoutes(e *echo.Echo) {
 // It strips the prefix so the plugin's HTTPHandler sees a clean path.
 func uiProxy(c echo.Context) error {
 	ctx := c.Request().Context().(dutyContext.Context)
-	name := c.Param("name")
+	pluginRef := c.Param("name")
+	entry, err := resolvePlugin(ctx, pluginRef)
+	if err != nil {
+		return dutyAPI.WriteError(c, err)
+	}
 
-	sup := supervisor.LookupSupervisor(name)
+	sup := supervisor.LookupSupervisor(entry.ID)
 	if sup == nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", name))
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", pluginRef))
 	}
 	port := sup.UIPort()
 	if port == 0 {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINTERNAL).Errorf("plugin %q did not advertise a UI port", name))
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINTERNAL).Errorf("plugin %q did not advertise a UI port", pluginRef))
 	}
 
 	target, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
 	if err != nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "parse plugin url"))
 	}
-	prefix := "/api/plugins/" + name + "/ui"
-
+	prefix := "/api/plugins/" + pluginRef + "/ui"
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)

--- a/plugin/host/service.go
+++ b/plugin/host/service.go
@@ -15,6 +15,7 @@ import (
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
+	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2/expirable"
 	"google.golang.org/grpc"
 
@@ -29,7 +30,7 @@ import (
 const connectionCacheTTL = 5 * time.Minute
 
 type connKey struct {
-	pluginID string
+	pluginID uuid.UUID
 	typ      string
 	label    string
 	configID string
@@ -41,7 +42,7 @@ type connKey struct {
 type Service struct {
 	pluginpb.UnimplementedHostServiceServer
 
-	pluginID string
+	pluginID uuid.UUID
 	ctx      dutyContext.Context
 
 	// connCache memoises GetConnection results across calls within a single
@@ -52,7 +53,7 @@ type Service struct {
 // New creates a host Service for one plugin id. Multiple plugins running
 // concurrently get separate Services so the connection allowlist (read off
 // the Plugin CRD via the registry) is enforced per-plugin.
-func New(ctx dutyContext.Context, pluginID string) *Service {
+func New(ctx dutyContext.Context, pluginID uuid.UUID) *Service {
 	cache := lru.NewLRU[connKey, *pluginpb.ResolvedConnection](256, nil, connectionCacheTTL)
 	return &Service{
 		pluginID:  pluginID,
@@ -105,7 +106,7 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginpb.GetConnection
 
 	entry := registry.Default.Get(s.pluginID)
 	if entry == nil {
-		return nil, fmt.Errorf("plugin %q is not registered", s.pluginID)
+		return nil, fmt.Errorf("plugin %s is not registered", s.pluginID)
 	}
 
 	key := connKey{pluginID: s.pluginID, typ: req.GetType(), label: req.GetLabel(), configID: req.GetConfigItemId()}

--- a/plugin/host/service.go
+++ b/plugin/host/service.go
@@ -29,36 +29,35 @@ import (
 const connectionCacheTTL = 5 * time.Minute
 
 type connKey struct {
-	namespace string
-	plugin    string
-	typ       string
-	label     string
-	configID  string
+	pluginID string
+	typ      string
+	label    string
+	configID string
 }
 
 // Service is the host-side gRPC server. There is one per plugin process —
 // the supervisor instantiates it during Start() so it can stamp the plugin
-// name into requests for allowlist enforcement and caching.
+// id into requests for allowlist enforcement and caching.
 type Service struct {
 	pluginpb.UnimplementedHostServiceServer
 
-	pluginName string
-	ctx        dutyContext.Context
+	pluginID string
+	ctx      dutyContext.Context
 
 	// connCache memoises GetConnection results across calls within a single
-	// plugin process. Keyed by (namespace, plugin, type, label, configID).
+	// plugin process. Keyed by (plugin id, type, label, configID).
 	connCache *lru.LRU[connKey, *pluginpb.ResolvedConnection]
 }
 
-// New creates a host Service for one named plugin. Multiple plugins running
+// New creates a host Service for one plugin id. Multiple plugins running
 // concurrently get separate Services so the connection allowlist (read off
 // the Plugin CRD via the registry) is enforced per-plugin.
-func New(ctx dutyContext.Context, pluginName string) *Service {
+func New(ctx dutyContext.Context, pluginID string) *Service {
 	cache := lru.NewLRU[connKey, *pluginpb.ResolvedConnection](256, nil, connectionCacheTTL)
 	return &Service{
-		pluginName: pluginName,
-		ctx:        ctx,
-		connCache:  cache,
+		pluginID:  pluginID,
+		ctx:       ctx,
+		connCache: cache,
 	}
 }
 
@@ -104,12 +103,12 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginpb.GetConnection
 		return nil, fmt.Errorf("connection lookup is required")
 	}
 
-	entry := registry.Default.Get(s.pluginName)
+	entry := registry.Default.Get(s.pluginID)
 	if entry == nil {
-		return nil, fmt.Errorf("plugin %q is not registered", s.pluginName)
+		return nil, fmt.Errorf("plugin %q is not registered", s.pluginID)
 	}
 
-	key := connKey{namespace: entry.Namespace, plugin: s.pluginName, typ: req.GetType(), label: req.GetLabel(), configID: req.GetConfigItemId()}
+	key := connKey{pluginID: s.pluginID, typ: req.GetType(), label: req.GetLabel(), configID: req.GetConfigItemId()}
 	if cached, ok := s.connCache.Get(key); ok {
 		return cached, nil
 	}
@@ -130,7 +129,7 @@ func (s *Service) Log(ctx context.Context, e *pluginpb.LogEntry) (*pluginpb.Empt
 	for k, v := range e.Fields {
 		args = append(args, k, v)
 	}
-	prefix := fmt.Sprintf("[plugin %s] %s", s.pluginName, e.Message)
+	prefix := fmt.Sprintf("[plugin %s] %s", s.pluginID, e.Message)
 	switch e.Level {
 	case "debug":
 		logger.Debugf(prefix, args...)

--- a/plugin/host/service.go
+++ b/plugin/host/service.go
@@ -29,10 +29,11 @@ import (
 const connectionCacheTTL = 5 * time.Minute
 
 type connKey struct {
-	plugin   string
-	typ      string
-	label    string
-	configID string
+	namespace string
+	plugin    string
+	typ       string
+	label     string
+	configID  string
 }
 
 // Service is the host-side gRPC server. There is one per plugin process —
@@ -45,7 +46,7 @@ type Service struct {
 	ctx        dutyContext.Context
 
 	// connCache memoises GetConnection results across calls within a single
-	// plugin process. Keyed by (plugin, type, label, configID).
+	// plugin process. Keyed by (namespace, plugin, type, label, configID).
 	connCache *lru.LRU[connKey, *pluginpb.ResolvedConnection]
 }
 
@@ -103,17 +104,18 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginpb.GetConnection
 		return nil, fmt.Errorf("connection lookup is required")
 	}
 
-	key := connKey{plugin: s.pluginName, typ: req.GetType(), label: req.GetLabel(), configID: req.GetConfigItemId()}
-	if cached, ok := s.connCache.Get(key); ok {
-		return cached, nil
-	}
-
 	entry := registry.Default.Get(s.pluginName)
 	if entry == nil {
 		return nil, fmt.Errorf("plugin %q is not registered", s.pluginName)
 	}
 
-	resolved, err := resolveConnection(s.ctx, entry.Spec, req)
+	key := connKey{namespace: entry.Namespace, plugin: s.pluginName, typ: req.GetType(), label: req.GetLabel(), configID: req.GetConfigItemId()}
+	if cached, ok := s.connCache.Get(key); ok {
+		return cached, nil
+	}
+
+	pluginCtx := s.ctx.Wrap(ctx).WithNamespace(entry.Namespace)
+	resolved, err := resolveConnection(pluginCtx, entry.Spec, req)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/registry/reconciler.go
+++ b/plugin/registry/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flanksource/duty/context"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/google/uuid"
 )
 
 // EnvPluginPath is the env var that controls where plugin binaries are
@@ -34,7 +35,7 @@ func PluginPath() string {
 //
 // SupervisorStarter is injected by the cmd/server wiring at boot to break
 // the import cycle between registry and supervisor.
-var SupervisorStarter func(ctx context.Context, id string) error
+var SupervisorStarter func(ctx context.Context, id uuid.UUID) error
 
 func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 	if p == nil {
@@ -68,7 +69,10 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 
 	p.Status.InstalledPath = binPath
 
-	id := pluginID(p.Namespace, p.Name, string(p.UID))
+	id, err := parsePluginID(string(p.UID))
+	if err != nil {
+		return err
+	}
 
 	var previous *Entry
 	if entry := Default.Get(id); entry != nil {
@@ -76,12 +80,16 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 		previous = &copy
 	}
 
-	Default.Upsert(id, p.Namespace, p.Name, p.Spec)
+	if _, err := Default.Upsert(id, p.Namespace, p.Name, p.Spec); err != nil {
+		return err
+	}
 
 	if SupervisorStarter != nil {
 		if err := SupervisorStarter(ctx, id); err != nil {
 			if previous != nil {
-				Default.Upsert(previous.ID, previous.Namespace, previous.Name, previous.Spec)
+				if _, rollbackErr := Default.Upsert(previous.ID, previous.Namespace, previous.Name, previous.Spec); rollbackErr != nil {
+					ctx.Logger.Errorf("plugin %s: rollback registry entry: %v", id, rollbackErr)
+				}
 			} else {
 				Default.Remove(id)
 			}
@@ -97,27 +105,38 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 
 // SupervisorStopper is injected by the cmd/server wiring (same reason as
 // SupervisorStarter).
-var SupervisorStopper func(id string) error
+var SupervisorStopper func(id uuid.UUID) error
 
 // DeletePlugin is the kopper delete callback. It stops the supervised
 // process and drops the registry entry. The binary is left on disk —
 // re-creating the CRD won't re-download a binary that already exists.
 func DeletePlugin(ctx context.Context, id string) error {
-	if Default.Get(id) == nil {
+	pluginID, err := parsePluginID(id)
+	if err != nil {
+		entry, resolveErr := Default.Resolve(id)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if entry == nil {
+			return err
+		}
+		pluginID = entry.ID
+	}
+	if Default.Get(pluginID) == nil {
 		entry, err := Default.Resolve(id)
 		if err != nil {
 			return err
 		}
 		if entry != nil {
-			id = entry.ID
+			pluginID = entry.ID
 		}
 	}
 	if SupervisorStopper != nil {
-		if err := SupervisorStopper(id); err != nil {
+		if err := SupervisorStopper(pluginID); err != nil {
 			return err
 		}
 	}
-	Default.Remove(id)
+	Default.Remove(pluginID)
 	return nil
 }
 
@@ -127,7 +146,10 @@ func DeleteStalePlugin(ctx context.Context, newer *v1.Plugin) error {
 	if newer == nil {
 		return nil
 	}
-	newerID := pluginID(newer.Namespace, newer.Name, string(newer.UID))
+	newerID, err := parsePluginID(string(newer.UID))
+	if err != nil {
+		return err
+	}
 	for _, e := range Default.List() {
 		if e.Name != newer.Name || e.Namespace != newer.Namespace {
 			continue
@@ -145,14 +167,12 @@ func DeleteStalePlugin(ctx context.Context, newer *v1.Plugin) error {
 	return nil
 }
 
-func pluginID(namespace, name, uid string) string {
-	if uid != "" {
-		return uid
+func parsePluginID(id string) (uuid.UUID, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("plugin id %q is not a UUID: %w", id, err)
 	}
-	if namespace != "" {
-		return namespace + "/" + name
-	}
-	return name
+	return parsed, nil
 }
 
 // BinaryPathFor returns the on-disk path for a plugin's binary. The

--- a/plugin/registry/reconciler.go
+++ b/plugin/registry/reconciler.go
@@ -34,7 +34,7 @@ func PluginPath() string {
 //
 // SupervisorStarter is injected by the cmd/server wiring at boot to break
 // the import cycle between registry and supervisor.
-var SupervisorStarter func(ctx context.Context, name string) error
+var SupervisorStarter func(ctx context.Context, id string) error
 
 func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 	if p == nil {
@@ -68,25 +68,27 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 
 	p.Status.InstalledPath = binPath
 
+	id := pluginID(p.Namespace, p.Name, string(p.UID))
+
 	var previous *Entry
-	if entry := Default.Get(p.Name); entry != nil {
+	if entry := Default.Get(id); entry != nil {
 		copy := *entry
 		previous = &copy
 	}
 
-	Default.Upsert(string(p.UID), p.Namespace, p.Name, p.Spec)
+	Default.Upsert(id, p.Namespace, p.Name, p.Spec)
 
 	if SupervisorStarter != nil {
-		if err := SupervisorStarter(ctx, p.Name); err != nil {
+		if err := SupervisorStarter(ctx, id); err != nil {
 			if previous != nil {
 				Default.Upsert(previous.ID, previous.Namespace, previous.Name, previous.Spec)
 			} else {
-				Default.Remove(p.Name)
+				Default.Remove(id)
 			}
 			return err
 		}
 	}
-	if entry := Default.Get(p.Name); entry != nil && entry.Manifest != nil {
+	if entry := Default.Get(id); entry != nil && entry.Manifest != nil {
 		p.Status.PluginVersion = entry.Manifest.Version
 	}
 
@@ -95,22 +97,27 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 
 // SupervisorStopper is injected by the cmd/server wiring (same reason as
 // SupervisorStarter).
-var SupervisorStopper func(name string) error
+var SupervisorStopper func(id string) error
 
 // DeletePlugin is the kopper delete callback. It stops the supervised
 // process and drops the registry entry. The binary is left on disk —
 // re-creating the CRD won't re-download a binary that already exists.
 func DeletePlugin(ctx context.Context, id string) error {
-	name := Default.NameForID(id)
-	if name == "" {
-		name = id
+	if Default.Get(id) == nil {
+		entry, err := Default.Resolve(id)
+		if err != nil {
+			return err
+		}
+		if entry != nil {
+			id = entry.ID
+		}
 	}
 	if SupervisorStopper != nil {
-		if err := SupervisorStopper(name); err != nil {
+		if err := SupervisorStopper(id); err != nil {
 			return err
 		}
 	}
-	Default.Remove(name)
+	Default.Remove(id)
 	return nil
 }
 
@@ -120,26 +127,32 @@ func DeleteStalePlugin(ctx context.Context, newer *v1.Plugin) error {
 	if newer == nil {
 		return nil
 	}
-	newerID := string(newer.UID)
+	newerID := pluginID(newer.Namespace, newer.Name, string(newer.UID))
 	for _, e := range Default.List() {
-		name := e.Name
-		if e.Manifest != nil && e.Manifest.Name != "" {
-			name = e.Manifest.Name
-		}
-		if name != newer.Name {
+		if e.Name != newer.Name || e.Namespace != newer.Namespace {
 			continue
 		}
 		if e.ID == newerID && e.Spec.Source == newer.Spec.Source && e.Spec.Version == newer.Spec.Version {
 			continue
 		}
 		if SupervisorStopper != nil {
-			if err := SupervisorStopper(e.Name); err != nil {
+			if err := SupervisorStopper(e.ID); err != nil {
 				return err
 			}
 		}
-		Default.Remove(e.Name)
+		Default.Remove(e.ID)
 	}
 	return nil
+}
+
+func pluginID(namespace, name, uid string) string {
+	if uid != "" {
+		return uid
+	}
+	if namespace != "" {
+		return namespace + "/" + name
+	}
+	return name
 }
 
 // BinaryPathFor returns the on-disk path for a plugin's binary. The

--- a/plugin/registry/reconciler.go
+++ b/plugin/registry/reconciler.go
@@ -74,12 +74,12 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 		previous = &copy
 	}
 
-	Default.Upsert(string(p.UID), p.Name, p.Spec)
+	Default.Upsert(string(p.UID), p.Namespace, p.Name, p.Spec)
 
 	if SupervisorStarter != nil {
 		if err := SupervisorStarter(ctx, p.Name); err != nil {
 			if previous != nil {
-				Default.Upsert(previous.ID, previous.Name, previous.Spec)
+				Default.Upsert(previous.ID, previous.Namespace, previous.Name, previous.Spec)
 			} else {
 				Default.Remove(p.Name)
 			}

--- a/plugin/registry/registry.go
+++ b/plugin/registry/registry.go
@@ -8,12 +8,17 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 )
+
+var ErrAmbiguousPlugin = errors.New("ambiguous plugin reference")
 
 // Entry is everything the host needs to route a request to one plugin.
 // Manifest is populated by the supervisor once the plugin completes
@@ -29,22 +34,26 @@ type Entry struct {
 	Supervisor any
 }
 
-// Registry is the host-side in-memory store of plugins keyed by name.
+// Registry is the host-side in-memory store of plugins keyed by id. Name and
+// namespace/name indexes exist only to resolve user-facing references to ids.
 type Registry struct {
-	mu      sync.RWMutex
-	plugins map[string]*Entry
-	ids     map[string]string
+	mu sync.RWMutex
+
+	plugins     map[string]*Entry
+	nameIndex   map[string]map[string]struct{}
+	nsNameIndex map[string]string
 }
 
 // Default is the singleton used by the kopper reconciler and by every echo
-// handler that needs to look up a plugin by name.
+// handler that needs to look up a plugin.
 var Default = New()
 
 // New returns a fresh, empty registry. Tests use this; production uses Default.
 func New() *Registry {
 	return &Registry{
-		plugins: map[string]*Entry{},
-		ids:     map[string]string{},
+		plugins:     map[string]*Entry{},
+		nameIndex:   map[string]map[string]struct{}{},
+		nsNameIndex: map[string]string{},
 	}
 }
 
@@ -55,76 +64,118 @@ func New() *Registry {
 func (r *Registry) Upsert(id, namespace, name string, spec v1.PluginSpec) *Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	e, ok := r.plugins[name]
-	if !ok {
-		e = &Entry{Name: name}
-		r.plugins[name] = e
+
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	namespace = strings.TrimSpace(namespace)
+	if id == "" {
+		id = namespacedName(namespace, name)
 	}
-	if e.ID != "" && e.ID != id {
-		delete(r.ids, e.ID)
+
+	if existing := r.plugins[id]; existing != nil {
+		r.removeIndexes(existing)
+	}
+
+	e := r.plugins[id]
+	if e == nil {
+		e = &Entry{ID: id}
+		r.plugins[id] = e
 	}
 	e.ID = id
 	e.Name = name
 	e.Namespace = namespace
 	e.Spec = spec
-	if id != "" {
-		r.ids[id] = name
-	}
+	r.addIndexes(e)
 	return e
 }
 
 // SetSupervisor attaches a running supervisor to an existing entry. The
 // supervisor type is opaque here to avoid an import cycle.
-func (r *Registry) SetSupervisor(name string, sup any) error {
+func (r *Registry) SetSupervisor(id string, sup any) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	e, ok := r.plugins[name]
+	e, ok := r.plugins[id]
 	if !ok {
-		return fmt.Errorf("plugin %q not registered", name)
+		return fmt.Errorf("plugin %q not registered", id)
 	}
 	e.Supervisor = sup
 	return nil
 }
 
 // SetManifest stores the manifest a plugin returned from RegisterPlugin.
-func (r *Registry) SetManifest(name string, m *pluginpb.PluginManifest) error {
+func (r *Registry) SetManifest(id string, m *pluginpb.PluginManifest) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	e, ok := r.plugins[name]
+	e, ok := r.plugins[id]
 	if !ok {
-		return fmt.Errorf("plugin %q not registered", name)
+		return fmt.Errorf("plugin %q not registered", id)
 	}
 	e.Manifest = m
 	return nil
 }
 
-// Get returns the entry for the given plugin name, or nil if no plugin by
-// that name is registered.
-func (r *Registry) Get(name string) *Entry {
+// Get returns the entry for the given plugin id, or nil if no plugin by that
+// id is registered.
+func (r *Registry) Get(id string) *Entry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if e, ok := r.plugins[name]; ok {
+	if e, ok := r.plugins[id]; ok {
 		return snapshotEntry(e)
 	}
 	return nil
 }
 
-// NameForID resolves a Plugin CRD UID/id to the runtime plugin name.
-func (r *Registry) NameForID(id string) string {
+// Resolve accepts a plugin id, namespace/name, or unqualified name. Name-based
+// references are resolved to ids internally; unqualified names must be unique.
+func (r *Registry) Resolve(ref string) (*Entry, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.ids[id]
+
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, nil
+	}
+
+	if e, ok := r.plugins[ref]; ok {
+		return snapshotEntry(e), nil
+	}
+
+	if strings.Contains(ref, "/") {
+		if id := r.nsNameIndex[ref]; id != "" {
+			return snapshotEntry(r.plugins[id]), nil
+		}
+		return nil, nil
+	}
+
+	ids := r.nameIndex[ref]
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if len(ids) > 1 {
+		matches := make([]string, 0, len(ids))
+		for id := range ids {
+			if e := r.plugins[id]; e != nil {
+				matches = append(matches, displayRef(e))
+			}
+		}
+		sort.Strings(matches)
+		return nil, fmt.Errorf("%w %q; use plugin id or namespace/name, matches: %s", ErrAmbiguousPlugin, ref, strings.Join(matches, ", "))
+	}
+	for id := range ids {
+		return snapshotEntry(r.plugins[id]), nil
+	}
+	return nil, nil
 }
 
 // Remove drops a plugin from the registry. Callers are responsible for
 // stopping the supervisor first.
-func (r *Registry) Remove(name string) {
+func (r *Registry) Remove(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if e, ok := r.plugins[name]; ok && e.ID != "" {
-		delete(r.ids, e.ID)
+	if e, ok := r.plugins[id]; ok {
+		r.removeIndexes(e)
 	}
-	delete(r.plugins, name)
+	delete(r.plugins, id)
 }
 
 // List returns a snapshot of all registered plugins.
@@ -136,6 +187,54 @@ func (r *Registry) List() []*Entry {
 		out = append(out, snapshotEntry(e))
 	}
 	return out
+}
+
+func (r *Registry) addIndexes(e *Entry) {
+	if e.Name == "" {
+		return
+	}
+	ids := r.nameIndex[e.Name]
+	if ids == nil {
+		ids = map[string]struct{}{}
+		r.nameIndex[e.Name] = ids
+	}
+	ids[e.ID] = struct{}{}
+	if e.Namespace != "" {
+		r.nsNameIndex[namespacedName(e.Namespace, e.Name)] = e.ID
+	}
+}
+
+func (r *Registry) removeIndexes(e *Entry) {
+	if e.Name == "" {
+		return
+	}
+	if ids := r.nameIndex[e.Name]; ids != nil {
+		delete(ids, e.ID)
+		if len(ids) == 0 {
+			delete(r.nameIndex, e.Name)
+		}
+	}
+	if e.Namespace != "" {
+		key := namespacedName(e.Namespace, e.Name)
+		if r.nsNameIndex[key] == e.ID {
+			delete(r.nsNameIndex, key)
+		}
+	}
+}
+
+func namespacedName(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "/" + name
+}
+
+func displayRef(e *Entry) string {
+	ref := namespacedName(e.Namespace, e.Name)
+	if ref == "" {
+		return e.ID
+	}
+	return ref
 }
 
 func snapshotEntry(e *Entry) *Entry {

--- a/plugin/registry/registry.go
+++ b/plugin/registry/registry.go
@@ -20,10 +20,11 @@ import (
 // RegisterPlugin; it is nil while the plugin is starting up or has crashed
 // past the supervisor's restart budget.
 type Entry struct {
-	ID       string
-	Name     string
-	Spec     v1.PluginSpec
-	Manifest *pluginpb.PluginManifest
+	ID        string
+	Name      string
+	Namespace string
+	Spec      v1.PluginSpec
+	Manifest  *pluginpb.PluginManifest
 	// Supervisor is opaque here; the supervisor package sets it.
 	Supervisor any
 }
@@ -51,7 +52,7 @@ func New() *Registry {
 // a Plugin CRD is created or updated). Existing manifest/supervisor are
 // preserved so an in-flight plugin keeps running across CRD updates that
 // don't change the binary.
-func (r *Registry) Upsert(id, name string, spec v1.PluginSpec) *Entry {
+func (r *Registry) Upsert(id, namespace, name string, spec v1.PluginSpec) *Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.plugins[name]
@@ -64,6 +65,7 @@ func (r *Registry) Upsert(id, name string, spec v1.PluginSpec) *Entry {
 	}
 	e.ID = id
 	e.Name = name
+	e.Namespace = namespace
 	e.Spec = spec
 	if id != "" {
 		r.ids[id] = name

--- a/plugin/registry/registry.go
+++ b/plugin/registry/registry.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/google/uuid"
 )
 
 var ErrAmbiguousPlugin = errors.New("ambiguous plugin reference")
@@ -25,7 +26,7 @@ var ErrAmbiguousPlugin = errors.New("ambiguous plugin reference")
 // RegisterPlugin; it is nil while the plugin is starting up or has crashed
 // past the supervisor's restart budget.
 type Entry struct {
-	ID        string
+	ID        uuid.UUID
 	Name      string
 	Namespace string
 	Spec      v1.PluginSpec
@@ -34,14 +35,19 @@ type Entry struct {
 	Supervisor any
 }
 
-// Registry is the host-side in-memory store of plugins keyed by id. Name and
-// namespace/name indexes exist only to resolve user-facing references to ids.
+// Registry is the host-side in-memory store of plugins.
 type Registry struct {
 	mu sync.RWMutex
 
-	plugins     map[string]*Entry
-	nameIndex   map[string]map[string]struct{}
-	nsNameIndex map[string]string
+	// plugins is the authoritative store keyed by plugin ID/UID. All runtime
+	// routing uses this key after a user-facing reference is resolved.
+	plugins map[uuid.UUID]*Entry
+
+	// refs maps exact plugin references to plugin IDs. The reference format is
+	// "namespace/name" for namespaced plugins and "/name" for plugins without a
+	// namespace. Bare-name lookups are resolved by scanning plugins so duplicate
+	// names can be reported as ambiguous instead of stored in this index.
+	refs map[string]uuid.UUID
 }
 
 // Default is the singleton used by the kopper reconciler and by every echo
@@ -51,9 +57,8 @@ var Default = New()
 // New returns a fresh, empty registry. Tests use this; production uses Default.
 func New() *Registry {
 	return &Registry{
-		plugins:     map[string]*Entry{},
-		nameIndex:   map[string]map[string]struct{}{},
-		nsNameIndex: map[string]string{},
+		plugins: map[uuid.UUID]*Entry{},
+		refs:    map[string]uuid.UUID{},
 	}
 }
 
@@ -61,15 +66,19 @@ func New() *Registry {
 // a Plugin CRD is created or updated). Existing manifest/supervisor are
 // preserved so an in-flight plugin keeps running across CRD updates that
 // don't change the binary.
-func (r *Registry) Upsert(id, namespace, name string, spec v1.PluginSpec) *Entry {
+func (r *Registry) Upsert(id uuid.UUID, namespace, name string, spec v1.PluginSpec) (*Entry, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	id = strings.TrimSpace(id)
+	if id == uuid.Nil {
+		return nil, fmt.Errorf("plugin id is required")
+	}
 	name = strings.TrimSpace(name)
 	namespace = strings.TrimSpace(namespace)
-	if id == "" {
-		id = namespacedName(namespace, name)
+
+	ref := namespacedName(namespace, name)
+	if existingID := r.refs[ref]; existingID != uuid.Nil && existingID != id {
+		return nil, fmt.Errorf("plugin %s is already registered with id %s", ref, existingID)
 	}
 
 	if existing := r.plugins[id]; existing != nil {
@@ -86,29 +95,29 @@ func (r *Registry) Upsert(id, namespace, name string, spec v1.PluginSpec) *Entry
 	e.Namespace = namespace
 	e.Spec = spec
 	r.addIndexes(e)
-	return e
+	return e, nil
 }
 
 // SetSupervisor attaches a running supervisor to an existing entry. The
 // supervisor type is opaque here to avoid an import cycle.
-func (r *Registry) SetSupervisor(id string, sup any) error {
+func (r *Registry) SetSupervisor(id uuid.UUID, sup any) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.plugins[id]
 	if !ok {
-		return fmt.Errorf("plugin %q not registered", id)
+		return fmt.Errorf("plugin %s not registered", id)
 	}
 	e.Supervisor = sup
 	return nil
 }
 
 // SetManifest stores the manifest a plugin returned from RegisterPlugin.
-func (r *Registry) SetManifest(id string, m *pluginpb.PluginManifest) error {
+func (r *Registry) SetManifest(id uuid.UUID, m *pluginpb.PluginManifest) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e, ok := r.plugins[id]
 	if !ok {
-		return fmt.Errorf("plugin %q not registered", id)
+		return fmt.Errorf("plugin %s not registered", id)
 	}
 	e.Manifest = m
 	return nil
@@ -116,7 +125,7 @@ func (r *Registry) SetManifest(id string, m *pluginpb.PluginManifest) error {
 
 // Get returns the entry for the given plugin id, or nil if no plugin by that
 // id is registered.
-func (r *Registry) Get(id string) *Entry {
+func (r *Registry) Get(id uuid.UUID) *Entry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if e, ok := r.plugins[id]; ok {
@@ -136,40 +145,43 @@ func (r *Registry) Resolve(ref string) (*Entry, error) {
 		return nil, nil
 	}
 
-	if e, ok := r.plugins[ref]; ok {
-		return snapshotEntry(e), nil
+	if id, err := uuid.Parse(ref); err == nil {
+		if e, ok := r.plugins[id]; ok {
+			return snapshotEntry(e), nil
+		}
+		return nil, nil
 	}
 
 	if strings.Contains(ref, "/") {
-		if id := r.nsNameIndex[ref]; id != "" {
+		if id := r.refs[ref]; id != uuid.Nil {
 			return snapshotEntry(r.plugins[id]), nil
 		}
 		return nil, nil
 	}
 
-	ids := r.nameIndex[ref]
-	if len(ids) == 0 {
+	matches := make([]*Entry, 0, 1)
+	for _, e := range r.plugins {
+		if e.Name == ref {
+			matches = append(matches, e)
+		}
+	}
+	if len(matches) == 0 {
 		return nil, nil
 	}
-	if len(ids) > 1 {
-		matches := make([]string, 0, len(ids))
-		for id := range ids {
-			if e := r.plugins[id]; e != nil {
-				matches = append(matches, displayRef(e))
-			}
+	if len(matches) > 1 {
+		refs := make([]string, 0, len(matches))
+		for _, e := range matches {
+			refs = append(refs, displayRef(e))
 		}
-		sort.Strings(matches)
-		return nil, fmt.Errorf("%w %q; use plugin id or namespace/name, matches: %s", ErrAmbiguousPlugin, ref, strings.Join(matches, ", "))
+		sort.Strings(refs)
+		return nil, fmt.Errorf("%w %q; use plugin id or namespace/name, matches: %s", ErrAmbiguousPlugin, ref, strings.Join(refs, ", "))
 	}
-	for id := range ids {
-		return snapshotEntry(r.plugins[id]), nil
-	}
-	return nil, nil
+	return snapshotEntry(matches[0]), nil
 }
 
 // Remove drops a plugin from the registry. Callers are responsible for
 // stopping the supervisor first.
-func (r *Registry) Remove(id string) {
+func (r *Registry) Remove(id uuid.UUID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if e, ok := r.plugins[id]; ok {
@@ -193,46 +205,27 @@ func (r *Registry) addIndexes(e *Entry) {
 	if e.Name == "" {
 		return
 	}
-	ids := r.nameIndex[e.Name]
-	if ids == nil {
-		ids = map[string]struct{}{}
-		r.nameIndex[e.Name] = ids
-	}
-	ids[e.ID] = struct{}{}
-	if e.Namespace != "" {
-		r.nsNameIndex[namespacedName(e.Namespace, e.Name)] = e.ID
-	}
+	r.refs[namespacedName(e.Namespace, e.Name)] = e.ID
 }
 
 func (r *Registry) removeIndexes(e *Entry) {
 	if e.Name == "" {
 		return
 	}
-	if ids := r.nameIndex[e.Name]; ids != nil {
-		delete(ids, e.ID)
-		if len(ids) == 0 {
-			delete(r.nameIndex, e.Name)
-		}
-	}
-	if e.Namespace != "" {
-		key := namespacedName(e.Namespace, e.Name)
-		if r.nsNameIndex[key] == e.ID {
-			delete(r.nsNameIndex, key)
-		}
+	ref := namespacedName(e.Namespace, e.Name)
+	if r.refs[ref] == e.ID {
+		delete(r.refs, ref)
 	}
 }
 
 func namespacedName(namespace, name string) string {
-	if namespace == "" {
-		return name
-	}
 	return namespace + "/" + name
 }
 
 func displayRef(e *Entry) string {
 	ref := namespacedName(e.Namespace, e.Name)
 	if ref == "" {
-		return e.ID
+		return e.ID.String()
 	}
 	return ref
 }

--- a/plugin/supervisor/supervisor.go
+++ b/plugin/supervisor/supervisor.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/google/uuid"
 	goplugin "github.com/hashicorp/go-plugin"
 
 	dutyContext "github.com/flanksource/duty/context"
@@ -31,6 +32,7 @@ var pluginMap = map[string]goplugin.Plugin{
 
 // Supervisor owns the lifecycle of one plugin process.
 type Supervisor struct {
+	ID         uuid.UUID
 	Name       string
 	BinaryPath string
 
@@ -60,8 +62,8 @@ const (
 )
 
 // New creates a Supervisor for a plugin binary.
-func New(name, binaryPath string) *Supervisor {
-	return &Supervisor{Name: name, BinaryPath: binaryPath}
+func New(id uuid.UUID, binaryPath string) *Supervisor {
+	return &Supervisor{ID: id, Name: id.String(), BinaryPath: binaryPath}
 }
 
 // Start launches the plugin process and completes the RegisterPlugin
@@ -134,11 +136,11 @@ func (s *Supervisor) Start(ctx dutyContext.Context, startHost func(broker *goplu
 	s.manifest = manifest
 	s.startHost = startHost
 
-	if err := registry.Default.SetManifest(s.Name, manifest); err != nil {
+	if err := registry.Default.SetManifest(s.ID, manifest); err != nil {
 		// Not fatal — the registry might have been recreated, but the supervisor still works.
 		ctx.Logger.Warnf("plugin %s: register manifest: %v", s.Name, err)
 	}
-	if err := registry.Default.SetSupervisor(s.Name, s); err != nil {
+	if err := registry.Default.SetSupervisor(s.ID, s); err != nil {
 		ctx.Logger.Warnf("plugin %s: register supervisor: %v", s.Name, err)
 	}
 

--- a/plugin/supervisor/wire.go
+++ b/plugin/supervisor/wire.go
@@ -26,64 +26,68 @@ var (
 // the supervisor package (that would create an import cycle); this function
 // injects the start/stop callbacks at boot.
 func Wire(ctx dutyContext.Context) {
-	registry.SupervisorStarter = func(c dutyContext.Context, name string) error {
-		return startPlugin(c, name)
+	registry.SupervisorStarter = func(c dutyContext.Context, id string) error {
+		return startPlugin(c, id)
 	}
-	registry.SupervisorStopper = func(name string) error {
-		return stopPlugin(name)
+	registry.SupervisorStopper = func(id string) error {
+		return stopPlugin(id)
 	}
 }
 
-func startPlugin(ctx dutyContext.Context, name string) error {
-	binPath := registry.BinaryPathFor(name)
-	svc := host.New(ctx, name)
+func startPlugin(ctx dutyContext.Context, id string) error {
+	entry := registry.Default.Get(id)
+	if entry == nil {
+		return fmt.Errorf("plugin %s: not registered", id)
+	}
+	binPath := registry.BinaryPathFor(entry.Name)
+	svc := host.New(ctx, id)
 
 	// startHost is invoked after Dispense() so the broker is live. It opens
 	// a listener on the broker, starts a gRPC server for this plugin's
 	// HostService, and returns the broker id so the supervisor can pass it
 	// to the plugin in RegisterPlugin.
 	startHost := func(broker *goplugin.GRPCBroker) (uint32, error) {
-		id := broker.NextId()
+		brokerID := broker.NextId()
 		go func() {
-			lis, err := broker.Accept(id)
+			lis, err := broker.Accept(brokerID)
 			if err != nil {
-				ctx.Logger.Errorf("plugin %s: host broker accept: %v", name, err)
+				ctx.Logger.Errorf("plugin %s: host broker accept: %v", id, err)
 				return
 			}
 			s := adapter.GRPCServerFactory(nil)
 			svc.Register(s)
 			if err := s.Serve(lis); err != nil {
-				ctx.Logger.Debugf("plugin %s: host server stopped: %v", name, err)
+				ctx.Logger.Debugf("plugin %s: host server stopped: %v", id, err)
 			}
 		}()
-		return id, nil
+		return brokerID, nil
 	}
 
 	mu.Lock()
-	if active[name] != nil {
+	if active[id] != nil {
 		mu.Unlock()
 		return nil
 	}
-	sup := New(name, binPath)
-	active[name] = sup
+	sup := New(id, binPath)
+	active[id] = sup
 	mu.Unlock()
 
 	if err := sup.Start(ctx, startHost); err != nil {
 		mu.Lock()
-		if active[name] == sup {
-			delete(active, name)
+		if active[id] == sup {
+			delete(active, id)
 		}
 		mu.Unlock()
-		return fmt.Errorf("plugin %s: start supervisor: %w", name, err)
+		return fmt.Errorf("plugin %s: start supervisor: %w", id, err)
 	}
 
 	return nil
 }
 
-func stopPlugin(name string) error {
+func stopPlugin(id string) error {
 	mu.Lock()
-	sup := active[name]
-	delete(active, name)
+	sup := active[id]
+	delete(active, id)
 	mu.Unlock()
 	if sup != nil {
 		sup.Stop()
@@ -91,10 +95,10 @@ func stopPlugin(name string) error {
 	return nil
 }
 
-// LookupSupervisor returns the running supervisor for a named plugin, or
-// nil if the plugin is not running. Used by the echo handlers and CLI.
-func LookupSupervisor(name string) *Supervisor {
+// LookupSupervisor returns the running supervisor for a plugin id, or nil if
+// the plugin is not running. Used by the echo handlers and CLI.
+func LookupSupervisor(id string) *Supervisor {
 	mu.Lock()
 	defer mu.Unlock()
-	return active[name]
+	return active[id]
 }

--- a/plugin/supervisor/wire.go
+++ b/plugin/supervisor/wire.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	dutyContext "github.com/flanksource/duty/context"
+	"github.com/google/uuid"
 	goplugin "github.com/hashicorp/go-plugin"
 
 	"github.com/flanksource/incident-commander/plugin/adapter"
@@ -16,7 +17,7 @@ import (
 // on CRD delete.
 var (
 	mu     sync.Mutex
-	active = map[string]*Supervisor{}
+	active = map[uuid.UUID]*Supervisor{}
 )
 
 // Wire installs the supervisor as the registry's start/stop hook.
@@ -26,15 +27,15 @@ var (
 // the supervisor package (that would create an import cycle); this function
 // injects the start/stop callbacks at boot.
 func Wire(ctx dutyContext.Context) {
-	registry.SupervisorStarter = func(c dutyContext.Context, id string) error {
+	registry.SupervisorStarter = func(c dutyContext.Context, id uuid.UUID) error {
 		return startPlugin(c, id)
 	}
-	registry.SupervisorStopper = func(id string) error {
+	registry.SupervisorStopper = func(id uuid.UUID) error {
 		return stopPlugin(id)
 	}
 }
 
-func startPlugin(ctx dutyContext.Context, id string) error {
+func startPlugin(ctx dutyContext.Context, id uuid.UUID) error {
 	entry := registry.Default.Get(id)
 	if entry == nil {
 		return fmt.Errorf("plugin %s: not registered", id)
@@ -84,7 +85,7 @@ func startPlugin(ctx dutyContext.Context, id string) error {
 	return nil
 }
 
-func stopPlugin(id string) error {
+func stopPlugin(id uuid.UUID) error {
 	mu.Lock()
 	sup := active[id]
 	delete(active, id)
@@ -97,7 +98,7 @@ func stopPlugin(id string) error {
 
 // LookupSupervisor returns the running supervisor for a plugin id, or nil if
 // the plugin is not running. Used by the echo handlers and CLI.
-func LookupSupervisor(id string) *Supervisor {
+func LookupSupervisor(id uuid.UUID) *Supervisor {
 	mu.Lock()
 	defer mu.Unlock()
 	return active[id]


### PR DESCRIPTION
Plugin CRDs are namespaced, so multiple plugin instances can share the same `metadata.name`.

The registry and supervisor were still keyed by plugin name, which meant same-name plugins in different namespaces could overwrite each other or route operation, UI proxy, and host connection lookups to the wrong process.

Use the Plugin UID as the internal runtime key across the registry, supervisor, and host service. Name-based HTTP/UI routes remain unchanged; incoming names are resolved to an ID internally, and exact `namespace/name` refs are tracked separately.

Connection resolution still runs with the plugin CRD namespace, so unqualified connection refs resolve in the plugin's namespace.
