### PR TITLE
feat(plugins): add postgres connection status plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ plugins-ui: $(LOCALBIN)/pnpm ## Build embedded plugin UI bundles
 .PHONY: build-plugins
 build-plugins: plugins-ui
 	make -C plugins/kubernetes-logs build
+	make -C plugins/postgres build
 
 .PHONY: test
 test:

--- a/plugins/postgres/Makefile
+++ b/plugins/postgres/Makefile
@@ -1,0 +1,18 @@
+PLUGIN_NAME := postgres
+PLUGIN_PATH ?= $(MISSION_CONTROL_PLUGIN_PATH)
+PLUGIN_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+VERSION ?= dev
+BUILD_DATE := $(shell date "+%Y-%m-%d %H:%M:%S")
+
+.PHONY: build
+build:
+	@test -n "$(PLUGIN_PATH)" || (echo "MISSION_CONTROL_PLUGIN_PATH is required"; exit 1)
+	mkdir -p "$(PLUGIN_PATH)"
+	go build \
+		-ldflags "-X 'main.Version=$(VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" \
+		-o "$(PLUGIN_PATH)/$(PLUGIN_NAME)" \
+		"$(PLUGIN_DIR)"
+
+.PHONY: install
+install: build
+	kubectl apply -f "$(PLUGIN_DIR)/Plugin.yaml"

--- a/plugins/postgres/Plugin.yaml
+++ b/plugins/postgres/Plugin.yaml
@@ -1,0 +1,12 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Plugin
+metadata:
+  name: postgres
+spec:
+  source: postgres
+  selector:
+    types:
+      - MissionControl::Connection
+  connections:
+    types:
+      postgres: connection://mc/mission-control

--- a/plugins/postgres/README.md
+++ b/plugins/postgres/README.md
@@ -1,0 +1,33 @@
+# Postgres Plugin
+
+Shows connection state metrics from PostgreSQL `pg_stat_activity`.
+
+## Operation
+
+`connection_status` returns:
+
+```json
+{
+  "Idle": 12,
+  "Active": 3,
+  "Unknown": 1
+}
+```
+
+`Unknown` includes every state other than `idle` and `active`, including `idle in transaction`, `disabled`, and null states.
+
+## Build & install
+
+Update `Plugin.yaml` to point `spec.connections.types.postgres` at your Postgres connection, then:
+
+```sh
+mkdir -p $MISSION_CONTROL_PLUGIN_PATH
+make -C plugins/postgres build
+kubectl apply -f plugins/postgres/Plugin.yaml
+```
+
+## CLI
+
+```sh
+mission-control plugin postgres connection_status
+```

--- a/plugins/postgres/connection.go
+++ b/plugins/postgres/connection.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+func openPostgres(ctx context.Context, host sdk.HostClient, configItemID string) (*sql.DB, error) {
+	if host == nil {
+		return nil, fmt.Errorf("host client is unavailable")
+	}
+
+	var conn *pluginpb.ResolvedConnection
+	var err error
+	if configItemID != "" {
+		conn, err = host.GetConnectionForConfig(ctx, configItemID)
+	} else {
+		conn, err = host.GetConnectionByType(ctx, sdk.ConnectionTypePostgres)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if conn == nil {
+		return nil, fmt.Errorf("postgres connection was not resolved")
+	}
+
+	dsn, err := postgresDSN(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres connection: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	db.SetConnMaxLifetime(time.Minute)
+	return db, nil
+}
+
+func postgresDSN(conn *pluginpb.ResolvedConnection) (string, error) {
+	if strings.TrimSpace(conn.Url) != "" {
+		return conn.Url, nil
+	}
+
+	props := map[string]any{}
+	if conn.Properties != nil {
+		props = conn.Properties.AsMap()
+	}
+
+	host := stringProp(props, "host", "localhost")
+	database := stringProp(props, "database", "postgres")
+	if !strings.Contains(host, ":") {
+		if port := stringProp(props, "port", ""); port != "" {
+			host = net.JoinHostPort(host, port)
+		}
+	}
+
+	u := &url.URL{Scheme: "postgres", Host: host, Path: database}
+	if conn.Username != "" || conn.Password != "" {
+		u.User = url.UserPassword(conn.Username, conn.Password)
+	}
+
+	q := u.Query()
+	if boolProp(props, "insecure_tls") || boolProp(props, "insecureTLS") {
+		q.Set("sslmode", "disable")
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func stringProp(props map[string]any, key, fallback string) string {
+	if v, ok := props[key]; ok {
+		s := strings.TrimSpace(fmt.Sprint(v))
+		if s != "" {
+			return s
+		}
+	}
+	return fallback
+}
+
+func boolProp(props map[string]any, key string) bool {
+	if v, ok := props[key]; ok {
+		switch val := v.(type) {
+		case bool:
+			return val
+		case string:
+			return strings.EqualFold(val, "true") || val == "1"
+		default:
+			return strings.EqualFold(fmt.Sprint(val), "true") || fmt.Sprint(val) == "1"
+		}
+	}
+	return false
+}

--- a/plugins/postgres/main.go
+++ b/plugins/postgres/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"io/fs"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+//go:embed all:ui
+var uiAssets embed.FS
+
+var (
+	Version   = ""
+	BuildDate = ""
+)
+
+func main() {
+	sub, err := fs.Sub(uiAssets, "ui")
+	if err != nil {
+		panic(err)
+	}
+	sdk.Serve(&PostgresPlugin{}, sdk.WithStaticAssets(sub))
+}
+
+type PostgresPlugin struct{}
+
+func (p *PostgresPlugin) Manifest() *pluginpb.PluginManifest {
+	return &pluginpb.PluginManifest{
+		Name:         "postgres",
+		Version:      sdk.FormatVersion(Version, BuildDate, ""),
+		Description:  "Postgres activity metrics from pg_stat_activity.",
+		Capabilities: []string{"operations"},
+		Tabs: []*pluginpb.TabSpec{
+			{Name: "Postgres", Icon: "lucide:database", Path: "/", Scope: "global"},
+		},
+	}
+}
+
+func (p *PostgresPlugin) Configure(_ context.Context, _ map[string]any) error {
+	return nil
+}
+
+func (p *PostgresPlugin) Operations() []sdk.Operation {
+	return []sdk.Operation{
+		{
+			Def: &pluginpb.OperationDef{
+				Name:        "connection_status",
+				Description: "Count Postgres connections by active, idle, and unknown state using pg_stat_activity.",
+				Scope:       "global",
+				ResultMime:  sdk.ClickyResultMimeType,
+			},
+			Handler: p.connectionStatus,
+		},
+	}
+}

--- a/plugins/postgres/status.go
+++ b/plugins/postgres/status.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+type ConnectionStatus struct {
+	Idle    int `json:"Idle"`
+	Active  int `json:"Active"`
+	Unknown int `json:"Unknown"`
+}
+
+func (p *PostgresPlugin) connectionStatus(ctx context.Context, req sdk.InvokeCtx) (any, error) {
+	db, err := openPostgres(ctx, req.Host, req.ConfigItemID)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	rows, err := db.QueryContext(queryCtx, `
+		SELECT COALESCE(state, 'unknown') AS state, count(*)::int AS connections
+		FROM pg_stat_activity
+		WHERE pid <> pg_backend_pid()
+		GROUP BY COALESCE(state, 'unknown')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query pg_stat_activity: %w", err)
+	}
+	defer rows.Close()
+
+	var status ConnectionStatus
+	for rows.Next() {
+		var state string
+		var count int
+		if err := rows.Scan(&state, &count); err != nil {
+			return nil, fmt.Errorf("scan pg_stat_activity: %w", err)
+		}
+		switch strings.ToLower(state) {
+		case "idle":
+			status.Idle += count
+		case "active":
+			status.Active += count
+		default:
+			status.Unknown += count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read pg_stat_activity: %w", err)
+	}
+
+	return status, nil
+}

--- a/plugins/postgres/ui/index.html
+++ b/plugins/postgres/ui/index.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Postgres Connection Status</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: transparent;
+        color: CanvasText;
+      }
+      body {
+        margin: 0;
+      }
+      .wrap {
+        min-height: 100vh;
+        box-sizing: border-box;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+      }
+      .card {
+        width: min(720px, 100%);
+        border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+        border-radius: 16px;
+        padding: 24px;
+        background: color-mix(in srgb, Canvas 92%, transparent);
+        box-shadow: 0 10px 30px color-mix(in srgb, CanvasText 8%, transparent);
+      }
+      .header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .title {
+        margin: 0 0 4px;
+        font-size: 18px;
+        font-weight: 650;
+      }
+      .refresh {
+        border: 1px solid color-mix(in srgb, CanvasText 16%, transparent);
+        border-radius: 10px;
+        background: color-mix(in srgb, CanvasText 5%, transparent);
+        color: CanvasText;
+        cursor: pointer;
+        font: inherit;
+        font-size: 13px;
+        padding: 8px 12px;
+      }
+      .refresh:hover:not(:disabled) {
+        background: color-mix(in srgb, CanvasText 9%, transparent);
+      }
+      .refresh:disabled {
+        cursor: wait;
+        opacity: 0.65;
+      }
+      .subtitle {
+        margin: 0 0 24px;
+        color: color-mix(in srgb, CanvasText 62%, transparent);
+        font-size: 13px;
+      }
+      .content {
+        display: grid;
+        grid-template-columns: 260px 1fr;
+        gap: 28px;
+        align-items: center;
+      }
+      .chart {
+        width: 240px;
+        height: 240px;
+        border-radius: 50%;
+        background: conic-gradient(#22c55e 0deg, #22c55e var(--active), #64748b var(--active), #64748b var(--idle), #f59e0b var(--idle), #f59e0b 360deg);
+        position: relative;
+      }
+      .chart::after {
+        content: attr(data-total);
+        position: absolute;
+        inset: 48px;
+        display: grid;
+        place-items: center;
+        border-radius: 50%;
+        background: Canvas;
+        font-size: 34px;
+        font-weight: 750;
+      }
+      .legend {
+        display: grid;
+        gap: 12px;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 14px 1fr auto;
+        gap: 10px;
+        align-items: center;
+        padding: 10px 12px;
+        border-radius: 10px;
+        background: color-mix(in srgb, CanvasText 5%, transparent);
+      }
+      .swatch {
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+      }
+      .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 700;
+      }
+      .error {
+        color: #ef4444;
+        white-space: pre-wrap;
+      }
+      @media (max-width: 640px) {
+        .content {
+          grid-template-columns: 1fr;
+          justify-items: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <section class="card">
+        <div class="header">
+          <div>
+            <h1 class="title">Postgres connection status</h1>
+            <p class="subtitle" id="subtitle">Loading pg_stat_activity…</p>
+          </div>
+          <button class="refresh" id="refresh" type="button">Refresh</button>
+        </div>
+        <div id="app"></div>
+      </section>
+    </main>
+
+    <script>
+      const app = document.getElementById("app");
+      const subtitle = document.getElementById("subtitle");
+      const refresh = document.getElementById("refresh");
+
+      function render(data) {
+        const idle = Number(data.Idle || data.idle || 0);
+        const active = Number(data.Active || data.active || 0);
+        const unknown = Number(data.Unknown || data.unknown || 0);
+        const total = idle + active + unknown;
+        const activeDeg = total ? (active / total) * 360 : 0;
+        const idleDeg = total ? activeDeg + (idle / total) * 360 : 0;
+
+        subtitle.textContent = "Current sessions grouped from pg_stat_activity";
+        app.innerHTML = `
+          <div class="content">
+            <div class="chart" data-total="${total}" style="--active:${activeDeg}deg; --idle:${idleDeg}deg" title="${total} total connections"></div>
+            <div class="legend">
+              ${row("#22c55e", "Active", active)}
+              ${row("#64748b", "Idle", idle)}
+              ${row("#f59e0b", "Unknown", unknown)}
+            </div>
+          </div>
+        `;
+      }
+
+      function row(color, label, value) {
+        return `<div class="row"><span class="swatch" style="background:${color}"></span><span>${label}</span><span class="value">${value}</span></div>`;
+      }
+
+      async function load() {
+        refresh.disabled = true;
+        try {
+          const res = await fetch("/api/plugins/postgres/invoke/connection_status", {
+            method: "POST",
+            body: "{}",
+            headers: { "Content-Type": "application/json" },
+            credentials: "same-origin",
+          });
+          if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+          render(await res.json());
+        } catch (err) {
+          subtitle.textContent = "Failed to load connection status";
+          app.innerHTML = `<div class="error"></div>`;
+          app.querySelector(".error").textContent = err instanceof Error ? err.message : String(err);
+        } finally {
+          refresh.disabled = false;
+          window.parent?.postMessage({ type: "mc.tab.ready" }, "*");
+        }
+      }
+
+      refresh.addEventListener("click", load);
+      load();
+      setInterval(load, 30000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a Postgres plugin that resolves a configured Postgres connection and exposes a `connection_status` operation backed by `pg_stat_activity`.

The operation returns active, idle, and unknown connection counts while excluding the plugin's own backend session. It also includes a simple embedded UI tab that renders the counts as a pie chart with manual and periodic refresh.