### PR TITLE
feat: record plugin invocations as config changes

### DIFF
--- a/api/v1/plugin_types.go
+++ b/api/v1/plugin_types.go
@@ -57,6 +57,14 @@ type PluginSpec struct {
 	//+kubebuilder:validation:Optional
 	Connections PluginConnectionMappings `json:"connections,omitempty"`
 
+	// Audit selects plugin operations whose invocations should be recorded as
+	// catalog config changes. Each entry is matched against the operation name
+	// using Mission Control match expressions: exact names, wildcards such as
+	// "*" or "logs-*", and negations such as "!debug". When omitted or empty,
+	// plugin invocations are not recorded as changes.
+	//+kubebuilder:validation:Optional
+	Audit []string `json:"audit,omitempty"`
+
 	// Properties are arbitrary key/value settings forwarded to the plugin
 	// via the Configure() RPC at startup. Use this for plugin-specific
 	// configuration that doesn't fit any of the other fields.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -3480,6 +3480,11 @@ func (in *PluginSpec) DeepCopyInto(out *PluginSpec) {
 	*out = *in
 	in.Selector.DeepCopyInto(&out.Selector)
 	in.Connections.DeepCopyInto(&out.Connections)
+	if in.Audit != nil {
+		in, out := &in.Audit, &out.Audit
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Properties != nil {
 		in, out := &in.Properties, &out.Properties
 		*out = make(map[string]string, len(*in))

--- a/config/crds/mission-control.flanksource.com_plugins.yaml
+++ b/config/crds/mission-control.flanksource.com_plugins.yaml
@@ -45,6 +45,16 @@ spec:
               iframed into the catalog detail page, and operations that are exposed
               over the HTTP API and as CLI subcommands.
             properties:
+              audit:
+                description: |-
+                  Audit selects plugin operations whose invocations should be recorded as
+                  catalog config changes. Each entry is matched against the operation name
+                  using Mission Control match expressions: exact names, wildcards such as
+                  "*" or "logs-*", and negations such as "!debug". When omitted or empty,
+                  plugin invocations are not recorded as changes.
+                items:
+                  type: string
+                type: array
               checksum:
                 description: |-
                   Checksum optionally pins the downloaded binary to a known good hash.

--- a/fixtures/plugins/kubernetes.yaml
+++ b/fixtures/plugins/kubernetes.yaml
@@ -1,0 +1,18 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Plugin
+metadata:
+  name: kubernetes-logs
+spec:
+  source: kubernetes-logs
+  version: "0.1.0"
+  selector:
+    types:
+      - Kubernetes::Pod
+      - Kubernetes::Deployment
+      - Kubernetes::StatefulSet
+      - Kubernetes::DaemonSet
+      - Kubernetes::ReplicaSet
+      - Kubernetes::Job
+      - Kubernetes::CronJob
+  audit:
+    - "*"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.34.0 // indirect
 	github.com/flanksource/commons v1.51.4
-	github.com/flanksource/duty v1.0.1307
+	github.com/flanksource/duty v1.0.1308
 	github.com/flanksource/gomplate/v3 v3.24.79
 	github.com/flanksource/kopper v1.0.22
 	github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFE
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
 github.com/flanksource/deps v1.0.28 h1:mm7l7WjzLbkj2aFrgnlMaRizp+j+0x22TvtwXzRlFtE=
 github.com/flanksource/deps v1.0.28/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
-github.com/flanksource/duty v1.0.1307 h1:5wmA2uHo9oi0T6EfiZ4/dtMMsVmZ6vZ2bJ/l8boIVPs=
-github.com/flanksource/duty v1.0.1307/go.mod h1:aH4xdGF3brwBiOKUEFsspgu8U7tBiJOZDXrEqB3OMtc=
+github.com/flanksource/duty v1.0.1308 h1:R0TdDfmIjEI5Na9GVO3G/E66jkn7TqyfD5LzgGWQn90=
+github.com/flanksource/duty v1.0.1308/go.mod h1:aH4xdGF3brwBiOKUEFsspgu8U7tBiJOZDXrEqB3OMtc=
 github.com/flanksource/gomplate/v3 v3.24.79 h1:T5Ls0tjsnDhcV/dQWjrm2UpHiwOhytDLmYDSF0O6p3Q=
 github.com/flanksource/gomplate/v3 v3.24.79/go.mod h1:RzIg+YwNQI0eUV61LtqmhNN2Qw8ebm1cGa6IhNQmkWE=
 github.com/flanksource/is-healthy v1.0.87 h1:wSK9wI9tu//gdKO9JxyZe8ZQ5H7MCpwG17KdbWaiMeM=

--- a/plugin/controller/controller.go
+++ b/plugin/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/flanksource/duty/query"
 	dutyRBAC "github.com/flanksource/duty/rbac"
 	"github.com/flanksource/duty/rbac/policy"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
 	"google.golang.org/grpc/metadata"
@@ -104,17 +105,24 @@ func InvokeOperation(c echo.Context) error {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q operation %q not found", pluginRef, op))
 	}
 
-	sup := supervisor.LookupSupervisor(entry.ID)
-	if sup == nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", pluginRef))
-	}
-
 	configID := c.QueryParam("config_id")
-	if configID != "" && !selectorMatches(ctx, entry, configID) {
+	if configID == "" {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is required"))
+	}
+	configUUID, err := uuid.Parse(configID)
+	if err != nil {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is invalid"))
+	}
+	if !selectorMatches(ctx, entry, configID) {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
 	}
 	if err := enforcePluginInvokePermission(ctx, entry, op, configID); err != nil {
 		return dutyAPI.WriteError(c, err)
+	}
+
+	sup := supervisor.LookupSupervisor(entry.ID)
+	if sup == nil {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", pluginRef))
 	}
 
 	body, err := io.ReadAll(c.Request().Body)
@@ -136,6 +144,7 @@ func InvokeOperation(c echo.Context) error {
 	// token on HostService callbacks so Mission Control can verify the actor.
 	invokeCtx = metadata.AppendToOutgoingContext(invokeCtx, plugin.InvocationTokenGRPCMetadataKey, invocationToken)
 
+	paramsHash := hashBytes(body)
 	resp, err := sup.Invoke(invokeCtx, &pluginpb.InvokeRequest{
 		Operation:    op,
 		ParamsJson:   body,
@@ -143,11 +152,15 @@ func InvokeOperation(c echo.Context) error {
 		Caller:       caller,
 	})
 	if err != nil {
+		recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, err.Error(), c.Request(), body)
 		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "plugin %s/%s", pluginRef, op))
 	}
 	if resp.ErrorMessage != "" {
+		recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, resp.ErrorMessage, c.Request(), body)
 		return dutyAPI.WriteError(c, ctx.Oops().Code(resp.ErrorCode).Errorf("%s", resp.ErrorMessage))
 	}
+
+	recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, "", c.Request(), body)
 
 	mime := resp.Mime
 	if mime == "" {

--- a/plugin/controller/invocation_audit.go
+++ b/plugin/controller/invocation_audit.go
@@ -1,0 +1,249 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/incident-commander/plugin/registry"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	changeTypePluginInvocation = "InvokePlugin"
+	defaultDedupeWindow        = time.Hour
+)
+
+var initChangeCacheOnce sync.Once
+
+type invocationChangeInput struct {
+	Entry       registry.Entry
+	Operation   string
+	ConfigID    uuid.UUID
+	User        models.Person
+	Source      string
+	Method      string
+	ParamsHash  string
+	Error       string
+	RequestBody []byte
+	QueryParams url.Values
+}
+
+func recordPluginInvocation(ctx dutyContext.Context, entry *registry.Entry, op string, configID uuid.UUID, source, method, paramsHash, errorMessage string, req *http.Request, requestBody []byte) {
+	user := models.Person{}
+	if ctx.User() != nil {
+		user = *ctx.User()
+	}
+
+	if err := recordInvocationChange(ctx, invocationChangeInput{
+		Entry:       *entry,
+		Operation:   op,
+		ConfigID:    configID,
+		User:        user,
+		Source:      source,
+		Method:      method,
+		ParamsHash:  paramsHash,
+		Error:       errorMessage,
+		RequestBody: requestBody,
+		QueryParams: requestQueryParams(req),
+	}); err != nil {
+		ctx.Logger.Warnf("record plugin invocation config change: %v", err)
+	}
+}
+
+func recordInvocationChange(ctx dutyContext.Context, in invocationChangeInput) error {
+	change, err := buildInvocationConfigChange(ctx, in)
+	if err != nil {
+		return err
+	}
+
+	window := ctx.Properties().Duration("changes.dedup.window", defaultDedupeWindow)
+	initChangeCacheOnce.Do(func() {
+		if err := models.InitChangeFingerprintCache(ctx.DB(), window); err != nil {
+			ctx.Logger.Warnf("init config change fingerprint cache: %v", err)
+		}
+	})
+
+	nonDuped, deduped := models.DedupConfigChanges(window, []*models.ConfigChange{change})
+	for _, c := range nonDuped {
+		if err := ctx.DB().Create(c).Error; err != nil {
+			return ctx.Oops().Wrapf(err, "record plugin invocation config change")
+		}
+	}
+	for _, d := range deduped {
+		if err := updateDedupedChange(ctx, d).Error; err != nil {
+			return ctx.Oops().With("change_id", d.Change.ID).Wrapf(err, "update deduped plugin invocation config change")
+		}
+	}
+
+	return nil
+}
+
+func buildInvocationConfigChange(ctx dutyContext.Context, in invocationChangeInput) (*models.ConfigChange, error) {
+	if in.ParamsHash == "" {
+		in.ParamsHash = hashBytes(nil)
+	}
+	detailsJSON, err := json.Marshal(invocationDetails(in))
+	if err != nil {
+		return nil, ctx.Oops().Wrapf(err, "marshal plugin invocation details")
+	}
+
+	createdAt := time.Now()
+	fingerprint := invocationFingerprint(in.Entry.ID.String(), in.Operation, invocationUserID(in.User), in.ParamsHash)
+	change := &models.ConfigChange{
+		ID:          uuid.New().String(),
+		ConfigID:    in.ConfigID.String(),
+		ChangeType:  changeTypePluginInvocation,
+		Severity:    models.SeverityInfo,
+		Source:      invocationPluginSource(in.Entry),
+		Summary:     invocationSummary(in),
+		Fingerprint: &fingerprint,
+		Details:     types.JSON(detailsJSON),
+		CreatedAt:   &createdAt,
+		Count:       1,
+		IsPushed:    false,
+	}
+	if in.User.ID != uuid.Nil {
+		change.CreatedBy = &in.User.ID
+	}
+	return change, nil
+}
+
+func updateDedupedChange(ctx dutyContext.Context, dedup models.ConfigChangeUpdate) *gorm.DB {
+	change := dedup.Change
+	update := map[string]any{
+		"change_type":         change.ChangeType,
+		"count":               gorm.Expr("count + ?", dedup.CountIncrement),
+		"created_at":          change.CreatedAt,
+		"created_by":          change.CreatedBy,
+		"details":             change.Details,
+		"diff":                change.Diff,
+		"external_change_id":  change.ExternalChangeID,
+		"external_created_by": change.ExternalCreatedBy,
+		"fingerprint":         change.Fingerprint,
+		"inserted_at":         time.Now(),
+		"is_pushed":           false,
+		"severity":            change.Severity,
+		"source":              change.Source,
+		"summary":             change.Summary,
+	}
+	if change.Patches != "" {
+		update["patches"] = change.Patches
+	}
+	return ctx.DB().Model(&models.ConfigChange{}).Where("id = ?", change.ID).UpdateColumns(update)
+}
+
+func hashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func httpParamsHash(method string, values url.Values) string {
+	return hashBytes([]byte(strings.ToUpper(method) + "\n" + normalizedQueryParams(values).Encode()))
+}
+
+func normalizedQueryParams(values url.Values) url.Values {
+	copy := url.Values{}
+	for key, vals := range values {
+		if strings.EqualFold(key, "config_id") {
+			continue
+		}
+		sorted := append([]string(nil), vals...)
+		sort.Strings(sorted)
+		copy[key] = sorted
+	}
+	return copy
+}
+
+func invocationFingerprint(pluginID, operation, userID, paramsHash string) string {
+	return hashBytes([]byte(strings.Join([]string{pluginID, operation, userID, paramsHash}, "\x00")))
+}
+
+func invocationDetails(in invocationChangeInput) map[string]any {
+	pluginName := in.Entry.Name
+	if in.Entry.Manifest != nil && in.Entry.Manifest.Name != "" {
+		pluginName = in.Entry.Manifest.Name
+	}
+
+	details := map[string]any{
+		"plugin": map[string]any{
+			"id":        in.Entry.ID.String(),
+			"name":      pluginName,
+			"namespace": in.Entry.Namespace,
+		},
+		"operation": in.Operation,
+		"source":    in.Source,
+		"method":    in.Method,
+	}
+	if in.Error != "" {
+		details["error"] = in.Error
+	}
+
+	request := map[string]any{}
+	if in.Source == "http" && len(in.QueryParams) > 0 {
+		request["queryParam"] = in.QueryParams
+	} else if in.Source == "grpc" && len(in.RequestBody) > 0 {
+		request["body"] = requestBodyJSON(in.RequestBody)
+	}
+	if len(request) > 0 {
+		details["request"] = request
+	}
+
+	return details
+}
+
+func invocationUserID(user models.Person) string {
+	if user.ID == uuid.Nil {
+		return ""
+	}
+	return user.ID.String()
+}
+
+func invocationSummary(in invocationChangeInput) string {
+	return invocationPluginName(in.Entry) + "." + in.Operation
+}
+
+func invocationPluginName(entry registry.Entry) string {
+	if entry.Manifest != nil && entry.Manifest.Name != "" {
+		return entry.Manifest.Name
+	}
+	return entry.Name
+}
+
+func invocationPluginSource(entry registry.Entry) string {
+	parts := []string{"mission-control", "plugin"}
+	if entry.Namespace != "" {
+		parts = append(parts, entry.Namespace)
+	}
+	parts = append(parts, entry.Name)
+	return strings.Join(parts, "/")
+}
+
+func requestQueryParams(req *http.Request) url.Values {
+	if req == nil || req.URL == nil {
+		return url.Values{}
+	}
+	return normalizedQueryParams(req.URL.Query())
+}
+
+func requestBodyJSON(body []byte) any {
+	if len(body) == 0 {
+		return map[string]any{}
+	}
+
+	var out any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return string(body)
+	}
+	return out
+}

--- a/plugin/controller/invocation_audit.go
+++ b/plugin/controller/invocation_audit.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/flanksource/commons/collections"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
@@ -40,6 +41,10 @@ type invocationChangeInput struct {
 }
 
 func recordPluginInvocation(ctx dutyContext.Context, entry *registry.Entry, op string, configID uuid.UUID, source, method, paramsHash, errorMessage string, req *http.Request, requestBody []byte) {
+	if !pluginInvocationAudited(entry, op) {
+		return
+	}
+
 	user := models.Person{}
 	if ctx.User() != nil {
 		user = *ctx.User()
@@ -59,6 +64,15 @@ func recordPluginInvocation(ctx dutyContext.Context, entry *registry.Entry, op s
 	}); err != nil {
 		ctx.Logger.Warnf("record plugin invocation config change: %v", err)
 	}
+}
+
+func pluginInvocationAudited(entry *registry.Entry, op string) bool {
+	if entry == nil || len(entry.Spec.Audit) == 0 {
+		return false
+	}
+
+	matches, _ := collections.MatchItem(op, entry.Spec.Audit...)
+	return matches
 }
 
 func recordInvocationChange(ctx dutyContext.Context, in invocationChangeInput) error {

--- a/plugin/controller/proxy.go
+++ b/plugin/controller/proxy.go
@@ -10,6 +10,7 @@ import (
 	dutyAPI "github.com/flanksource/duty/api"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/rbac/policy"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
 
@@ -74,7 +75,14 @@ func operationHTTPProxy(c echo.Context) error {
 	}
 
 	configID := c.QueryParam("config_id")
-	if configID != "" && !selectorMatches(ctx, entry, configID) {
+	if configID == "" {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is required"))
+	}
+	configUUID, err := uuid.Parse(configID)
+	if err != nil {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is invalid"))
+	}
+	if !selectorMatches(ctx, entry, configID) {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
 	}
 	if err := enforcePluginInvokePermission(ctx, entry, op, configID); err != nil {
@@ -86,7 +94,14 @@ func operationHTTPProxy(c echo.Context) error {
 		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "mint plugin invocation token"))
 	}
 
-	return proxyToPluginOperation(c, entry, pluginRef, op, invocationToken)
+	paramsHash := httpParamsHash(c.Request().Method, c.QueryParams())
+	if err := proxyToPluginOperation(c, entry, pluginRef, op, invocationToken); err != nil {
+		return err
+	}
+
+	recordPluginInvocation(ctx, entry, op, configUUID, "http", c.Request().Method, paramsHash, "", c.Request(), nil)
+
+	return nil
 }
 
 func proxyToPluginUI(c echo.Context, entry *registry.Entry, pluginRef, prefix string) error {

--- a/plugin/controller/proxy_test.go
+++ b/plugin/controller/proxy_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"net/url"
 
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -24,5 +25,27 @@ var _ = ginkgo.Describe("plugin HTTP proxy", func() {
 		Expect(operationHTTPBindingAllowed(def, http.MethodGet)).To(BeTrue())
 		Expect(operationHTTPBindingAllowed(def, http.MethodPost)).To(BeFalse())
 		Expect(operationHTTPBindingAllowed(&pluginpb.OperationDef{}, http.MethodGet)).To(BeFalse())
+	})
+
+	ginkgo.It("excludes config_id and sorts query values for HTTP params hashes", func() {
+		left := url.Values{
+			"config_id": []string{"config-a"},
+			"level":     []string{"info"},
+			"pod":       []string{"b", "a"},
+		}
+		right := url.Values{
+			"config_id": []string{"config-b"},
+			"pod":       []string{"a", "b"},
+			"level":     []string{"info"},
+		}
+
+		Expect(httpParamsHash(http.MethodGet, left)).To(Equal(httpParamsHash(http.MethodGet, right)))
+		Expect(httpParamsHash(http.MethodPost, left)).ToNot(Equal(httpParamsHash(http.MethodGet, left)))
+	})
+
+	ginkgo.It("uses only stable fields for fingerprints", func() {
+		paramsHash := hashBytes([]byte(`{"pod":"api"}`))
+		Expect(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)).To(Equal(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)))
+		Expect(invocationFingerprint("plugin-id", "tail", "other-user", paramsHash)).ToNot(Equal(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)))
 	})
 })

--- a/plugin/controller/proxy_test.go
+++ b/plugin/controller/proxy_test.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 	"net/url"
 
+	v1 "github.com/flanksource/incident-commander/api/v1"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/registry"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -47,5 +49,14 @@ var _ = ginkgo.Describe("plugin HTTP proxy", func() {
 		paramsHash := hashBytes([]byte(`{"pod":"api"}`))
 		Expect(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)).To(Equal(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)))
 		Expect(invocationFingerprint("plugin-id", "tail", "other-user", paramsHash)).ToNot(Equal(invocationFingerprint("plugin-id", "tail", "user-id", paramsHash)))
+	})
+
+	ginkgo.It("audits invocation changes using plugin spec match expressions", func() {
+		Expect(pluginInvocationAudited(nil, "logs")).To(BeFalse())
+		Expect(pluginInvocationAudited(&registry.Entry{}, "logs")).To(BeFalse())
+		Expect(pluginInvocationAudited(&registry.Entry{Spec: v1.PluginSpec{Audit: []string{"logs"}}}, "logs")).To(BeTrue())
+		Expect(pluginInvocationAudited(&registry.Entry{Spec: v1.PluginSpec{Audit: []string{"logs"}}}, "exec")).To(BeFalse())
+		Expect(pluginInvocationAudited(&registry.Entry{Spec: v1.PluginSpec{Audit: []string{"*", "!debug"}}}, "exec")).To(BeTrue())
+		Expect(pluginInvocationAudited(&registry.Entry{Spec: v1.PluginSpec{Audit: []string{"*", "!debug"}}}, "debug")).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Plugin operation invocations should appear in catalog change history for the target config item.

resolves: https://github.com/flanksource/mission-control/issues/3068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin audit capability to record invocations as catalog config changes based on configurable match expressions.
  * Implemented invocation tracking with request hashing and fingerprinting for deduplication within a configurable time window.
  * Config ID is now required as a query parameter for plugin operations.

* **Tests**
  * Added tests for audit matching, invocation fingerprinting, and parameter hashing behavior.

* **Chores**
  * Updated dependency version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->