### PR TITLE
feat(plugin): Plugin to Plugin invocation

### DIFF
--- a/auth/plugin_invocation.go
+++ b/auth/plugin_invocation.go
@@ -46,14 +46,20 @@ func init() {
 type PluginInvocationClaims struct {
 	Plugin uuid.UUID `json:"pluginID"`
 	Type   string    `json:"typ"`
+	Depth  int       `json:"depth,omitempty"`
 	jwt.RegisteredClaims
 }
 
 func MintPluginInvocationToken(user models.Person, pluginID uuid.UUID) (string, error) {
+	return MintPluginInvocationTokenWithDepth(user, pluginID, 0)
+}
+
+func MintPluginInvocationTokenWithDepth(user models.Person, pluginID uuid.UUID, depth int) (string, error) {
 	now := time.Now()
 	claims := PluginInvocationClaims{
 		Plugin: pluginID,
 		Type:   pluginInvocationTokenType,
+		Depth:  depth,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    pluginInvocationTokenIssuer,
 			Subject:   user.ID.String(),

--- a/fixtures/plugins/kubernetes-logs.yaml
+++ b/fixtures/plugins/kubernetes-logs.yaml
@@ -1,0 +1,18 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Plugin
+metadata:
+  name: kubernetes-logs
+spec:
+  source: kubernetes-logs
+  version: "0.1.0"
+  selector:
+    types:
+      - Kubernetes::Pod
+      - Kubernetes::Deployment
+      - Kubernetes::StatefulSet
+      - Kubernetes::DaemonSet
+      - Kubernetes::ReplicaSet
+      - Kubernetes::Job
+      - Kubernetes::CronJob
+  audit:
+    - "*"

--- a/fixtures/plugins/kubernetes.yaml
+++ b/fixtures/plugins/kubernetes.yaml
@@ -1,18 +1,26 @@
 apiVersion: mission-control.flanksource.com/v1
 kind: Plugin
 metadata:
-  name: kubernetes-logs
+  name: kubernetes
+  namespace: default
 spec:
-  source: kubernetes-logs
+  source: kubernetes
   version: "0.1.0"
   selector:
     types:
-      - Kubernetes::Pod
-      - Kubernetes::Deployment
-      - Kubernetes::StatefulSet
-      - Kubernetes::DaemonSet
-      - Kubernetes::ReplicaSet
-      - Kubernetes::Job
-      - Kubernetes::CronJob
-  audit:
-    - "*"
+      - Kubernetes::Namespace
+---
+apiVersion: mission-control.flanksource.com/v1
+kind: Permission
+metadata:
+  name: allow-kubernetes-plugin-kubernetes-logs
+  namespace: default
+spec:
+  subject:
+    plugin: default/kubernetes
+  actions:
+    - invoke:kubernetes-logs:list-pods
+  object:
+    configs:
+      - types:
+          - Kubernetes::Namespace

--- a/plugin/controller/controller.go
+++ b/plugin/controller/controller.go
@@ -17,27 +17,21 @@ package controller
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
 
 	dutyAPI "github.com/flanksource/duty/api"
 	dutyContext "github.com/flanksource/duty/context"
-	"github.com/flanksource/duty/models"
-	"github.com/flanksource/duty/query"
-	dutyRBAC "github.com/flanksource/duty/rbac"
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/samber/lo"
-	"google.golang.org/grpc/metadata"
 
-	"github.com/flanksource/incident-commander/auth"
 	echoSrv "github.com/flanksource/incident-commander/echo"
-	"github.com/flanksource/incident-commander/plugin"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 	"github.com/flanksource/incident-commander/plugin/registry"
+	pluginruntime "github.com/flanksource/incident-commander/plugin/runtime"
 	"github.com/flanksource/incident-commander/plugin/supervisor"
 	"github.com/flanksource/incident-commander/rbac"
 )
@@ -76,7 +70,7 @@ func ListPlugins(c echo.Context) error {
 		if e.Manifest == nil {
 			continue
 		}
-		if configID != "" && !selectorMatches(ctx, e, configID) {
+		if configID != "" && !pluginruntime.SelectorMatches(ctx, e, configID) {
 			continue
 		}
 		out = append(out, PluginListing{
@@ -97,14 +91,6 @@ func InvokeOperation(c echo.Context) error {
 	pluginRef := c.Param("name")
 	op := c.Param("op")
 
-	entry, err := resolvePlugin(ctx, pluginRef)
-	if err != nil {
-		return dutyAPI.WriteError(c, err)
-	}
-	if operationDef(entry, op) == nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q operation %q not found", pluginRef, op))
-	}
-
 	configID := c.QueryParam("config_id")
 	if configID == "" {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is required"))
@@ -113,47 +99,28 @@ func InvokeOperation(c echo.Context) error {
 	if err != nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is invalid"))
 	}
-	if !selectorMatches(ctx, entry, configID) {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
-	}
-	if err := enforcePluginInvokePermission(ctx, entry, op, configID); err != nil {
-		return dutyAPI.WriteError(c, err)
-	}
-
-	sup := supervisor.LookupSupervisor(entry.ID)
-	if sup == nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", pluginRef))
-	}
 
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "read request body"))
 	}
 
-	invocationToken, err := auth.MintPluginInvocationToken(lo.FromPtr(ctx.User()), entry.ID)
-	if err != nil {
-		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "mint plugin invocation token"))
-	}
-
-	caller := callerFromCtx(ctx)
-	invokeCtx, cancel := context.WithTimeout(c.Request().Context(), 60*time.Second)
-	defer cancel()
-
-	// Like Set-Cookie in HTTP, Mission Control issues a short-lived invocation
-	// token to the plugin over gRPC metadata. The plugin SDK presents the same
-	// token on HostService callbacks so Mission Control can verify the actor.
-	invokeCtx = metadata.AppendToOutgoingContext(invokeCtx, plugin.InvocationTokenGRPCMetadataKey, invocationToken)
-
 	paramsHash := hashBytes(body)
-	resp, err := sup.Invoke(invokeCtx, &pluginpb.InvokeRequest{
+	resp, entry, err := pluginruntime.Invoke(ctx, pluginruntime.Request{
+		Context:      c.Request().Context(),
+		PluginRef:    pluginRef,
 		Operation:    op,
-		ParamsJson:   body,
-		ConfigItemId: configID,
-		Caller:       caller,
-	})
+		ConfigItemID: configID,
+		ParamsJSON:   body,
+		User:         ctx.User(),
+		Depth:        0,
+		Timeout:      60 * time.Second,
+	}, invokeViaSupervisor)
 	if err != nil {
-		recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, err.Error(), c.Request(), body)
-		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "plugin %s/%s", pluginRef, op))
+		if entry != nil {
+			recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, err.Error(), c.Request(), body)
+		}
+		return dutyAPI.WriteError(c, err)
 	}
 	if resp.ErrorMessage != "" {
 		recordPluginInvocation(ctx, entry, op, configUUID, "grpc", c.Request().Method, paramsHash, resp.ErrorMessage, c.Request(), body)
@@ -170,80 +137,10 @@ func InvokeOperation(c echo.Context) error {
 	return c.Blob(http.StatusOK, mime, resp.Result)
 }
 
-func resolvePlugin(ctx dutyContext.Context, ref string) (*registry.Entry, error) {
-	entry, err := registry.Default.Resolve(ref)
-	if err != nil {
-		if errors.Is(err, registry.ErrAmbiguousPlugin) {
-			return nil, ctx.Oops().Code(dutyAPI.ECONFLICT).Wrap(err)
-		}
-		return nil, ctx.Oops().Wrap(err)
+func invokeViaSupervisor(ctx context.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
+	sup := supervisor.LookupSupervisor(pluginID)
+	if sup == nil {
+		return nil, fmt.Errorf("plugin %s not running", pluginID)
 	}
-	if entry == nil {
-		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", ref)
-	}
-	return entry, nil
-}
-
-func operationDef(entry *registry.Entry, op string) *pluginpb.OperationDef {
-	if entry == nil || entry.Manifest == nil {
-		return nil
-	}
-	for _, def := range entry.Manifest.Operations {
-		if def != nil && def.Name == op {
-			return def
-		}
-	}
-	return nil
-}
-
-func enforcePluginInvokePermission(ctx dutyContext.Context, entry *registry.Entry, op, configID string) error {
-	user := ctx.User()
-	if user == nil {
-		return ctx.Oops().Code(dutyAPI.EUNAUTHORIZED).Errorf("not logged in")
-	}
-
-	attr := &models.ABACAttribute{}
-
-	if configID != "" {
-		item, err := query.ConfigItemFromCache(ctx, configID)
-		if err != nil {
-			return ctx.Oops().Wrapf(err, "get config item %s", configID)
-		}
-		attr.Config = item
-	}
-
-	if !canInvokePluginOperation(ctx, user.ID.String(), attr, entry.Name, op) {
-		return ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("not allowed to invoke plugin %s operation %s", entry.Name, op)
-	}
-
-	return nil
-}
-
-func canInvokePluginOperation(ctx dutyContext.Context, subject string, attr *models.ABACAttribute, pluginName, op string) bool {
-	return dutyRBAC.HasPermission(ctx, subject, attr, policy.NewPluginInvokeAction(pluginName, op))
-}
-
-// selectorMatches returns true when the given config id satisfies the plugin
-// CRD's ResourceSelector. Centralised so all routes apply the same check.
-func selectorMatches(ctx dutyContext.Context, entry *registry.Entry, configID string) bool {
-	selector := entry.Spec.Selector
-	if selector.IsEmpty() {
-		return true
-	}
-
-	item, err := query.ConfigItemFromCache(ctx, configID)
-	if err != nil {
-		return false
-	}
-
-	return selector.Matches(item)
-}
-
-func callerFromCtx(ctx dutyContext.Context) *pluginpb.CallerContext {
-	cc := &pluginpb.CallerContext{}
-	if u := ctx.User(); u != nil {
-		cc.UserId = u.ID.String()
-	}
-
-	return cc
+	return sup.Invoke(ctx, req)
 }

--- a/plugin/controller/controller.go
+++ b/plugin/controller/controller.go
@@ -16,8 +16,6 @@
 package controller
 
 import (
-	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -137,10 +135,11 @@ func InvokeOperation(c echo.Context) error {
 	return c.Blob(http.StatusOK, mime, resp.Result)
 }
 
-func invokeViaSupervisor(ctx context.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
+func invokeViaSupervisor(ctx dutyContext.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
 	sup := supervisor.LookupSupervisor(pluginID)
 	if sup == nil {
-		return nil, fmt.Errorf("plugin %s not running", pluginID)
+		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %s not running", pluginID)
 	}
+
 	return sup.Invoke(ctx, req)
 }

--- a/plugin/controller/proxy.go
+++ b/plugin/controller/proxy.go
@@ -86,10 +86,10 @@ func operationHTTPProxy(c echo.Context) error {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
 	}
 	user := ctx.User()
-	subject := ""
-	if user != nil {
-		subject = user.ID.String()
+	if user == nil {
+		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EUNAUTHORIZED).Errorf("not logged in"))
 	}
+	subject := user.ID.String()
 	if err := pluginruntime.EnforceInvokePermission(ctx, subject, entry, op, configID); err != nil {
 		return dutyAPI.WriteError(c, err)
 	}

--- a/plugin/controller/proxy.go
+++ b/plugin/controller/proxy.go
@@ -12,12 +12,12 @@ import (
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/samber/lo"
 
 	"github.com/flanksource/incident-commander/auth"
 	"github.com/flanksource/incident-commander/plugin"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 	"github.com/flanksource/incident-commander/plugin/registry"
+	pluginruntime "github.com/flanksource/incident-commander/plugin/runtime"
 	"github.com/flanksource/incident-commander/plugin/supervisor"
 	"github.com/flanksource/incident-commander/rbac"
 )
@@ -36,12 +36,12 @@ func registerProxyRoutes(e *echo.Echo) {
 func uiProxy(c echo.Context) error {
 	ctx := c.Request().Context().(dutyContext.Context)
 	pluginRef := c.Param("name")
-	entry, err := resolvePlugin(ctx, pluginRef)
+	entry, err := pluginruntime.ResolvePlugin(ctx, pluginRef)
 	if err != nil {
 		return dutyAPI.WriteError(c, err)
 	}
 
-	if cfg := c.QueryParam("config_id"); cfg != "" && !selectorMatches(ctx, entry, cfg) {
+	if cfg := c.QueryParam("config_id"); cfg != "" && !pluginruntime.SelectorMatches(ctx, entry, cfg) {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, cfg))
 	}
 
@@ -62,11 +62,11 @@ func operationHTTPProxy(c echo.Context) error {
 	pluginRef := c.Param("name")
 	op := c.Param("op")
 
-	entry, err := resolvePlugin(ctx, pluginRef)
+	entry, err := pluginruntime.ResolvePlugin(ctx, pluginRef)
 	if err != nil {
 		return dutyAPI.WriteError(c, err)
 	}
-	def := operationDef(entry, op)
+	def := pluginruntime.OperationDef(entry, op)
 	if def == nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q operation %q not found", pluginRef, op))
 	}
@@ -82,14 +82,19 @@ func operationHTTPProxy(c echo.Context) error {
 	if err != nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("config_id is invalid"))
 	}
-	if !selectorMatches(ctx, entry, configID) {
+	if !pluginruntime.SelectorMatches(ctx, entry, configID) {
 		return dutyAPI.WriteError(c, ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("plugin %q is not enabled for config %s", pluginRef, configID))
 	}
-	if err := enforcePluginInvokePermission(ctx, entry, op, configID); err != nil {
+	user := ctx.User()
+	subject := ""
+	if user != nil {
+		subject = user.ID.String()
+	}
+	if err := pluginruntime.EnforceInvokePermission(ctx, subject, entry, op, configID); err != nil {
 		return dutyAPI.WriteError(c, err)
 	}
 
-	invocationToken, err := auth.MintPluginInvocationToken(lo.FromPtr(ctx.User()), entry.ID)
+	invocationToken, err := auth.MintPluginInvocationToken(*user, entry.ID)
 	if err != nil {
 		return dutyAPI.WriteError(c, ctx.Oops().Wrapf(err, "mint plugin invocation token"))
 	}

--- a/plugin/host/interceptor.go
+++ b/plugin/host/interceptor.go
@@ -27,6 +27,13 @@ func (s *Service) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
+type invocationClaimsContextKey struct{}
+
+func invocationClaimsFromContext(ctx context.Context) (*auth.PluginInvocationClaims, bool) {
+	claims, ok := ctx.Value(invocationClaimsContextKey{}).(*auth.PluginInvocationClaims)
+	return claims, ok
+}
+
 func (s *Service) contextWithInvocation(ctx context.Context) (context.Context, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -49,14 +56,15 @@ func (s *Service) contextWithInvocation(ctx context.Context) (context.Context, e
 		return nil, status.Errorf(codes.Unauthenticated, "plugin invocation subject %s: %v", claims.Subject, err)
 	}
 
-	return baseCtx.WithUser(&person), nil
+	return baseCtx.WithUser(&person).WithValue(invocationClaimsContextKey{}, claims), nil
 }
 
 func requiresInvocation(method string) bool {
 	switch method {
 	case pluginpb.HostService_GetConfigItem_FullMethodName,
 		pluginpb.HostService_ListConfigs_FullMethodName,
-		pluginpb.HostService_GetConnection_FullMethodName:
+		pluginpb.HostService_GetConnection_FullMethodName,
+		pluginpb.HostService_InvokePlugin_FullMethodName:
 		return true
 	default:
 		return false

--- a/plugin/host/service.go
+++ b/plugin/host/service.go
@@ -22,10 +22,14 @@ import (
 	"github.com/flanksource/incident-commander/auth"
 	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 	"github.com/flanksource/incident-commander/plugin/registry"
+	pluginruntime "github.com/flanksource/incident-commander/plugin/runtime"
 )
 
 // connectionCacheTTL is how long a resolved connection stays cached on the host.
 const connectionCacheTTL = 5 * time.Minute
+
+// PluginInvoker invokes a target plugin through its supervisor.
+type PluginInvoker = pluginruntime.Invoker
 
 type connKey struct {
 	connectionID string
@@ -43,6 +47,8 @@ type Service struct {
 	// connCache memoises named connection resolutions across calls within a single
 	// plugin process. Authorization is checked before serving cached results.
 	connCache *lru.LRU[connKey, *pluginpb.ResolvedConnection]
+
+	invokePlugin PluginInvoker
 }
 
 // New creates a host Service for one plugin id. Multiple plugins running
@@ -55,6 +61,11 @@ func New(ctx dutyContext.Context, pluginID uuid.UUID) *Service {
 		ctx:       ctx,
 		connCache: cache,
 	}
+}
+
+// SetPluginInvoker configures the callback used by InvokePlugin.
+func (s *Service) SetPluginInvoker(invoke PluginInvoker) {
+	s.invokePlugin = invoke
 }
 
 // Register exposes the service on the given gRPC server.
@@ -146,6 +157,39 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginpb.GetConnection
 	default:
 		return nil, fmt.Errorf("connection lookup is required")
 	}
+}
+
+func (s *Service) InvokePlugin(ctx context.Context, req *pluginpb.InvokePluginRequest) (*pluginpb.InvokeResponse, error) {
+	dutyCtx := invocationDutyContext(s.ctx, ctx)
+	source := registry.Default.Get(s.pluginID)
+	if source == nil {
+		return nil, fmt.Errorf("plugin %s is not registered", s.pluginID)
+	}
+
+	depth := 1
+	if claims, ok := invocationClaimsFromContext(ctx); ok {
+		depth = claims.Depth + 1
+	}
+
+	resp, _, err := pluginruntime.Invoke(dutyCtx, pluginruntime.Request{
+		Context:      ctx,
+		PluginRef:    req.Plugin,
+		Operation:    req.Operation,
+		ParamsJSON:   req.ParamsJson,
+		ConfigItemID: req.ConfigItemId,
+		User:         dutyCtx.User(),
+		Subject:      pluginruntime.PluginSubject(source.Namespace, source.Name),
+		Depth:        depth,
+		Deadline:     req.Deadline,
+	}, s.invokePlugin)
+	return resp, err
+}
+
+func invocationDutyContext(base dutyContext.Context, ctx context.Context) dutyContext.Context {
+	if dutyCtx, ok := ctx.(dutyContext.Context); ok {
+		return dutyCtx
+	}
+	return base.Wrap(ctx)
 }
 
 func (s *Service) Log(ctx context.Context, e *pluginpb.LogEntry) (*pluginpb.Empty, error) {

--- a/plugin/proto/plugin.pb.go
+++ b/plugin/proto/plugin.pb.go
@@ -747,6 +747,82 @@ func (x *InvokeResponse) GetLogs() []*LogEntry {
 	return nil
 }
 
+type InvokePluginRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Plugin        string                 `protobuf:"bytes,1,opt,name=plugin,proto3" json:"plugin,omitempty"`
+	Operation     string                 `protobuf:"bytes,2,opt,name=operation,proto3" json:"operation,omitempty"`
+	ParamsJson    []byte                 `protobuf:"bytes,3,opt,name=params_json,json=paramsJson,proto3" json:"params_json,omitempty"`
+	ConfigItemId  string                 `protobuf:"bytes,4,opt,name=config_item_id,json=configItemId,proto3" json:"config_item_id,omitempty"`
+	Deadline      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=deadline,proto3" json:"deadline,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokePluginRequest) Reset() {
+	*x = InvokePluginRequest{}
+	mi := &file_plugin_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokePluginRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokePluginRequest) ProtoMessage() {}
+
+func (x *InvokePluginRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokePluginRequest.ProtoReflect.Descriptor instead.
+func (*InvokePluginRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *InvokePluginRequest) GetPlugin() string {
+	if x != nil {
+		return x.Plugin
+	}
+	return ""
+}
+
+func (x *InvokePluginRequest) GetOperation() string {
+	if x != nil {
+		return x.Operation
+	}
+	return ""
+}
+
+func (x *InvokePluginRequest) GetParamsJson() []byte {
+	if x != nil {
+		return x.ParamsJson
+	}
+	return nil
+}
+
+func (x *InvokePluginRequest) GetConfigItemId() string {
+	if x != nil {
+		return x.ConfigItemId
+	}
+	return ""
+}
+
+func (x *InvokePluginRequest) GetDeadline() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Deadline
+	}
+	return nil
+}
+
 type OperationList struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Operations    []*OperationDef        `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
@@ -756,7 +832,7 @@ type OperationList struct {
 
 func (x *OperationList) Reset() {
 	*x = OperationList{}
-	mi := &file_plugin_proto_msgTypes[11]
+	mi := &file_plugin_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -768,7 +844,7 @@ func (x *OperationList) String() string {
 func (*OperationList) ProtoMessage() {}
 
 func (x *OperationList) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[11]
+	mi := &file_plugin_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -781,7 +857,7 @@ func (x *OperationList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationList.ProtoReflect.Descriptor instead.
 func (*OperationList) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{11}
+	return file_plugin_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *OperationList) GetOperations() []*OperationDef {
@@ -801,7 +877,7 @@ type HealthStatus struct {
 
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -813,7 +889,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[12]
+	mi := &file_plugin_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -826,7 +902,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{12}
+	return file_plugin_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HealthStatus) GetOk() bool {
@@ -862,7 +938,7 @@ type ConfigItem struct {
 
 func (x *ConfigItem) Reset() {
 	*x = ConfigItem{}
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -874,7 +950,7 @@ func (x *ConfigItem) String() string {
 func (*ConfigItem) ProtoMessage() {}
 
 func (x *ConfigItem) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[13]
+	mi := &file_plugin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -887,7 +963,7 @@ func (x *ConfigItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigItem.ProtoReflect.Descriptor instead.
 func (*ConfigItem) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{13}
+	return file_plugin_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ConfigItem) GetId() string {
@@ -977,7 +1053,7 @@ type ConfigItemList struct {
 
 func (x *ConfigItemList) Reset() {
 	*x = ConfigItemList{}
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -989,7 +1065,7 @@ func (x *ConfigItemList) String() string {
 func (*ConfigItemList) ProtoMessage() {}
 
 func (x *ConfigItemList) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[14]
+	mi := &file_plugin_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1002,7 +1078,7 @@ func (x *ConfigItemList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigItemList.ProtoReflect.Descriptor instead.
 func (*ConfigItemList) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{14}
+	return file_plugin_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ConfigItemList) GetItems() []*ConfigItem {
@@ -1028,7 +1104,7 @@ type GetConfigItemRequest struct {
 
 func (x *GetConfigItemRequest) Reset() {
 	*x = GetConfigItemRequest{}
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1116,7 @@ func (x *GetConfigItemRequest) String() string {
 func (*GetConfigItemRequest) ProtoMessage() {}
 
 func (x *GetConfigItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[15]
+	mi := &file_plugin_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1129,7 @@ func (x *GetConfigItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigItemRequest.ProtoReflect.Descriptor instead.
 func (*GetConfigItemRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{15}
+	return file_plugin_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetConfigItemRequest) GetId() string {
@@ -1086,7 +1162,7 @@ type ResourceSelector struct {
 
 func (x *ResourceSelector) Reset() {
 	*x = ResourceSelector{}
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1098,7 +1174,7 @@ func (x *ResourceSelector) String() string {
 func (*ResourceSelector) ProtoMessage() {}
 
 func (x *ResourceSelector) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[16]
+	mi := &file_plugin_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1111,7 +1187,7 @@ func (x *ResourceSelector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceSelector.ProtoReflect.Descriptor instead.
 func (*ResourceSelector) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{16}
+	return file_plugin_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ResourceSelector) GetAgent() string {
@@ -1230,7 +1306,7 @@ type ListConfigsRequest struct {
 
 func (x *ListConfigsRequest) Reset() {
 	*x = ListConfigsRequest{}
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1242,7 +1318,7 @@ func (x *ListConfigsRequest) String() string {
 func (*ListConfigsRequest) ProtoMessage() {}
 
 func (x *ListConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[17]
+	mi := &file_plugin_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1255,7 +1331,7 @@ func (x *ListConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ListConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{17}
+	return file_plugin_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListConfigsRequest) GetSelector() *ResourceSelector {
@@ -1297,7 +1373,7 @@ type GetConnectionRequest struct {
 
 func (x *GetConnectionRequest) Reset() {
 	*x = GetConnectionRequest{}
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1309,7 +1385,7 @@ func (x *GetConnectionRequest) String() string {
 func (*GetConnectionRequest) ProtoMessage() {}
 
 func (x *GetConnectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[18]
+	mi := &file_plugin_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1322,7 +1398,7 @@ func (x *GetConnectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConnectionRequest.ProtoReflect.Descriptor instead.
 func (*GetConnectionRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{18}
+	return file_plugin_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetConnectionRequest) GetLookup() isGetConnectionRequest_Lookup {
@@ -1397,7 +1473,7 @@ type ResolvedConnection struct {
 
 func (x *ResolvedConnection) Reset() {
 	*x = ResolvedConnection{}
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1409,7 +1485,7 @@ func (x *ResolvedConnection) String() string {
 func (*ResolvedConnection) ProtoMessage() {}
 
 func (x *ResolvedConnection) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[19]
+	mi := &file_plugin_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1422,7 +1498,7 @@ func (x *ResolvedConnection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolvedConnection.ProtoReflect.Descriptor instead.
 func (*ResolvedConnection) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{19}
+	return file_plugin_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ResolvedConnection) GetType() string {
@@ -1493,7 +1569,7 @@ type LogEntry struct {
 
 func (x *LogEntry) Reset() {
 	*x = LogEntry{}
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1505,7 +1581,7 @@ func (x *LogEntry) String() string {
 func (*LogEntry) ProtoMessage() {}
 
 func (x *LogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[20]
+	mi := &file_plugin_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +1594,7 @@ func (x *LogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{20}
+	return file_plugin_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *LogEntry) GetLevel() string {
@@ -1561,7 +1637,7 @@ type Artifact struct {
 
 func (x *Artifact) Reset() {
 	*x = Artifact{}
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1573,7 +1649,7 @@ func (x *Artifact) String() string {
 func (*Artifact) ProtoMessage() {}
 
 func (x *Artifact) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[21]
+	mi := &file_plugin_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1586,7 +1662,7 @@ func (x *Artifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Artifact.ProtoReflect.Descriptor instead.
 func (*Artifact) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{21}
+	return file_plugin_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Artifact) GetName() string {
@@ -1627,7 +1703,7 @@ type ArtifactRef struct {
 
 func (x *ArtifactRef) Reset() {
 	*x = ArtifactRef{}
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1639,7 +1715,7 @@ func (x *ArtifactRef) String() string {
 func (*ArtifactRef) ProtoMessage() {}
 
 func (x *ArtifactRef) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[22]
+	mi := &file_plugin_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1652,7 +1728,7 @@ func (x *ArtifactRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArtifactRef.ProtoReflect.Descriptor instead.
 func (*ArtifactRef) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{22}
+	return file_plugin_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ArtifactRef) GetId() string {
@@ -1734,7 +1810,14 @@ const file_plugin_proto_rawDesc = "" +
 	"\rerror_message\x18\x03 \x01(\tR\ferrorMessage\x12\x1d\n" +
 	"\n" +
 	"error_code\x18\x04 \x01(\tR\terrorCode\x126\n" +
-	"\x04logs\x18\x05 \x03(\v2\".missioncontrol.plugin.v1.LogEntryR\x04logs\"W\n" +
+	"\x04logs\x18\x05 \x03(\v2\".missioncontrol.plugin.v1.LogEntryR\x04logs\"\xca\x01\n" +
+	"\x13InvokePluginRequest\x12\x16\n" +
+	"\x06plugin\x18\x01 \x01(\tR\x06plugin\x12\x1c\n" +
+	"\toperation\x18\x02 \x01(\tR\toperation\x12\x1f\n" +
+	"\vparams_json\x18\x03 \x01(\fR\n" +
+	"paramsJson\x12$\n" +
+	"\x0econfig_item_id\x18\x04 \x01(\tR\fconfigItemId\x126\n" +
+	"\bdeadline\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\bdeadline\"W\n" +
 	"\rOperationList\x12F\n" +
 	"\n" +
 	"operations\x18\x01 \x03(\v2&.missioncontrol.plugin.v1.OperationDefR\n" +
@@ -1833,14 +1916,15 @@ const file_plugin_proto_rawDesc = "" +
 	"\x0eListOperations\x12\x1f.missioncontrol.plugin.v1.Empty\x1a'.missioncontrol.plugin.v1.OperationList\x12[\n" +
 	"\x06Invoke\x12'.missioncontrol.plugin.v1.InvokeRequest\x1a(.missioncontrol.plugin.v1.InvokeResponse\x12Q\n" +
 	"\x06Health\x12\x1f.missioncontrol.plugin.v1.Empty\x1a&.missioncontrol.plugin.v1.HealthStatus\x12L\n" +
-	"\bShutdown\x12\x1f.missioncontrol.plugin.v1.Empty\x1a\x1f.missioncontrol.plugin.v1.Empty2\xcd\x04\n" +
+	"\bShutdown\x12\x1f.missioncontrol.plugin.v1.Empty\x1a\x1f.missioncontrol.plugin.v1.Empty2\xb6\x05\n" +
 	"\vHostService\x12e\n" +
 	"\rGetConfigItem\x12..missioncontrol.plugin.v1.GetConfigItemRequest\x1a$.missioncontrol.plugin.v1.ConfigItem\x12e\n" +
 	"\vListConfigs\x12,.missioncontrol.plugin.v1.ListConfigsRequest\x1a(.missioncontrol.plugin.v1.ConfigItemList\x12m\n" +
 	"\rGetConnection\x12..missioncontrol.plugin.v1.GetConnectionRequest\x1a,.missioncontrol.plugin.v1.ResolvedConnection\x12J\n" +
 	"\x03Log\x12\".missioncontrol.plugin.v1.LogEntry\x1a\x1f.missioncontrol.plugin.v1.Empty\x12Z\n" +
 	"\rWriteArtifact\x12\".missioncontrol.plugin.v1.Artifact\x1a%.missioncontrol.plugin.v1.ArtifactRef\x12Y\n" +
-	"\fReadArtifact\x12%.missioncontrol.plugin.v1.ArtifactRef\x1a\".missioncontrol.plugin.v1.ArtifactBAZ?github.com/flanksource/incident-commander/plugin/proto;pluginpbb\x06proto3"
+	"\fReadArtifact\x12%.missioncontrol.plugin.v1.ArtifactRef\x1a\".missioncontrol.plugin.v1.Artifact\x12g\n" +
+	"\fInvokePlugin\x12-.missioncontrol.plugin.v1.InvokePluginRequest\x1a(.missioncontrol.plugin.v1.InvokeResponseBAZ?github.com/flanksource/incident-commander/plugin/proto;pluginpbb\x06proto3"
 
 var (
 	file_plugin_proto_rawDescOnce sync.Once
@@ -1854,7 +1938,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 	return file_plugin_proto_rawDescData
 }
 
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_plugin_proto_goTypes = []any{
 	(*Empty)(nil),                 // 0: missioncontrol.plugin.v1.Empty
 	(*PluginManifest)(nil),        // 1: missioncontrol.plugin.v1.PluginManifest
@@ -1867,77 +1951,81 @@ var file_plugin_proto_goTypes = []any{
 	(*CallerContext)(nil),         // 8: missioncontrol.plugin.v1.CallerContext
 	(*InvokeRequest)(nil),         // 9: missioncontrol.plugin.v1.InvokeRequest
 	(*InvokeResponse)(nil),        // 10: missioncontrol.plugin.v1.InvokeResponse
-	(*OperationList)(nil),         // 11: missioncontrol.plugin.v1.OperationList
-	(*HealthStatus)(nil),          // 12: missioncontrol.plugin.v1.HealthStatus
-	(*ConfigItem)(nil),            // 13: missioncontrol.plugin.v1.ConfigItem
-	(*ConfigItemList)(nil),        // 14: missioncontrol.plugin.v1.ConfigItemList
-	(*GetConfigItemRequest)(nil),  // 15: missioncontrol.plugin.v1.GetConfigItemRequest
-	(*ResourceSelector)(nil),      // 16: missioncontrol.plugin.v1.ResourceSelector
-	(*ListConfigsRequest)(nil),    // 17: missioncontrol.plugin.v1.ListConfigsRequest
-	(*GetConnectionRequest)(nil),  // 18: missioncontrol.plugin.v1.GetConnectionRequest
-	(*ResolvedConnection)(nil),    // 19: missioncontrol.plugin.v1.ResolvedConnection
-	(*LogEntry)(nil),              // 20: missioncontrol.plugin.v1.LogEntry
-	(*Artifact)(nil),              // 21: missioncontrol.plugin.v1.Artifact
-	(*ArtifactRef)(nil),           // 22: missioncontrol.plugin.v1.ArtifactRef
-	nil,                           // 23: missioncontrol.plugin.v1.RegisterRequest.EnvEntry
-	nil,                           // 24: missioncontrol.plugin.v1.ConfigItem.LabelsEntry
-	nil,                           // 25: missioncontrol.plugin.v1.ConfigItem.TagsEntry
-	nil,                           // 26: missioncontrol.plugin.v1.LogEntry.FieldsEntry
-	nil,                           // 27: missioncontrol.plugin.v1.Artifact.MetadataEntry
-	(*structpb.Struct)(nil),       // 28: google.protobuf.Struct
-	(*timestamppb.Timestamp)(nil), // 29: google.protobuf.Timestamp
+	(*InvokePluginRequest)(nil),   // 11: missioncontrol.plugin.v1.InvokePluginRequest
+	(*OperationList)(nil),         // 12: missioncontrol.plugin.v1.OperationList
+	(*HealthStatus)(nil),          // 13: missioncontrol.plugin.v1.HealthStatus
+	(*ConfigItem)(nil),            // 14: missioncontrol.plugin.v1.ConfigItem
+	(*ConfigItemList)(nil),        // 15: missioncontrol.plugin.v1.ConfigItemList
+	(*GetConfigItemRequest)(nil),  // 16: missioncontrol.plugin.v1.GetConfigItemRequest
+	(*ResourceSelector)(nil),      // 17: missioncontrol.plugin.v1.ResourceSelector
+	(*ListConfigsRequest)(nil),    // 18: missioncontrol.plugin.v1.ListConfigsRequest
+	(*GetConnectionRequest)(nil),  // 19: missioncontrol.plugin.v1.GetConnectionRequest
+	(*ResolvedConnection)(nil),    // 20: missioncontrol.plugin.v1.ResolvedConnection
+	(*LogEntry)(nil),              // 21: missioncontrol.plugin.v1.LogEntry
+	(*Artifact)(nil),              // 22: missioncontrol.plugin.v1.Artifact
+	(*ArtifactRef)(nil),           // 23: missioncontrol.plugin.v1.ArtifactRef
+	nil,                           // 24: missioncontrol.plugin.v1.RegisterRequest.EnvEntry
+	nil,                           // 25: missioncontrol.plugin.v1.ConfigItem.LabelsEntry
+	nil,                           // 26: missioncontrol.plugin.v1.ConfigItem.TagsEntry
+	nil,                           // 27: missioncontrol.plugin.v1.LogEntry.FieldsEntry
+	nil,                           // 28: missioncontrol.plugin.v1.Artifact.MetadataEntry
+	(*structpb.Struct)(nil),       // 29: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil), // 30: google.protobuf.Timestamp
 }
 var file_plugin_proto_depIdxs = []int32{
 	3,  // 0: missioncontrol.plugin.v1.PluginManifest.operations:type_name -> missioncontrol.plugin.v1.OperationDef
 	2,  // 1: missioncontrol.plugin.v1.PluginManifest.tabs:type_name -> missioncontrol.plugin.v1.TabSpec
-	28, // 2: missioncontrol.plugin.v1.OperationDef.params_schema:type_name -> google.protobuf.Struct
+	29, // 2: missioncontrol.plugin.v1.OperationDef.params_schema:type_name -> google.protobuf.Struct
 	4,  // 3: missioncontrol.plugin.v1.OperationDef.http:type_name -> missioncontrol.plugin.v1.HTTPBinding
-	23, // 4: missioncontrol.plugin.v1.RegisterRequest.env:type_name -> missioncontrol.plugin.v1.RegisterRequest.EnvEntry
-	28, // 5: missioncontrol.plugin.v1.ConfigureRequest.settings:type_name -> google.protobuf.Struct
+	24, // 4: missioncontrol.plugin.v1.RegisterRequest.env:type_name -> missioncontrol.plugin.v1.RegisterRequest.EnvEntry
+	29, // 5: missioncontrol.plugin.v1.ConfigureRequest.settings:type_name -> google.protobuf.Struct
 	8,  // 6: missioncontrol.plugin.v1.InvokeRequest.caller:type_name -> missioncontrol.plugin.v1.CallerContext
-	29, // 7: missioncontrol.plugin.v1.InvokeRequest.deadline:type_name -> google.protobuf.Timestamp
-	20, // 8: missioncontrol.plugin.v1.InvokeResponse.logs:type_name -> missioncontrol.plugin.v1.LogEntry
-	3,  // 9: missioncontrol.plugin.v1.OperationList.operations:type_name -> missioncontrol.plugin.v1.OperationDef
-	28, // 10: missioncontrol.plugin.v1.ConfigItem.properties:type_name -> google.protobuf.Struct
-	28, // 11: missioncontrol.plugin.v1.ConfigItem.config:type_name -> google.protobuf.Struct
-	24, // 12: missioncontrol.plugin.v1.ConfigItem.labels:type_name -> missioncontrol.plugin.v1.ConfigItem.LabelsEntry
-	25, // 13: missioncontrol.plugin.v1.ConfigItem.tags:type_name -> missioncontrol.plugin.v1.ConfigItem.TagsEntry
-	13, // 14: missioncontrol.plugin.v1.ConfigItemList.items:type_name -> missioncontrol.plugin.v1.ConfigItem
-	16, // 15: missioncontrol.plugin.v1.ListConfigsRequest.selector:type_name -> missioncontrol.plugin.v1.ResourceSelector
-	28, // 16: missioncontrol.plugin.v1.ResolvedConnection.properties:type_name -> google.protobuf.Struct
-	29, // 17: missioncontrol.plugin.v1.ResolvedConnection.expires_at:type_name -> google.protobuf.Timestamp
-	26, // 18: missioncontrol.plugin.v1.LogEntry.fields:type_name -> missioncontrol.plugin.v1.LogEntry.FieldsEntry
-	29, // 19: missioncontrol.plugin.v1.LogEntry.ts:type_name -> google.protobuf.Timestamp
-	27, // 20: missioncontrol.plugin.v1.Artifact.metadata:type_name -> missioncontrol.plugin.v1.Artifact.MetadataEntry
-	5,  // 21: missioncontrol.plugin.v1.PluginService.RegisterPlugin:input_type -> missioncontrol.plugin.v1.RegisterRequest
-	6,  // 22: missioncontrol.plugin.v1.PluginService.Configure:input_type -> missioncontrol.plugin.v1.ConfigureRequest
-	0,  // 23: missioncontrol.plugin.v1.PluginService.ListOperations:input_type -> missioncontrol.plugin.v1.Empty
-	9,  // 24: missioncontrol.plugin.v1.PluginService.Invoke:input_type -> missioncontrol.plugin.v1.InvokeRequest
-	0,  // 25: missioncontrol.plugin.v1.PluginService.Health:input_type -> missioncontrol.plugin.v1.Empty
-	0,  // 26: missioncontrol.plugin.v1.PluginService.Shutdown:input_type -> missioncontrol.plugin.v1.Empty
-	15, // 27: missioncontrol.plugin.v1.HostService.GetConfigItem:input_type -> missioncontrol.plugin.v1.GetConfigItemRequest
-	17, // 28: missioncontrol.plugin.v1.HostService.ListConfigs:input_type -> missioncontrol.plugin.v1.ListConfigsRequest
-	18, // 29: missioncontrol.plugin.v1.HostService.GetConnection:input_type -> missioncontrol.plugin.v1.GetConnectionRequest
-	20, // 30: missioncontrol.plugin.v1.HostService.Log:input_type -> missioncontrol.plugin.v1.LogEntry
-	21, // 31: missioncontrol.plugin.v1.HostService.WriteArtifact:input_type -> missioncontrol.plugin.v1.Artifact
-	22, // 32: missioncontrol.plugin.v1.HostService.ReadArtifact:input_type -> missioncontrol.plugin.v1.ArtifactRef
-	1,  // 33: missioncontrol.plugin.v1.PluginService.RegisterPlugin:output_type -> missioncontrol.plugin.v1.PluginManifest
-	7,  // 34: missioncontrol.plugin.v1.PluginService.Configure:output_type -> missioncontrol.plugin.v1.ConfigureResponse
-	11, // 35: missioncontrol.plugin.v1.PluginService.ListOperations:output_type -> missioncontrol.plugin.v1.OperationList
-	10, // 36: missioncontrol.plugin.v1.PluginService.Invoke:output_type -> missioncontrol.plugin.v1.InvokeResponse
-	12, // 37: missioncontrol.plugin.v1.PluginService.Health:output_type -> missioncontrol.plugin.v1.HealthStatus
-	0,  // 38: missioncontrol.plugin.v1.PluginService.Shutdown:output_type -> missioncontrol.plugin.v1.Empty
-	13, // 39: missioncontrol.plugin.v1.HostService.GetConfigItem:output_type -> missioncontrol.plugin.v1.ConfigItem
-	14, // 40: missioncontrol.plugin.v1.HostService.ListConfigs:output_type -> missioncontrol.plugin.v1.ConfigItemList
-	19, // 41: missioncontrol.plugin.v1.HostService.GetConnection:output_type -> missioncontrol.plugin.v1.ResolvedConnection
-	0,  // 42: missioncontrol.plugin.v1.HostService.Log:output_type -> missioncontrol.plugin.v1.Empty
-	22, // 43: missioncontrol.plugin.v1.HostService.WriteArtifact:output_type -> missioncontrol.plugin.v1.ArtifactRef
-	21, // 44: missioncontrol.plugin.v1.HostService.ReadArtifact:output_type -> missioncontrol.plugin.v1.Artifact
-	33, // [33:45] is the sub-list for method output_type
-	21, // [21:33] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	30, // 7: missioncontrol.plugin.v1.InvokeRequest.deadline:type_name -> google.protobuf.Timestamp
+	21, // 8: missioncontrol.plugin.v1.InvokeResponse.logs:type_name -> missioncontrol.plugin.v1.LogEntry
+	30, // 9: missioncontrol.plugin.v1.InvokePluginRequest.deadline:type_name -> google.protobuf.Timestamp
+	3,  // 10: missioncontrol.plugin.v1.OperationList.operations:type_name -> missioncontrol.plugin.v1.OperationDef
+	29, // 11: missioncontrol.plugin.v1.ConfigItem.properties:type_name -> google.protobuf.Struct
+	29, // 12: missioncontrol.plugin.v1.ConfigItem.config:type_name -> google.protobuf.Struct
+	25, // 13: missioncontrol.plugin.v1.ConfigItem.labels:type_name -> missioncontrol.plugin.v1.ConfigItem.LabelsEntry
+	26, // 14: missioncontrol.plugin.v1.ConfigItem.tags:type_name -> missioncontrol.plugin.v1.ConfigItem.TagsEntry
+	14, // 15: missioncontrol.plugin.v1.ConfigItemList.items:type_name -> missioncontrol.plugin.v1.ConfigItem
+	17, // 16: missioncontrol.plugin.v1.ListConfigsRequest.selector:type_name -> missioncontrol.plugin.v1.ResourceSelector
+	29, // 17: missioncontrol.plugin.v1.ResolvedConnection.properties:type_name -> google.protobuf.Struct
+	30, // 18: missioncontrol.plugin.v1.ResolvedConnection.expires_at:type_name -> google.protobuf.Timestamp
+	27, // 19: missioncontrol.plugin.v1.LogEntry.fields:type_name -> missioncontrol.plugin.v1.LogEntry.FieldsEntry
+	30, // 20: missioncontrol.plugin.v1.LogEntry.ts:type_name -> google.protobuf.Timestamp
+	28, // 21: missioncontrol.plugin.v1.Artifact.metadata:type_name -> missioncontrol.plugin.v1.Artifact.MetadataEntry
+	5,  // 22: missioncontrol.plugin.v1.PluginService.RegisterPlugin:input_type -> missioncontrol.plugin.v1.RegisterRequest
+	6,  // 23: missioncontrol.plugin.v1.PluginService.Configure:input_type -> missioncontrol.plugin.v1.ConfigureRequest
+	0,  // 24: missioncontrol.plugin.v1.PluginService.ListOperations:input_type -> missioncontrol.plugin.v1.Empty
+	9,  // 25: missioncontrol.plugin.v1.PluginService.Invoke:input_type -> missioncontrol.plugin.v1.InvokeRequest
+	0,  // 26: missioncontrol.plugin.v1.PluginService.Health:input_type -> missioncontrol.plugin.v1.Empty
+	0,  // 27: missioncontrol.plugin.v1.PluginService.Shutdown:input_type -> missioncontrol.plugin.v1.Empty
+	16, // 28: missioncontrol.plugin.v1.HostService.GetConfigItem:input_type -> missioncontrol.plugin.v1.GetConfigItemRequest
+	18, // 29: missioncontrol.plugin.v1.HostService.ListConfigs:input_type -> missioncontrol.plugin.v1.ListConfigsRequest
+	19, // 30: missioncontrol.plugin.v1.HostService.GetConnection:input_type -> missioncontrol.plugin.v1.GetConnectionRequest
+	21, // 31: missioncontrol.plugin.v1.HostService.Log:input_type -> missioncontrol.plugin.v1.LogEntry
+	22, // 32: missioncontrol.plugin.v1.HostService.WriteArtifact:input_type -> missioncontrol.plugin.v1.Artifact
+	23, // 33: missioncontrol.plugin.v1.HostService.ReadArtifact:input_type -> missioncontrol.plugin.v1.ArtifactRef
+	11, // 34: missioncontrol.plugin.v1.HostService.InvokePlugin:input_type -> missioncontrol.plugin.v1.InvokePluginRequest
+	1,  // 35: missioncontrol.plugin.v1.PluginService.RegisterPlugin:output_type -> missioncontrol.plugin.v1.PluginManifest
+	7,  // 36: missioncontrol.plugin.v1.PluginService.Configure:output_type -> missioncontrol.plugin.v1.ConfigureResponse
+	12, // 37: missioncontrol.plugin.v1.PluginService.ListOperations:output_type -> missioncontrol.plugin.v1.OperationList
+	10, // 38: missioncontrol.plugin.v1.PluginService.Invoke:output_type -> missioncontrol.plugin.v1.InvokeResponse
+	13, // 39: missioncontrol.plugin.v1.PluginService.Health:output_type -> missioncontrol.plugin.v1.HealthStatus
+	0,  // 40: missioncontrol.plugin.v1.PluginService.Shutdown:output_type -> missioncontrol.plugin.v1.Empty
+	14, // 41: missioncontrol.plugin.v1.HostService.GetConfigItem:output_type -> missioncontrol.plugin.v1.ConfigItem
+	15, // 42: missioncontrol.plugin.v1.HostService.ListConfigs:output_type -> missioncontrol.plugin.v1.ConfigItemList
+	20, // 43: missioncontrol.plugin.v1.HostService.GetConnection:output_type -> missioncontrol.plugin.v1.ResolvedConnection
+	0,  // 44: missioncontrol.plugin.v1.HostService.Log:output_type -> missioncontrol.plugin.v1.Empty
+	23, // 45: missioncontrol.plugin.v1.HostService.WriteArtifact:output_type -> missioncontrol.plugin.v1.ArtifactRef
+	22, // 46: missioncontrol.plugin.v1.HostService.ReadArtifact:output_type -> missioncontrol.plugin.v1.Artifact
+	10, // 47: missioncontrol.plugin.v1.HostService.InvokePlugin:output_type -> missioncontrol.plugin.v1.InvokeResponse
+	35, // [35:48] is the sub-list for method output_type
+	22, // [22:35] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -1945,7 +2033,7 @@ func file_plugin_proto_init() {
 	if File_plugin_proto != nil {
 		return
 	}
-	file_plugin_proto_msgTypes[18].OneofWrappers = []any{
+	file_plugin_proto_msgTypes[19].OneofWrappers = []any{
 		(*GetConnectionRequest_Type)(nil),
 		(*GetConnectionRequest_ConfigItemId)(nil),
 		(*GetConnectionRequest_Label)(nil),
@@ -1956,7 +2044,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/plugin/proto/plugin.proto
+++ b/plugin/proto/plugin.proto
@@ -28,6 +28,7 @@ service HostService {
   rpc Log            (LogEntry)             returns (Empty);
   rpc WriteArtifact  (Artifact)             returns (ArtifactRef);
   rpc ReadArtifact   (ArtifactRef)          returns (Artifact);
+  rpc InvokePlugin   (InvokePluginRequest)  returns (InvokeResponse);
 }
 
 message PluginManifest {
@@ -99,6 +100,14 @@ message InvokeResponse {
   string error_message = 3;
   string error_code    = 4;
   repeated LogEntry logs = 5;
+}
+
+message InvokePluginRequest {
+  string plugin         = 1;
+  string operation      = 2;
+  bytes  params_json    = 3;
+  string config_item_id = 4;
+  google.protobuf.Timestamp deadline = 5;
 }
 
 message OperationList { repeated OperationDef operations = 1; }

--- a/plugin/proto/plugin_grpc.pb.go
+++ b/plugin/proto/plugin_grpc.pb.go
@@ -321,6 +321,7 @@ const (
 	HostService_Log_FullMethodName           = "/missioncontrol.plugin.v1.HostService/Log"
 	HostService_WriteArtifact_FullMethodName = "/missioncontrol.plugin.v1.HostService/WriteArtifact"
 	HostService_ReadArtifact_FullMethodName  = "/missioncontrol.plugin.v1.HostService/ReadArtifact"
+	HostService_InvokePlugin_FullMethodName  = "/missioncontrol.plugin.v1.HostService/InvokePlugin"
 )
 
 // HostServiceClient is the client API for HostService service.
@@ -336,6 +337,7 @@ type HostServiceClient interface {
 	Log(ctx context.Context, in *LogEntry, opts ...grpc.CallOption) (*Empty, error)
 	WriteArtifact(ctx context.Context, in *Artifact, opts ...grpc.CallOption) (*ArtifactRef, error)
 	ReadArtifact(ctx context.Context, in *ArtifactRef, opts ...grpc.CallOption) (*Artifact, error)
+	InvokePlugin(ctx context.Context, in *InvokePluginRequest, opts ...grpc.CallOption) (*InvokeResponse, error)
 }
 
 type hostServiceClient struct {
@@ -406,6 +408,16 @@ func (c *hostServiceClient) ReadArtifact(ctx context.Context, in *ArtifactRef, o
 	return out, nil
 }
 
+func (c *hostServiceClient) InvokePlugin(ctx context.Context, in *InvokePluginRequest, opts ...grpc.CallOption) (*InvokeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InvokeResponse)
+	err := c.cc.Invoke(ctx, HostService_InvokePlugin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // HostServiceServer is the server API for HostService service.
 // All implementations must embed UnimplementedHostServiceServer
 // for forward compatibility.
@@ -419,6 +431,7 @@ type HostServiceServer interface {
 	Log(context.Context, *LogEntry) (*Empty, error)
 	WriteArtifact(context.Context, *Artifact) (*ArtifactRef, error)
 	ReadArtifact(context.Context, *ArtifactRef) (*Artifact, error)
+	InvokePlugin(context.Context, *InvokePluginRequest) (*InvokeResponse, error)
 	mustEmbedUnimplementedHostServiceServer()
 }
 
@@ -446,6 +459,9 @@ func (UnimplementedHostServiceServer) WriteArtifact(context.Context, *Artifact) 
 }
 func (UnimplementedHostServiceServer) ReadArtifact(context.Context, *ArtifactRef) (*Artifact, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReadArtifact not implemented")
+}
+func (UnimplementedHostServiceServer) InvokePlugin(context.Context, *InvokePluginRequest) (*InvokeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InvokePlugin not implemented")
 }
 func (UnimplementedHostServiceServer) mustEmbedUnimplementedHostServiceServer() {}
 func (UnimplementedHostServiceServer) testEmbeddedByValue()                     {}
@@ -576,6 +592,24 @@ func _HostService_ReadArtifact_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _HostService_InvokePlugin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InvokePluginRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostServiceServer).InvokePlugin(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostService_InvokePlugin_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostServiceServer).InvokePlugin(ctx, req.(*InvokePluginRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // HostService_ServiceDesc is the grpc.ServiceDesc for HostService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -606,6 +640,10 @@ var HostService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReadArtifact",
 			Handler:    _HostService_ReadArtifact_Handler,
+		},
+		{
+			MethodName: "InvokePlugin",
+			Handler:    _HostService_InvokePlugin_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plugin/runtime/invoke.go
+++ b/plugin/runtime/invoke.go
@@ -1,0 +1,185 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	dutyAPI "github.com/flanksource/duty/api"
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/query"
+	dutyRBAC "github.com/flanksource/duty/rbac"
+	"github.com/flanksource/duty/rbac/policy"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/flanksource/incident-commander/auth"
+	"github.com/flanksource/incident-commander/plugin"
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/registry"
+)
+
+const MaxInvokeDepth = 5
+
+type Invoker func(ctx context.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error)
+
+type Request struct {
+	Context      context.Context
+	PluginRef    string
+	Operation    string
+	ParamsJSON   []byte
+	ConfigItemID string
+	Caller       *pluginpb.CallerContext
+	User         *models.Person
+	Subject      string
+	Depth        int
+	Deadline     *timestamppb.Timestamp
+	Timeout      time.Duration
+}
+
+func Invoke(ctx dutyContext.Context, req Request, invoker Invoker) (*pluginpb.InvokeResponse, *registry.Entry, error) {
+	if invoker == nil {
+		return nil, nil, dutyAPI.Errorf(dutyAPI.EINTERNAL, "plugin invocation is not configured")
+	}
+	if req.PluginRef == "" {
+		return nil, nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin is required")
+	}
+	if req.Operation == "" {
+		return nil, nil, dutyAPI.Errorf(dutyAPI.EINVALID, "operation is required")
+	}
+	if req.User == nil {
+		return nil, nil, dutyAPI.Errorf(dutyAPI.EUNAUTHORIZED, "not logged in")
+	}
+	if req.Depth > MaxInvokeDepth {
+		return nil, nil, dutyAPI.Errorf(dutyAPI.EINVALID, "maximum plugin invocation depth %d exceeded", MaxInvokeDepth)
+	}
+
+	entry, err := ResolvePlugin(ctx, req.PluginRef)
+	if err != nil {
+		return nil, nil, err
+	}
+	if OperationDef(entry, req.Operation) == nil {
+		return nil, entry, dutyAPI.Errorf(dutyAPI.ENOTFOUND, "plugin %q operation %q not found", req.PluginRef, req.Operation)
+	}
+	if req.ConfigItemID != "" && !SelectorMatches(ctx, entry, req.ConfigItemID) {
+		return nil, entry, dutyAPI.Errorf(dutyAPI.EFORBIDDEN, "plugin %q is not enabled for config %s", req.PluginRef, req.ConfigItemID)
+	}
+
+	subject := req.Subject
+	if subject == "" {
+		subject = req.User.ID.String()
+	}
+	if err := EnforceInvokePermission(ctx, subject, entry, req.Operation, req.ConfigItemID); err != nil {
+		return nil, entry, err
+	}
+
+	token, err := auth.MintPluginInvocationTokenWithDepth(*req.User, entry.ID, req.Depth)
+	if err != nil {
+		return nil, entry, ctx.Oops().Wrapf(err, "mint plugin invocation token")
+	}
+
+	invokeCtx := req.Context
+	if invokeCtx == nil {
+		invokeCtx = ctx
+	}
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		invokeCtx, cancel = context.WithTimeout(invokeCtx, req.Timeout)
+		defer cancel()
+	}
+	invokeCtx = metadata.AppendToOutgoingContext(invokeCtx, plugin.InvocationTokenGRPCMetadataKey, token)
+
+	caller := req.Caller
+	if caller == nil {
+		caller = CallerFromUser(req.User)
+	}
+	resp, err := invoker(invokeCtx, entry.ID, &pluginpb.InvokeRequest{
+		Operation:    req.Operation,
+		ParamsJson:   req.ParamsJSON,
+		ConfigItemId: req.ConfigItemID,
+		Caller:       caller,
+		Deadline:     req.Deadline,
+	})
+	return resp, entry, err
+}
+
+func ResolvePlugin(ctx dutyContext.Context, ref string) (*registry.Entry, error) {
+	entry, err := registry.Default.Resolve(ref)
+	if err != nil {
+		if errors.Is(err, registry.ErrAmbiguousPlugin) {
+			return nil, ctx.Oops().Code(dutyAPI.ECONFLICT).Wrap(err)
+		}
+		return nil, ctx.Oops().Wrap(err)
+	}
+	if entry == nil || entry.Manifest == nil {
+		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %q not running", ref)
+	}
+	return entry, nil
+}
+
+func OperationDef(entry *registry.Entry, op string) *pluginpb.OperationDef {
+	if entry == nil || entry.Manifest == nil {
+		return nil
+	}
+	for _, def := range entry.Manifest.Operations {
+		if def != nil && def.Name == op {
+			return def
+		}
+	}
+	return nil
+}
+
+func SelectorMatches(ctx dutyContext.Context, entry *registry.Entry, configID string) bool {
+	if entry == nil {
+		return false
+	}
+	selector := entry.Spec.Selector
+	if selector.IsEmpty() {
+		return true
+	}
+
+	item, err := query.ConfigItemFromCache(ctx, configID)
+	if err != nil {
+		return false
+	}
+	return selector.Matches(item)
+}
+
+func EnforceInvokePermission(ctx dutyContext.Context, subject string, entry *registry.Entry, op, configID string) error {
+	if subject == "" {
+		return ctx.Oops().Code(dutyAPI.EUNAUTHORIZED).Errorf("not logged in")
+	}
+
+	attr := &models.ABACAttribute{}
+	if configID != "" {
+		item, err := query.ConfigItemFromCache(ctx, configID)
+		if err != nil {
+			return ctx.Oops().Wrapf(err, "get config item %s", configID)
+		}
+		attr.Config = item
+	}
+
+	if CanInvokePluginOperation(ctx, subject, attr, entry.Name, op) {
+		return nil
+	}
+	return ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("not allowed to invoke plugin %s operation %s", entry.Name, op)
+}
+
+func CanInvokePluginOperation(ctx dutyContext.Context, subject string, attr *models.ABACAttribute, pluginName, op string) bool {
+	return dutyRBAC.HasPermission(ctx, subject, attr, policy.NewPluginInvokeAction(pluginName, op))
+}
+
+func CallerFromUser(user *models.Person) *pluginpb.CallerContext {
+	cc := &pluginpb.CallerContext{}
+	if user != nil {
+		cc.UserId = user.ID.String()
+	}
+	return cc
+}
+
+func PluginSubject(namespace, name string) string {
+	return fmt.Sprintf("plugin:%s/%s", namespace, name)
+}

--- a/plugin/runtime/invoke.go
+++ b/plugin/runtime/invoke.go
@@ -24,7 +24,7 @@ import (
 
 const MaxInvokeDepth = 5
 
-type Invoker func(ctx context.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error)
+type Invoker func(ctx dutyContext.Context, pluginID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error)
 
 type Request struct {
 	Context      context.Context
@@ -81,16 +81,20 @@ func Invoke(ctx dutyContext.Context, req Request, invoker Invoker) (*pluginpb.In
 		return nil, entry, ctx.Oops().Wrapf(err, "mint plugin invocation token")
 	}
 
-	invokeCtx := req.Context
-	if invokeCtx == nil {
-		invokeCtx = ctx
+	invokeCtx := ctx
+	if req.Context != nil {
+		if dutyCtx, ok := req.Context.(dutyContext.Context); ok {
+			invokeCtx = dutyCtx
+		} else {
+			invokeCtx = ctx.Wrap(req.Context)
+		}
 	}
 	if req.Timeout > 0 {
 		var cancel context.CancelFunc
-		invokeCtx, cancel = context.WithTimeout(invokeCtx, req.Timeout)
+		invokeCtx, cancel = invokeCtx.WithTimeout(req.Timeout)
 		defer cancel()
 	}
-	invokeCtx = metadata.AppendToOutgoingContext(invokeCtx, plugin.InvocationTokenGRPCMetadataKey, token)
+	invokeCtx = invokeCtx.Wrap(metadata.AppendToOutgoingContext(invokeCtx, plugin.InvocationTokenGRPCMetadataKey, token)).WithUser(req.User)
 
 	caller := req.Caller
 	if caller == nil {

--- a/plugin/sdk/host_client.go
+++ b/plugin/sdk/host_client.go
@@ -34,6 +34,9 @@ type HostClient interface {
 	// Log forwards a structured log entry to the host's logger.
 	Log(ctx context.Context, level, message string, fields map[string]string) error
 
+	// InvokePlugin invokes another plugin operation through Mission Control.
+	InvokePlugin(ctx context.Context, plugin, operation, configItemID string, params json.RawMessage) (*pluginpb.InvokeResponse, error)
+
 	// WriteArtifact persists raw bytes via the host's artifact store and returns a reference.
 	WriteArtifact(ctx context.Context, a *pluginpb.Artifact) (*pluginpb.ArtifactRef, error)
 
@@ -80,6 +83,15 @@ func (h *hostClient) GetConnectionByLabel(ctx context.Context, label string) (*p
 func (h *hostClient) Log(ctx context.Context, level, message string, fields map[string]string) error {
 	_, err := h.c.Log(h.authContext(ctx), &pluginpb.LogEntry{Level: level, Message: message, Fields: fields})
 	return err
+}
+
+func (h *hostClient) InvokePlugin(ctx context.Context, plugin, operation, configItemID string, params json.RawMessage) (*pluginpb.InvokeResponse, error) {
+	return h.c.InvokePlugin(h.authContext(ctx), &pluginpb.InvokePluginRequest{
+		Plugin:       plugin,
+		Operation:    operation,
+		ConfigItemId: configItemID,
+		ParamsJson:   params,
+	})
 }
 
 func (h *hostClient) WriteArtifact(ctx context.Context, a *pluginpb.Artifact) (*pluginpb.ArtifactRef, error) {

--- a/plugin/supervisor/wire.go
+++ b/plugin/supervisor/wire.go
@@ -1,10 +1,10 @@
 package supervisor
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
+	dutyAPI "github.com/flanksource/duty/api"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/google/uuid"
 	goplugin "github.com/hashicorp/go-plugin"
@@ -45,10 +45,10 @@ func startPlugin(ctx dutyContext.Context, id uuid.UUID) error {
 	}
 	binPath := registry.BinaryPathFor(entry.Name)
 	svc := host.New(ctx, id)
-	svc.SetPluginInvoker(func(invokeCtx context.Context, targetID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
+	svc.SetPluginInvoker(func(invokeCtx dutyContext.Context, targetID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
 		sup := LookupSupervisor(targetID)
 		if sup == nil {
-			return nil, fmt.Errorf("plugin %s not running", targetID)
+			return nil, invokeCtx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %s not running", targetID)
 		}
 		return sup.Invoke(invokeCtx, req)
 	})

--- a/plugin/supervisor/wire.go
+++ b/plugin/supervisor/wire.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/flanksource/incident-commander/plugin/adapter"
 	"github.com/flanksource/incident-commander/plugin/host"
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
 	"github.com/flanksource/incident-commander/plugin/registry"
 )
 
@@ -43,6 +45,13 @@ func startPlugin(ctx dutyContext.Context, id uuid.UUID) error {
 	}
 	binPath := registry.BinaryPathFor(entry.Name)
 	svc := host.New(ctx, id)
+	svc.SetPluginInvoker(func(invokeCtx context.Context, targetID uuid.UUID, req *pluginpb.InvokeRequest) (*pluginpb.InvokeResponse, error) {
+		sup := LookupSupervisor(targetID)
+		if sup == nil {
+			return nil, fmt.Errorf("plugin %s not running", targetID)
+		}
+		return sup.Invoke(invokeCtx, req)
+	})
 
 	// startHost is invoked after Dispense() so the broker is live. It opens
 	// a listener on the broker, starts a gRPC server for this plugin's


### PR DESCRIPTION
Adds plugin-to-plugin invocation through Mission Control rather than direct plugin networking.

Introduces a shared plugin runtime invocation layer used by both HTTP and gRPC gateways for target resolution, operation checks, selector matching, RBAC, token minting, and depth tracking.

Expose `InvokePlugin` on HostService and the SDK HostClient so plugins can invoke other plugin operations while preserving Mission Control as the policy boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can invoke other plugins via a new host InvokePlugin API and corresponding SDK method.

* **Enhancements**
  * Invocation tokens optionally carry a depth value; recursive invocations are now limited.

* **Refactor**
  * Plugin invocation flow centralized into a runtime with unified selector checks, permission enforcement, supervisor forwarding, and host-side invocation support.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->