### PR TITLE
chore(deps): bump flanksource/deps to v1.0.30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ NODE_VERSION ?= 24.11.0
 PNPM_VERSION ?= 10.33.0
 TAILWIND_VERSION ?= 3.4.17
 TAILWIND_JS = auth/oidc/static/tailwind.min.js
+DEPS_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/flanksource/deps 2>/dev/null || echo latest)
 
 $(TAILWIND_JS):
 	curl -sL "https://cdn.tailwindcss.com/$(TAILWIND_VERSION)" -o $(TAILWIND_JS)
@@ -203,7 +204,14 @@ $(DEPS): | $(LOCALBIN)
 	elif command -v deps >/dev/null 2>&1; then \
 		ln -sf "$$(command -v deps)" "$(DEPS)"; \
 	else \
-		curl -sSL https://github.com/flanksource/deps/releases/latest/download/deps-$(OS)-$(ARCH).tar.gz | tar -xz -C $(LOCALBIN); \
+		url="https://github.com/flanksource/deps/releases/download/$(DEPS_VERSION)/deps-$(OS)-$(ARCH).tar.gz"; \
+		tmp="$(LOCALBIN)/deps-$(OS)-$(ARCH).tar.gz"; \
+		if curl -fsSL "$$url" -o "$$tmp"; then \
+			tar -xzf "$$tmp" -C $(LOCALBIN); \
+		else \
+			GOBIN=$(LOCALBIN) go install github.com/flanksource/deps/cmd/deps@$(DEPS_VERSION); \
+		fi; \
+		rm -f "$$tmp"; \
 	fi
 
 .PHONY: deps

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/flanksource/artifacts v1.0.24
 	github.com/flanksource/clicky v1.21.9
 	github.com/flanksource/commons-test v0.1.13
-	github.com/flanksource/deps v1.0.28
+	github.com/flanksource/deps v1.0.30
 	github.com/fluxcd/pkg/gittestserver v0.28.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/glebarez/sqlite v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/flanksource/commons v1.51.4 h1:ys3O4g0exWoz/viKf9vwTUItTkP/RgP1jORooh
 github.com/flanksource/commons v1.51.4/go.mod h1:XXLA39QGuFUyqIK19W5oDCIZDinLzFyFcGj83ZkyOfo=
 github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFEO9DYd15bw4=
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
-github.com/flanksource/deps v1.0.28 h1:mm7l7WjzLbkj2aFrgnlMaRizp+j+0x22TvtwXzRlFtE=
-github.com/flanksource/deps v1.0.28/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
+github.com/flanksource/deps v1.0.30 h1:zZILaYzPEzuFoLu+aK6wGA7qD1r6lvdlyu/XDm0zWv4=
+github.com/flanksource/deps v1.0.30/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
 github.com/flanksource/duty v1.0.1309 h1:IDHymku2rjI5kOdtbZEgaMywUeM6bsN60f1ni39Z1C8=
 github.com/flanksource/duty v1.0.1309/go.mod h1:aH4xdGF3brwBiOKUEFsspgu8U7tBiJOZDXrEqB3OMtc=
 github.com/flanksource/gomplate/v3 v3.24.79 h1:T5Ls0tjsnDhcV/dQWjrm2UpHiwOhytDLmYDSF0O6p3Q=


### PR DESCRIPTION
Update github.com/flanksource/deps from v1.0.28 to v1.0.30.

Also make the deps CLI installer use the module version and fall back to go install when release assets are unavailable.