### PR TITLE
chore(deps): bump flanksource deps to v1.0.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/flanksource/artifacts v1.0.24
 	github.com/flanksource/clicky v1.21.9
 	github.com/flanksource/commons-test v0.1.13
-	github.com/flanksource/deps v1.0.31
+	github.com/flanksource/deps v1.0.32
 	github.com/fluxcd/pkg/gittestserver v0.28.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/glebarez/sqlite v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/flanksource/commons v1.51.4 h1:ys3O4g0exWoz/viKf9vwTUItTkP/RgP1jORooh
 github.com/flanksource/commons v1.51.4/go.mod h1:XXLA39QGuFUyqIK19W5oDCIZDinLzFyFcGj83ZkyOfo=
 github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFEO9DYd15bw4=
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
-github.com/flanksource/deps v1.0.31 h1:BTfIoERk4NO3Vk8euPETITO0IC4JCazUrw+Pw8SYlKI=
-github.com/flanksource/deps v1.0.31/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
+github.com/flanksource/deps v1.0.32 h1:x4BXAknYYWEkfU50fkNmL5jIm/5Xre2aMS+o/JYjd1A=
+github.com/flanksource/deps v1.0.32/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
 github.com/flanksource/duty v1.0.1309 h1:IDHymku2rjI5kOdtbZEgaMywUeM6bsN60f1ni39Z1C8=
 github.com/flanksource/duty v1.0.1309/go.mod h1:aH4xdGF3brwBiOKUEFsspgu8U7tBiJOZDXrEqB3OMtc=
 github.com/flanksource/gomplate/v3 v3.24.79 h1:T5Ls0tjsnDhcV/dQWjrm2UpHiwOhytDLmYDSF0O6p3Q=


### PR DESCRIPTION
Bump github.com/flanksource/deps from v1.0.31 to v1.0.32.

This updates the module requirement and refreshes go.sum via go mod tidy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->