### PR TITLE
fix: use React Router for frontend SPA navigation

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -17,7 +17,8 @@
     "@tanstack/react-query": "^5.80.7",
     "iconify-icon": "^3.0.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.15.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/ui/frontend/pnpm-lock.yaml
+++ b/ui/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.15.1
+        version: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -1926,6 +1929,23 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2001,6 +2021,9 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -4749,6 +4772,20 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router-dom@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.1.1
+      react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4891,6 +4928,8 @@ snapshots:
   scule@1.3.0: {}
 
   semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -138,28 +138,28 @@ function Home() {
 
 function TypeRoute() {
   const { configType } = useParams();
-  return <TypeView configType={decodeParam(configType ?? "")} />;
+  return <TypeView configType={configType ?? ""} />;
 }
 
 function ItemRoute({ commandRuntime }: { commandRuntime: ClickyCommandRuntime }) {
   const { id } = useParams();
-  return <ItemView id={decodeParam(id ?? "")} commandRuntime={commandRuntime} />;
+  return <ItemView id={id ?? ""} commandRuntime={commandRuntime} />;
 }
 
 function AccessRoute() {
   const { mode, id } = useParams();
   if (mode !== "users" && mode !== "groups") return <Navigate to="/access/users" replace />;
-  return <AccessBrowser mode={mode as AccessBrowserMode} id={id ? decodeParam(id) : undefined} />;
+  return <AccessBrowser mode={mode as AccessBrowserMode} id={id} />;
 }
 
 function PlaybookRunRoute() {
   const { runId } = useParams();
-  return <PlaybookBrowser mode="run" runId={decodeParam(runId ?? "")} />;
+  return <PlaybookBrowser mode="run" runId={runId ?? ""} />;
 }
 
 function SettingsScrapersRoute() {
   const { scraperId } = useParams();
-  return <SettingsBrowser mode="scrapers" scraperId={scraperId ? decodeParam(scraperId) : undefined} />;
+  return <SettingsBrowser mode="scrapers" scraperId={scraperId} />;
 }
 
 function ExplorerRoute() {
@@ -200,14 +200,6 @@ function SidebarButton({
       </span>
     </NavLink>
   );
-}
-
-function decodeParam(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
 }
 
 // buildCommandHref maps a resolved clicky command (command name + args/flags)

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -1,16 +1,15 @@
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   DensitySwitcher,
   Icon,
   ThemeSwitcher,
-  useHistoryRoute,
   type ClickyCommandRuntime,
   type ClickyResolvedCommand,
   type RenderLink,
-  type UseHistoryRouteOptions,
 } from "@flanksource/clicky-ui";
 import { EntityExplorerApp } from "@flanksource/clicky-ui/api-explorer";
 import { MissionControlLogo } from "@flanksource/icons/mi";
+import { Link, Navigate, NavLink, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { apiClient } from "./api";
 import { CatalogSidebar } from "./CatalogSidebar";
 import { TypeView } from "./TypeView";
@@ -18,111 +17,20 @@ import { ItemView } from "./ItemView";
 import { AccessBrowser, type AccessBrowserMode } from "./access/AccessBrowser";
 import { CommandPalette, CommandPaletteButton } from "./CommandPalette";
 import { PlaybookBrowser } from "./playbooks/PlaybookBrowser";
-import { SettingsBrowser, type SettingsMode } from "./settings/SettingsBrowser";
-
-export type Route =
-  | { kind: "type"; configType: string }
-  | { kind: "item"; id: string }
-  | { kind: "access"; mode: AccessBrowserMode; id?: string }
-  | { kind: "playbooks"; mode: "list" | "runs"; runId?: undefined }
-  | { kind: "playbooks"; mode: "run"; runId: string }
-  | { kind: "settings"; mode: "scrapers"; scraperId?: string }
-  | { kind: "settings"; mode: Exclude<SettingsMode, "scrapers"> }
-  | { kind: "explorer" }
-  | { kind: "home" };
-
-const BASE = "/ui";
-
-function parseRoute(pathname: string): Route {
-  const rel = pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
-  if (rel === "" || rel === "/") return { kind: "home" };
-  const typeMatch = rel.match(/^\/type\/(.+)$/);
-  if (typeMatch) return { kind: "type", configType: decodeURIComponent(typeMatch[1]) };
-  const itemMatch = rel.match(/^\/item\/(.+)$/);
-  if (itemMatch) return { kind: "item", id: decodeURIComponent(itemMatch[1]) };
-  const accessMatch = rel.match(/^\/access\/(users|groups)(?:\/(.+))?$/);
-  if (accessMatch) {
-    return {
-      kind: "access",
-      mode: accessMatch[1] as AccessBrowserMode,
-      id: accessMatch[2] ? decodeURIComponent(accessMatch[2]) : undefined,
-    };
-  }
-  const playbookRunMatch = rel.match(/^\/playbooks\/runs\/(.+)$/);
-  if (playbookRunMatch) return { kind: "playbooks", mode: "run", runId: decodeURIComponent(playbookRunMatch[1]) };
-  if (rel === "/playbooks/runs") return { kind: "playbooks", mode: "runs" };
-  if (rel === "/playbooks") return { kind: "playbooks", mode: "list" };
-  const scraperSettingsMatch = rel.match(/^\/settings\/scrapers(?:\/(.+))?$/);
-  if (scraperSettingsMatch) {
-    return {
-      kind: "settings",
-      mode: "scrapers",
-      scraperId: scraperSettingsMatch[1] ? decodeURIComponent(scraperSettingsMatch[1]) : undefined,
-    };
-  }
-  if (rel === "/settings/scrape-plugins") return { kind: "settings", mode: "scrape-plugins" };
-  if (rel.startsWith("/explorer")) return { kind: "explorer" };
-  return { kind: "home" };
-}
-
-function buildRoute(route: Route): string {
-  switch (route.kind) {
-    case "home":
-      return `${BASE}/`;
-    case "type":
-      return `${BASE}/type/${encodeURIComponent(route.configType)}`;
-    case "item":
-      return `${BASE}/item/${encodeURIComponent(route.id)}`;
-    case "access":
-      return `${BASE}/access/${route.mode}${route.id ? `/${encodeURIComponent(route.id)}` : ""}`;
-    case "playbooks":
-      if (route.mode === "run") return `${BASE}/playbooks/runs/${encodeURIComponent(route.runId)}`;
-      if (route.mode === "runs") return `${BASE}/playbooks/runs`;
-      return `${BASE}/playbooks`;
-    case "settings":
-      if (route.mode === "scrapers") {
-        return `${BASE}/settings/scrapers${route.scraperId ? `/${encodeURIComponent(route.scraperId)}` : ""}`;
-      }
-      return `${BASE}/settings/${route.mode}`;
-    case "explorer":
-      return `${BASE}/explorer`;
-  }
-}
-
-const routeOptions: UseHistoryRouteOptions<Route> = {
-  parse: (pathname) => parseRoute(pathname),
-  build: buildRoute,
-};
+import { SettingsBrowser } from "./settings/SettingsBrowser";
+import { UI_BASE, routerPathFromHref } from "./navigation";
 
 const renderLink: RenderLink = ({ to, className, children, title, key }) => (
-  <a
-    key={key}
-    href={to}
-    className={className}
-    title={title}
-    onClick={(e) => {
-      // Plain left-clicks should use the SPA history; let modifier-clicks
-      // and non-primary buttons fall through to native navigation.
-      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
-        return;
-      }
-      e.preventDefault();
-      window.history.pushState(null, "", to);
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }}
-  >
+  <Link key={key} to={routerPathFromHref(to)} className={className} title={title}>
     {children}
-  </a>
+  </Link>
 );
 
 export function App() {
-  const [route] = useHistoryRoute<Route>(routeOptions);
+  const navigate = useNavigate();
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 
-  const navigateTo = useCallback((href: string) => {
-    window.history.pushState(null, "", href);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }, []);
+  const navigateTo = (href: string) => navigate(routerPathFromHref(href));
 
   const commandRuntime = useMemo<ClickyCommandRuntime>(
     () => ({
@@ -131,11 +39,10 @@ export function App() {
       onNavigate: (resolved) => {
         const href = buildCommandHref(resolved);
         if (!href) return;
-        window.history.pushState(null, "", href);
-        window.dispatchEvent(new PopStateEvent("popstate"));
+        navigate(routerPathFromHref(href));
       },
     }),
-    [],
+    [navigate],
   );
 
   return (
@@ -146,118 +53,143 @@ export function App() {
         onNavigate={navigateTo}
       />
       <aside className="flex w-72 shrink-0 flex-col border-r border-border bg-muted/30">
-        <a href={buildRoute({ kind: "home" })} className="flex h-14 items-center border-b border-border px-4 hover:bg-accent/40">
+        <Link to="/" className="flex h-14 items-center border-b border-border px-4 hover:bg-accent/40">
           <MissionControlLogo square={false} size={36} title="Mission Control" className="w-auto" />
-        </a>
+        </Link>
         <div className="min-h-0 flex-1 overflow-auto">
           <div className="border-b border-border p-2">
             <div className="mb-2">
               <CommandPaletteButton onClick={() => setCommandPaletteOpen(true)} />
             </div>
             <SidebarButton
-              active={route.kind === "access" && route.mode === "users"}
+              to="/access/users"
               icon="lucide:user"
               label="Access Users"
-              href={buildRoute({ kind: "access", mode: "users" })}
             />
             <SidebarButton
-              active={route.kind === "access" && route.mode === "groups"}
+              to="/access/groups"
               icon="lucide:users"
               label="Access Groups"
-              href={buildRoute({ kind: "access", mode: "groups" })}
             />
             <SidebarButton
-              active={route.kind === "playbooks"}
+              to="/playbooks"
               icon="lucide:book-open-check"
               label="Playbooks"
-              href={buildRoute({ kind: "playbooks", mode: "list" })}
             />
             <SidebarButton
-              active={route.kind === "settings" && route.mode === "scrapers"}
+              to="/settings/scrapers"
               icon="lucide:radar"
               label="Scrapers"
-              href={buildRoute({ kind: "settings", mode: "scrapers" })}
             />
             <SidebarButton
-              active={route.kind === "settings" && route.mode === "scrape-plugins"}
+              to="/settings/scrape-plugins"
               icon="lucide:plug-zap"
               label="Scrape Plugins"
-              href={buildRoute({ kind: "settings", mode: "scrape-plugins" })}
             />
           </div>
-          <CatalogSidebar
-            selected={route.kind === "type" ? route.configType : null}
-          />
+          <CatalogSidebar />
         </div>
         <div className="flex flex-col gap-density-2 border-t border-border p-2">
-          <a
-            href={buildRoute({ kind: "explorer" })}
-            className={[
+          <NavLink
+            to="/explorer"
+            className={({ isActive }) => [
               "flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-              route.kind === "explorer"
+              isActive
                 ? "bg-accent text-accent-foreground"
                 : "text-foreground/80 hover:bg-accent hover:text-accent-foreground",
             ].join(" ")}
           >
             <Icon name="lucide:database-zap" className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span>API Explorer</span>
-          </a>
+          </NavLink>
           <ThemeSwitcher className="w-full justify-between" />
           <DensitySwitcher className="w-full justify-between" />
         </div>
       </aside>
 
       <main className="min-h-0 min-w-0 flex-1 overflow-auto">
-        {route.kind === "home" && (
-          <div className="p-8 text-sm text-muted-foreground">
-            Select a resource type from the sidebar, or open the API Explorer.
-          </div>
-        )}
-        {route.kind === "type" && (
-          <TypeView configType={route.configType} />
-        )}
-        {route.kind === "item" && (
-          <ItemView id={route.id} commandRuntime={commandRuntime} />
-        )}
-        {route.kind === "access" && (
-          <AccessBrowser mode={route.mode} id={route.id} />
-        )}
-        {route.kind === "playbooks" && (
-          <PlaybookBrowser mode={route.mode} runId={route.runId} />
-        )}
-        {route.kind === "settings" && (
-          <SettingsBrowser mode={route.mode} scraperId={route.mode === "scrapers" ? route.scraperId : undefined} />
-        )}
-        {route.kind === "explorer" && (
-          <EntityExplorerApp
-            client={apiClient}
-            pathname={window.location.pathname}
-            renderLink={renderLink}
-            basePath={`${BASE}/explorer`}
-          />
-        )}
+        <Routes>
+          <Route index element={<Home />} />
+          <Route path="type/:configType" element={<TypeRoute />} />
+          <Route path="item/:id" element={<ItemRoute commandRuntime={commandRuntime} />} />
+          <Route path="access/:mode" element={<AccessRoute />} />
+          <Route path="access/:mode/:id" element={<AccessRoute />} />
+          <Route path="playbooks" element={<PlaybookBrowser mode="list" />} />
+          <Route path="playbooks/runs" element={<PlaybookBrowser mode="runs" />} />
+          <Route path="playbooks/runs/:runId" element={<PlaybookRunRoute />} />
+          <Route path="settings/scrapers" element={<SettingsScrapersRoute />} />
+          <Route path="settings/scrapers/:scraperId" element={<SettingsScrapersRoute />} />
+          <Route path="settings/scrape-plugins" element={<SettingsBrowser mode="scrape-plugins" />} />
+          <Route path="explorer/*" element={<ExplorerRoute />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
       </main>
     </div>
   );
 }
 
+function Home() {
+  return (
+    <div className="p-8 text-sm text-muted-foreground">
+      Select a resource type from the sidebar, or open the API Explorer.
+    </div>
+  );
+}
+
+function TypeRoute() {
+  const { configType } = useParams();
+  return <TypeView configType={decodeParam(configType ?? "")} />;
+}
+
+function ItemRoute({ commandRuntime }: { commandRuntime: ClickyCommandRuntime }) {
+  const { id } = useParams();
+  return <ItemView id={decodeParam(id ?? "")} commandRuntime={commandRuntime} />;
+}
+
+function AccessRoute() {
+  const { mode, id } = useParams();
+  if (mode !== "users" && mode !== "groups") return <Navigate to="/access/users" replace />;
+  return <AccessBrowser mode={mode as AccessBrowserMode} id={id ? decodeParam(id) : undefined} />;
+}
+
+function PlaybookRunRoute() {
+  const { runId } = useParams();
+  return <PlaybookBrowser mode="run" runId={decodeParam(runId ?? "")} />;
+}
+
+function SettingsScrapersRoute() {
+  const { scraperId } = useParams();
+  return <SettingsBrowser mode="scrapers" scraperId={scraperId ? decodeParam(scraperId) : undefined} />;
+}
+
+function ExplorerRoute() {
+  const location = useLocation();
+  const pathname = `${UI_BASE}${location.pathname}`;
+  return (
+    <EntityExplorerApp
+      client={apiClient}
+      pathname={pathname}
+      renderLink={renderLink}
+      basePath={`${UI_BASE}/explorer`}
+    />
+  );
+}
+
 function SidebarButton({
-  active,
+  to,
   icon,
   label,
-  href,
 }: {
-  active: boolean;
+  to: string;
   icon: string;
   label: string;
-  href: string;
 }) {
   return (
-    <a
-      href={href}
-      className={[
+    <NavLink
+      to={to}
+      className={({ isActive }) => [
         "mb-1 flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-sm transition-colors last:mb-0",
-        active
+        isActive
           ? "bg-accent font-semibold text-accent-foreground"
           : "text-foreground/80 hover:bg-accent/50 hover:text-accent-foreground",
       ].join(" ")}
@@ -266,8 +198,16 @@ function SidebarButton({
         <Icon name={icon} className="h-4 w-4 shrink-0 text-muted-foreground" />
         <span className="truncate">{label}</span>
       </span>
-    </a>
+    </NavLink>
   );
+}
+
+function decodeParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 // buildCommandHref maps a resolved clicky command (command name + args/flags)
@@ -280,17 +220,17 @@ function buildCommandHref(resolved: ClickyResolvedCommand): string | undefined {
   if (command === "getResource") {
     const id = resolved.request.args?.[0];
     if (!id) return undefined;
-    return `${BASE}/item/${encodeURIComponent(id)}`;
+    return `${UI_BASE}/item/${encodeURIComponent(id)}`;
   }
 
   if (command === "searchResources") {
     const configType = resolved.request.flags?.config_type;
-    if (configType) return `${BASE}/type/${encodeURIComponent(configType)}`;
+    if (configType) return `${UI_BASE}/type/${encodeURIComponent(configType)}`;
   }
 
   const params = new URLSearchParams();
   for (const a of resolved.request.args ?? []) params.append("arg", a);
   for (const [k, v] of Object.entries(resolved.request.flags ?? {})) params.set(k, v);
   const qs = params.toString();
-  return `${BASE}/explorer/commands/${encodeURIComponent(command)}${qs ? `?${qs}` : ""}`;
+  return `${UI_BASE}/explorer/commands/${encodeURIComponent(command)}${qs ? `?${qs}` : ""}`;
 }

--- a/ui/frontend/src/CatalogSidebar.tsx
+++ b/ui/frontend/src/CatalogSidebar.tsx
@@ -1,16 +1,14 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ErrorDetails, Icon, Tree } from "@flanksource/clicky-ui";
+import { NavLink, useNavigate } from "react-router-dom";
 import { fetchCatalogSummary } from "./api";
 import { errorDiagnosticsFromUnknown } from "./api/http";
 import { buildTypeTree, type TypeNode } from "./buildTree";
 import { ConfigIcon } from "./ConfigIcon";
 
-export type CatalogSidebarProps = {
-  selected: string | null;
-};
-
-export function CatalogSidebar({ selected }: CatalogSidebarProps) {
+export const CatalogSidebar = memo(function CatalogSidebar() {
+  const navigate = useNavigate();
   const [expandAll, setExpandAll] = useState<boolean | null>(null);
   const { data, isLoading, error } = useQuery({
     queryKey: ["catalog-summary"],
@@ -74,18 +72,12 @@ export function CatalogSidebar({ selected }: CatalogSidebarProps) {
         showControls={false}
         onSelect={(node) => {
           if (node.fullType) {
-            window.location.href = `/ui/type/${encodeURIComponent(node.fullType)}`;
+            navigate(typePath(node.fullType));
           }
         }}
         renderRow={({ node, hasChildren }) => {
           const isLeaf = !hasChildren && !!node.fullType;
-          const isSelected = isLeaf && selected === node.fullType;
-          const rowClassName = [
-            "flex w-full min-w-0 items-center justify-start gap-1 rounded px-1.5 py-0.5 text-left text-[13px]",
-            isSelected
-              ? "bg-accent font-semibold text-accent-foreground"
-              : "text-foreground/80 hover:bg-accent/50 hover:text-accent-foreground",
-          ].join(" ");
+          const baseClassName = "flex w-full min-w-0 items-center justify-start gap-1 rounded px-1.5 py-0.5 text-left text-[13px]";
 
           const content = (
             <>
@@ -103,18 +95,23 @@ export function CatalogSidebar({ selected }: CatalogSidebarProps) {
 
           if (isLeaf && node.fullType) {
             return (
-              <a
-                className={rowClassName}
-                href={`/ui/type/${encodeURIComponent(node.fullType)}`}
+              <NavLink
+                className={({ isActive }) => [
+                  baseClassName,
+                  isActive
+                    ? "bg-accent font-semibold text-accent-foreground"
+                    : "text-foreground/80 hover:bg-accent/50 hover:text-accent-foreground",
+                ].join(" ")}
+                to={typePath(node.fullType)}
                 onClick={(event) => event.stopPropagation()}
               >
                 {content}
-              </a>
+              </NavLink>
             );
           }
 
           return (
-            <div className={rowClassName}>
+            <div className={[baseClassName, "text-foreground/80 hover:bg-accent/50 hover:text-accent-foreground"].join(" ")}>
               {content}
             </div>
           );
@@ -126,4 +123,8 @@ export function CatalogSidebar({ selected }: CatalogSidebarProps) {
       />
     </div>
   );
+});
+
+function typePath(fullType: string) {
+  return `/type/${encodeURIComponent(fullType)}`;
 }

--- a/ui/frontend/src/TypeView.tsx
+++ b/ui/frontend/src/TypeView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Badge,
@@ -33,13 +33,18 @@ import {
 import { TagList } from "./config-detail/TagList";
 import { healthStatus } from "./config-detail/utils";
 import { DetailPageLayout, EntityHeader } from "./layout/DetailPageLayout";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 export type TypeViewProps = {
   configType: string;
 };
 
 export function TypeView({ configType }: TypeViewProps) {
-  const [searchParams, setSearchParams] = useLocationSearchParams();
+  const navigate = useNavigate();
+  const [searchParams, setRouterSearchParams] = useSearchParams();
+  const setSearchParams = useCallback((updater: (current: URLSearchParams) => URLSearchParams) => {
+    setRouterSearchParams((current) => updater(new URLSearchParams(current)), { replace: true });
+  }, [setRouterSearchParams]);
   const searchParamsKey = searchParams.toString();
   const filters = useMemo(
     () => parseConfigListFilters(searchParams, configType),
@@ -120,7 +125,7 @@ export function TypeView({ configType }: TypeViewProps) {
         value: configType,
         options: configTypeOptions,
         onChange: (value) => {
-          if (value && value !== configType) navigateToConfigType(value, searchParams);
+          if (value && value !== configType) navigateToConfigType(navigate, value, searchParams);
         },
         disabled: configTypeOptions.length === 0,
       },
@@ -177,6 +182,7 @@ export function TypeView({ configType }: TypeViewProps) {
       filters.status,
       groupByOptions,
       labelOptions,
+      navigate,
       searchParams,
       statusOptions,
       updateParam,
@@ -251,12 +257,13 @@ function ConfigGroups({ groups }: { groups: ReturnType<typeof groupConfigItems> 
 }
 
 function ConfigTable({ rows }: { rows: ConfigItem[] }) {
+  const navigate = useNavigate();
   return (
     <DataTable
       data={rows as unknown as Record<string, unknown>[]}
       columns={configColumns}
       getRowId={(row) => String(row.id)}
-      getRowHref={(row) => `/ui/item/${encodeURIComponent(String(row.id))}`}
+      onRowClick={(row) => navigate(`/item/${encodeURIComponent(String(row.id))}`)}
       showGlobalFilter={false}
       defaultSort={{ key: "name", dir: "asc" }}
       emptyMessage="No matching config items"
@@ -321,36 +328,11 @@ const configColumns: DataTableColumn<Record<string, unknown>>[] = [
   },
 ];
 
-function useLocationSearchParams(): [
-  URLSearchParams,
-  (updater: (current: URLSearchParams) => URLSearchParams) => void,
-] {
-  const [search, setSearch] = useState(() => window.location.search);
-
-  useEffect(() => {
-    const onPopState = () => setSearch(window.location.search);
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
-  }, []);
-
-  const setSearchParams = useCallback((updater: (current: URLSearchParams) => URLSearchParams) => {
-    const next = updater(new URLSearchParams(window.location.search));
-    const query = next.toString();
-    const url = `${window.location.pathname}${query ? `?${query}` : ""}`;
-    window.history.replaceState(null, "", url);
-    setSearch(window.location.search);
-  }, []);
-
-  return [useMemo(() => new URLSearchParams(search), [search]), setSearchParams];
-}
-
-function navigateToConfigType(configType: string, currentParams: URLSearchParams) {
+function navigateToConfigType(navigate: ReturnType<typeof useNavigate>, configType: string, currentParams: URLSearchParams) {
   const nextParams = new URLSearchParams(currentParams);
   nextParams.delete("configType");
   const query = nextParams.toString();
-  const href = `/ui/type/${encodeURIComponent(configType)}${query ? `?${query}` : ""}`;
-  window.history.pushState(null, "", href);
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  navigate(`/type/${encodeURIComponent(configType)}${query ? `?${query}` : ""}`);
 }
 
 function configLabelOptions(tags: ConfigLabelOption[], labels: ConfigLabelOption[]): MultiSelectOption[] {

--- a/ui/frontend/src/access/AccessBrowser.tsx
+++ b/ui/frontend/src/access/AccessBrowser.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Badge,
   DataTable,
@@ -31,6 +32,7 @@ import type {
 import { TagList } from "../config-detail/TagList";
 import { formatDate, isIndirectAccess, stringifyValue, timeAgo } from "../config-detail/utils";
 import { DetailPageLayout, EntityHeader, HeaderPill, PageBreadcrumbs } from "../layout/DetailPageLayout";
+import { AppLink } from "../navigation";
 
 export type AccessBrowserMode = "users" | "groups";
 
@@ -47,6 +49,7 @@ export function AccessBrowser({ mode, id }: AccessBrowserProps) {
 }
 
 function AccessUsersList() {
+  const navigate = useNavigate();
   const query = useAccessUsers();
   return (
     <AccessShell
@@ -61,7 +64,7 @@ function AccessUsersList() {
           data={query.data as unknown as Record<string, unknown>[]}
           columns={userColumns}
           getRowId={(row) => String(row.id)}
-          getRowHref={(row) => `/ui/access/users/${encodeURIComponent(String(row.id))}`}
+          onRowClick={(row) => navigate(`/access/users/${encodeURIComponent(String(row.id))}`)}
           defaultSort={{ key: "name", dir: "asc" }}
           autoFilter
         />
@@ -71,6 +74,7 @@ function AccessUsersList() {
 }
 
 function AccessGroupsList() {
+  const navigate = useNavigate();
   const query = useAccessGroups();
   return (
     <AccessShell
@@ -85,7 +89,7 @@ function AccessGroupsList() {
           data={query.data as unknown as Record<string, unknown>[]}
           columns={groupColumns}
           getRowId={(row) => String(row.id)}
-          getRowHref={(row) => `/ui/access/groups/${encodeURIComponent(String(row.id))}`}
+          onRowClick={(row) => navigate(`/access/groups/${encodeURIComponent(String(row.id))}`)}
           defaultSort={{ key: "name", dir: "asc" }}
           autoFilter
         />
@@ -436,6 +440,7 @@ function numberSortValue(value: unknown) {
 }
 
 function MembershipGroupsTable({ rows }: { rows: ExternalUserGroupMembership[] }) {
+  const navigate = useNavigate();
   const [showRemoved, setShowRemoved] = useState(false);
   const [search, setSearch] = useState("");
   if (rows.length === 0) return <DetailEmptyState label="No group memberships" />;
@@ -463,7 +468,7 @@ function MembershipGroupsTable({ rows }: { rows: ExternalUserGroupMembership[] }
           data={visibleRows as unknown as Record<string, unknown>[]}
           columns={membershipGroupColumns}
           getRowId={(row, index) => `${row.external_group_id}-${index}`}
-          getRowHref={(row) => `/ui/access/groups/${encodeURIComponent(String(row.external_group_id))}`}
+          onRowClick={(row) => navigate(`/access/groups/${encodeURIComponent(String(row.external_group_id))}`)}
           showGlobalFilter={false}
         />
       )}
@@ -521,13 +526,14 @@ function membershipGroupSearchText(row: ExternalUserGroupMembership) {
 }
 
 function MembershipUsersTable({ rows }: { rows: ExternalUserGroupMembership[] }) {
+  const navigate = useNavigate();
   if (rows.length === 0) return <DetailEmptyState label="No members" />;
   return (
     <DataTable
       data={rows as unknown as Record<string, unknown>[]}
       columns={membershipUserColumns}
       getRowId={(row, index) => `${row.external_user_id}-${index}`}
-      getRowHref={(row) => `/ui/access/users/${encodeURIComponent(String(row.external_user_id))}`}
+      onRowClick={(row) => navigate(`/access/users/${encodeURIComponent(String(row.external_user_id))}`)}
       autoFilter
     />
   );
@@ -660,7 +666,7 @@ function permissionMatrixRows(group: PermissionResourceGroup): MatrixTableRow[] 
   return group.resources.map((resource) => ({
     key: resource.id,
     label: (
-      <a href={configHref(resource.id)} className="flex min-w-0 items-center gap-2 hover:underline">
+      <AppLink href={configHref(resource.id)} className="flex min-w-0 items-center gap-2 hover:underline">
         <ConfigIcon primary={resource.type} className="h-4 max-w-4 shrink-0 text-muted-foreground" />
         <div className="min-w-0">
           <div className="truncate">{resource.name}</div>
@@ -668,15 +674,15 @@ function permissionMatrixRows(group: PermissionResourceGroup): MatrixTableRow[] 
             <div className="truncate font-mono text-[11px] font-normal text-muted-foreground">{resource.id}</div>
           )}
         </div>
-      </a>
+      </AppLink>
     ),
     cells: group.roles.map((role) => {
       const permission = resource.roles.get(role);
       if (!permission) return null;
       return (
-        <a href={configHref(resource.id)} className="inline-flex w-full justify-center" title={permissionTooltip(permission)}>
+        <AppLink href={configHref(resource.id)} className="inline-flex w-full justify-center" title={permissionTooltip(permission)}>
           <PermissionDot indirect={isIndirectAccess(permission)} />
-        </a>
+        </AppLink>
       );
     }),
   }));

--- a/ui/frontend/src/components/ConfigItemSelector.tsx
+++ b/ui/frontend/src/components/ConfigItemSelector.tsx
@@ -6,6 +6,7 @@ import { ConfigIcon } from "../ConfigIcon";
 import { searchConfigResources, type ResourceSelector } from "../api/configs";
 import { useConfigDetail } from "../api/hooks";
 import type { ConfigItem } from "../api/types";
+import { AppLink } from "../navigation";
 
 type ConfigItemSelectorProps = {
   valueId?: string;
@@ -191,10 +192,10 @@ function ConfigLink({
   if (!id) return <span className="text-muted-foreground">-</span>;
   const label = config?.name || labelFallback || id;
   return (
-    <a href={`/ui/item/${encodeURIComponent(id)}`} className="inline-flex max-w-full min-w-0 items-center gap-2 text-sm text-foreground hover:text-primary">
+    <AppLink href={`/ui/item/${encodeURIComponent(id)}`} className="inline-flex max-w-full min-w-0 items-center gap-2 text-sm text-foreground hover:text-primary">
       <ConfigIcon primary={config?.type || config?.config_class || "config"} className="h-4 max-w-4 shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate">{label}</span>
       {config?.deleted_at && <Badge tone="danger" size="xxs">Deleted</Badge>}
-    </a>
+    </AppLink>
   );
 }

--- a/ui/frontend/src/config-detail/ConfigItemDetail.tsx
+++ b/ui/frontend/src/config-detail/ConfigItemDetail.tsx
@@ -67,6 +67,7 @@ import type {
 } from "./config-changes/types";
 import { PluginTab } from "./PluginTab";
 import { pluginTabKey, usePluginTabs } from "./use-plugin-tabs";
+import { AppLink } from "../navigation";
 
 type TabKey = "overview" | "relationships" | "changes" | "insights" | "access" | "playbooks" | "json" | string;
 
@@ -263,9 +264,9 @@ function ConfigHeader({ config }: { config: ConfigItem }) {
         <>
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             {config.type && (
-              <a className="font-mono text-xs text-sky-700 hover:underline" href={`/ui/type/${encodeURIComponent(config.type)}`}>
+              <AppLink className="font-mono text-xs text-sky-700 hover:underline" href={`/ui/type/${encodeURIComponent(config.type)}`}>
                 {config.type}
-              </a>
+              </AppLink>
             )}
             {config.config_class && <span>{config.config_class}</span>}
             <span className="font-mono text-xs">{config.id}</span>
@@ -343,13 +344,13 @@ function OverviewTab({
           ) : (
             <div className="flex flex-col gap-2">
               {parents.map((parent) => (
-                <a key={parent.id} href={`/ui/item/${encodeURIComponent(parent.id)}`} className="rounded-md border border-border p-2 hover:bg-accent/50">
+                <AppLink key={parent.id} href={`/ui/item/${encodeURIComponent(parent.id)}`} className="rounded-md border border-border p-2 hover:bg-accent/50">
                   <div className="flex items-center gap-2">
                     <ConfigIcon primary={parent.type} className="h-4 max-w-4 shrink-0 text-muted-foreground" />
                     <span className="truncate text-sm font-medium">{parent.name}</span>
                   </div>
                   <div className="mt-1 truncate font-mono text-xs text-muted-foreground">{parent.type}</div>
-                </a>
+                </AppLink>
               ))}
               <div className="rounded-md border border-primary/30 bg-primary/5 p-2">
                 <div className="flex items-center gap-2">
@@ -490,13 +491,13 @@ function ParentageBlock({
   }
 
   return (
-    <a
+    <AppLink
       href={`/ui/item/${encodeURIComponent(id)}`}
       className="group shrink-0"
       title={item?.name || id}
     >
       {content}
-    </a>
+    </AppLink>
   );
 }
 
@@ -704,7 +705,7 @@ function RelationshipCard({ item }: { item: ConfigRelationshipTreeNode }) {
   const tags = tagEntries(item.tags);
   const tagValues = tags.map(([key, value]) => `${key}=${value}`);
   return (
-    <a
+    <AppLink
       href={`/ui/item/${encodeURIComponent(item.id)}`}
       className={[
         "group flex min-w-0 flex-1 items-center gap-2 rounded-md border bg-background px-2.5 py-1.5 shadow-sm transition hover:bg-accent/50 hover:shadow",
@@ -732,7 +733,7 @@ function RelationshipCard({ item }: { item: ConfigRelationshipTreeNode }) {
       )}
       {item.relation && <Badge size="xxs">{item.relation}</Badge>}
       {isRelated && <span className="h-2 w-2 shrink-0 rounded-full bg-violet-500" title="Related config" />}
-    </a>
+    </AppLink>
   );
 }
 
@@ -970,7 +971,7 @@ function AccessMatrix({ config, rows }: { config: ConfigItem; rows: ConfigAccess
             </button>
           ) : undefined}
         >
-          <a href={accessPrincipalHref(NIL_UUID, group.groupId, `group:${group.groupName}`)} className="flex min-w-0 items-center gap-2 hover:underline">
+          <AppLink href={accessPrincipalHref(NIL_UUID, group.groupId, `group:${group.groupName}`)} className="flex min-w-0 items-center gap-2 hover:underline">
             <Icon name="lucide:users" className="h-4 max-w-4 shrink-0 text-muted-foreground" />
             <div className="flex min-w-0 items-center gap-2">
               <span className="min-w-0 truncate">{group.groupName}</span>
@@ -980,7 +981,7 @@ function AccessMatrix({ config, rows }: { config: ConfigItem; rows: ConfigAccess
                 </Badge>
               )}
             </div>
-          </a>
+          </AppLink>
         </MatrixPrincipalLabel>
       ),
       cells: matrix.roles.map((role) => {
@@ -988,9 +989,9 @@ function AccessMatrix({ config, rows }: { config: ConfigItem; rows: ConfigAccess
         if (!row) return null;
         return (
           <AccessMatrixTooltip content={<AccessCellTooltip principalName={group.groupName} row={row} />}>
-            <a href={accessRoleHref(row)} className="inline-flex w-full justify-center">
+            <AppLink href={accessRoleHref(row)} className="inline-flex w-full justify-center">
               <AccessDot indirect />
-            </a>
+            </AppLink>
           </AccessMatrixTooltip>
         );
       }),
@@ -1027,7 +1028,7 @@ function matrixUserRow(
     key: child ? `${user.groupId ?? "group"}:${user.key}` : user.key,
     label: (
       <MatrixPrincipalLabel child={child}>
-        <a
+        <AppLink
           href={accessPrincipalHref(user.userId, user.groupId, child ? undefined : user.roleSource)}
           className="flex min-w-0 items-center gap-2 hover:underline"
         >
@@ -1036,7 +1037,7 @@ function matrixUserRow(
             <div className="truncate">{user.name}</div>
             {user.email && <div className="truncate text-xs font-normal text-muted-foreground">{user.email}</div>}
           </div>
-        </a>
+        </AppLink>
       </MatrixPrincipalLabel>
     ),
     cells: roles.map((role) => {
@@ -1045,9 +1046,9 @@ function matrixUserRow(
       const href = accessRoleHref(row);
       return (
         <AccessMatrixTooltip content={<AccessCellTooltip principalName={user.name} row={row} />}>
-          <a href={href} className="inline-flex w-full justify-center">
+          <AppLink href={href} className="inline-flex w-full justify-center">
             <AccessDot indirect={isIndirectAccess(row)} />
-          </a>
+          </AppLink>
         </AccessMatrixTooltip>
       );
     }),

--- a/ui/frontend/src/layout/DetailPageLayout.tsx
+++ b/ui/frontend/src/layout/DetailPageLayout.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 import { Icon } from "@flanksource/clicky-ui";
 import { ConfigIcon } from "../ConfigIcon";
+import { AppLink } from "../navigation";
 
 export type PageBreadcrumbItem = {
   label: ReactNode;
@@ -77,7 +78,7 @@ export function PageBreadcrumbs({ items }: { items: PageBreadcrumbItem[] }) {
           <span key={index} className="inline-flex min-w-0 items-center gap-3">
             {index > 0 && <span className="text-lg text-muted-foreground">/</span>}
             {item.href ? (
-              <a
+              <AppLink
                 href={item.href}
                 title={item.title}
                 className={[
@@ -86,7 +87,7 @@ export function PageBreadcrumbs({ items }: { items: PageBreadcrumbItem[] }) {
                 ].filter(Boolean).join(" ")}
               >
                 {content}
-              </a>
+              </AppLink>
             ) : (
               <span
                 title={item.title}

--- a/ui/frontend/src/main.tsx
+++ b/ui/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
 import {
   ThemeProvider,
   DensityProvider,
@@ -45,7 +46,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <ThemeProvider>
       <DensityProvider>
         <QueryClientProvider client={queryClient}>
-          <App />
+          <BrowserRouter basename="/ui">
+            <App />
+          </BrowserRouter>
         </QueryClientProvider>
       </DensityProvider>
     </ThemeProvider>

--- a/ui/frontend/src/navigation.tsx
+++ b/ui/frontend/src/navigation.tsx
@@ -1,0 +1,35 @@
+import { Link, type LinkProps } from "react-router-dom";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+export const UI_BASE = "/ui";
+
+export function routerPathFromHref(href: string): string {
+  if (href === UI_BASE) return "/";
+  if (href.startsWith(`${UI_BASE}/`)) return href.slice(UI_BASE.length);
+  return href;
+}
+
+export function uiHref(path: string): string {
+  return `${UI_BASE}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function isUiHref(href: string): boolean {
+  return href === UI_BASE || href.startsWith(`${UI_BASE}/`);
+}
+
+type AppLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
+  href: string;
+  children?: ReactNode;
+};
+
+export function AppLink({ href, children, ...props }: AppLinkProps) {
+  if (!isUiHref(href)) {
+    return <a href={href} {...props}>{children}</a>;
+  }
+
+  return (
+    <Link to={routerPathFromHref(href)} {...(props as Omit<LinkProps, "to">)}>
+      {children}
+    </Link>
+  );
+}

--- a/ui/frontend/src/playbooks/PlaybookBrowser.tsx
+++ b/ui/frontend/src/playbooks/PlaybookBrowser.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Badge,
   DataTable,
@@ -40,6 +41,7 @@ import {
   useRunnablePlaybooksForConfig,
 } from "../api/hooks";
 import { type ResourceSelector } from "../api/configs";
+import { AppLink } from "../navigation";
 import { ConfigItemSelector } from "../components/ConfigItemSelector";
 import type {
   ConfigItem,
@@ -616,10 +618,10 @@ function PlaybookCardMenu({
       className="absolute right-4 top-12 z-30 w-40 overflow-hidden rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-lg"
       onClick={(event) => event.stopPropagation()}
     >
-      <a href={historyHref} className={itemClass}>
+      <AppLink href={historyHref} className={itemClass}>
         <Icon name="lucide:history" />
         History
-      </a>
+      </AppLink>
       <button type="button" onClick={onRun} className={itemClass}>
         <Icon name="lucide:play" />
         Run
@@ -662,7 +664,7 @@ function RecentRunsPanel({ runs, loading }: { runs: PlaybookRun[]; loading: bool
               {runs.slice(0, 12).map((run) => {
                 const target = targetSummaryFromRun(run);
                 return (
-                  <a
+                  <AppLink
                     key={run.id}
                     href={`/ui/playbooks/runs/${encodeURIComponent(run.id)}`}
                     className="grid min-w-0 gap-2 rounded-md border border-transparent p-2 text-sm hover:border-border hover:bg-accent/30"
@@ -676,7 +678,7 @@ function RecentRunsPanel({ runs, loading }: { runs: PlaybookRun[]; loading: bool
                       <span className="truncate">{target?.label ?? "No target"}</span>
                       <span className="shrink-0">{timeAgo(run.start_time || run.scheduled_time || run.created_at || "")}</span>
                     </div>
-                  </a>
+                  </AppLink>
                 );
               })}
             </div>
@@ -1303,7 +1305,7 @@ function RunSideRail({
         ) : (
           <div className="grid gap-2">
             {childRuns.map((child) => (
-              <a
+              <AppLink
                 key={child.id}
                 href={`/ui/playbooks/runs/${encodeURIComponent(child.id)}`}
                 className="grid gap-1 rounded-md border border-border p-2 text-sm hover:bg-accent/30"
@@ -1313,7 +1315,7 @@ function RunSideRail({
                   <StatusDot status={child.status} />
                 </div>
                 <span className="truncate font-mono text-xs text-muted-foreground">{child.id}</span>
-              </a>
+              </AppLink>
             ))}
           </div>
         )}
@@ -1394,6 +1396,7 @@ function SubmitPlaybookRunDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [parameters, setParameters] = useState<PlaybookParameter[]>([]);
   const [values, setValues] = useState<Record<string, string>>({});
   const [runTarget, setRunTarget] = useState<PlaybookRunTarget>(target);
@@ -1405,8 +1408,7 @@ function SubmitPlaybookRunDialog({
     mutationFn: (request: PlaybookRunSubmitRequest) => submitPlaybookRun(request),
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["playbook_runs"] });
-      window.history.pushState(null, "", `/ui/playbooks/runs/${encodeURIComponent(response.run_id)}`);
-      window.dispatchEvent(new PopStateEvent("popstate"));
+      navigate(`/playbooks/runs/${encodeURIComponent(response.run_id)}`);
       onClose();
     },
   });
@@ -1799,7 +1801,6 @@ function PlaybookRunsTable({ runs }: { runs: PlaybookRun[] }) {
       data={runs as unknown as Record<string, unknown>[]}
       columns={runColumns}
       getRowId={(row) => String(row.id)}
-      getRowHref={(row) => `/ui/playbooks/runs/${encodeURIComponent(String(row.id))}`}
       defaultSort={{ key: "created_at", dir: "desc" }}
       autoFilter
       renderExpandedRow={(row) => <JsonView data={row} defaultOpenDepth={1} />}
@@ -1858,10 +1859,10 @@ function PlaybookShell({
           </div>
           <div className="min-w-0">
             {backHref && (
-              <a href={backHref} className="mb-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+              <AppLink href={backHref} className="mb-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
                 <Icon name="lucide:arrow-left" />
                 {backLabel}
-              </a>
+              </AppLink>
             )}
             <h1 className="truncate text-xl font-semibold">{title}</h1>
             {subtitle && <div className="mt-1 truncate text-sm text-muted-foreground">{subtitle}</div>}
@@ -1885,12 +1886,11 @@ function PlaybookPageTabs({ active }: { active: "playbooks" | "runs" }) {
     <div className="border-b border-border pb-2">
       <div className="flex flex-wrap items-center gap-2" role="tablist">
         {tabs.map((tab) => (
-          <button
+          <AppLink
             key={tab.id}
-            type="button"
+            href={tab.href}
             role="tab"
             aria-selected={active === tab.id}
-            onClick={() => navigateTo(tab.href)}
             className={[
               "inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium",
               active === tab.id
@@ -1900,7 +1900,7 @@ function PlaybookPageTabs({ active }: { active: "playbooks" | "runs" }) {
           >
             <ConfigIcon primary={tab.icon} className="h-4 max-w-4" />
             {tab.label}
-          </button>
+          </AppLink>
         ))}
       </div>
     </div>
@@ -1914,10 +1914,10 @@ function RunFilters({ status, playbookId }: { status?: string; playbookId?: stri
       <span>Filters:</span>
       {status && <Badge size="xs" icon="lucide:activity">Status {status}</Badge>}
       {playbookId && <Badge size="xs" icon="lucide:book-open-check">Playbook {playbookId}</Badge>}
-      <a href="/ui/playbooks/runs" className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 hover:bg-accent/50">
+      <Link to="/playbooks/runs" className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 hover:bg-accent/50">
         <Icon name="lucide:x" />
         Clear
-      </a>
+      </Link>
     </div>
   );
 }
@@ -1998,11 +1998,11 @@ function ConfigLink({
   if (!id) return <span className="text-muted-foreground">-</span>;
   const label = data?.name || labelFallback || id;
   return (
-    <a href={`/ui/item/${encodeURIComponent(id)}`} className={["inline-flex max-w-full items-center gap-2", className].join(" ")}>
+    <AppLink href={`/ui/item/${encodeURIComponent(id)}`} className={["inline-flex max-w-full items-center gap-2", className].join(" ")}>
       <ConfigIcon primary={data?.type || data?.config_class || "config"} className="h-4 max-w-4 shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate">{label}</span>
       {data?.deleted_at && <Badge tone="danger" size="xxs">Deleted</Badge>}
-    </a>
+    </AppLink>
   );
 }
 
@@ -2090,7 +2090,8 @@ const runColumns: DataTableColumn<Record<string, unknown>>[] = [
     grow: true,
     render: (value, row) => {
       const playbook = value as Playbook | null;
-      return (
+      const runId = String(row.id ?? "");
+      const content = (
         <div className="flex min-w-0 items-center gap-2">
           <PlaybookIcon playbook={playbook ?? { id: String(row.playbook_id ?? ""), name: String(row.playbook_id ?? "") }} className="h-5 max-w-5 shrink-0" />
           <div className="min-w-0">
@@ -2101,6 +2102,7 @@ const runColumns: DataTableColumn<Record<string, unknown>>[] = [
           </div>
         </div>
       );
+      return runId ? <AppLink href={`/ui/playbooks/runs/${encodeURIComponent(runId)}`} className="hover:underline">{content}</AppLink> : content;
     },
     filterValue: (value, row) => {
       const playbook = value as Playbook | null;
@@ -2120,15 +2122,13 @@ const runColumns: DataTableColumn<Record<string, unknown>>[] = [
 ];
 
 function usePlaybookRunFilters(): PlaybookRunsOptions {
-  const search = typeof window === "undefined" ? "" : window.location.search;
-  return useMemo(() => {
-    const params = new URLSearchParams(search);
-    return {
-      playbookId: params.get("playbook") || undefined,
-      status: params.get("status") || undefined,
-      limit: 50,
-    };
-  }, [search]);
+  const [params] = useSearchParams();
+  const search = params.toString();
+  return useMemo(() => ({
+    playbookId: params.get("playbook") || undefined,
+    status: params.get("status") || undefined,
+    limit: 50,
+  }), [params, search]);
 }
 
 function runnableListItemToPlaybook(item: PlaybookListItem): RunnablePlaybook {
@@ -2864,7 +2864,3 @@ function toneStepCircleClass(tone: PlaybookStatusVisual["tone"], emphasized = fa
   }
 }
 
-function navigateTo(href: string) {
-  window.history.pushState(null, "", href);
-  window.dispatchEvent(new PopStateEvent("popstate"));
-}

--- a/ui/frontend/src/settings/SettingsBrowser.tsx
+++ b/ui/frontend/src/settings/SettingsBrowser.tsx
@@ -29,6 +29,7 @@ import type { ConfigItem } from "../api/types";
 import { ConfigItemSelector } from "../components/ConfigItemSelector";
 import { formatDate, stringifyValue, timeAgo } from "../config-detail/utils";
 import { DetailPageLayout, EntityHeader, HeaderPill, PageBreadcrumbs } from "../layout/DetailPageLayout";
+import { AppLink } from "../navigation";
 
 export type SettingsMode = "scrapers" | "scrape-plugins";
 
@@ -426,10 +427,10 @@ function ScraperTable({ rows }: { rows: ConfigScraper[] }) {
           {rows.map((row) => (
             <tr key={row.id} className="border-b border-border last:border-b-0 hover:bg-accent/40">
               <td className="px-3 py-2">
-                <a href={`/ui/settings/scrapers/${encodeURIComponent(row.id)}`} className="flex min-w-0 items-center gap-2 hover:text-primary">
+                <AppLink href={`/ui/settings/scrapers/${encodeURIComponent(row.id)}`} className="flex min-w-0 items-center gap-2 hover:text-primary">
                   <Icon name="lucide:radar" className="shrink-0 text-muted-foreground" />
                   <span className="truncate font-medium">{row.name || row.id}</span>
-                </a>
+                </AppLink>
               </td>
               <td className="truncate px-3 py-2 text-muted-foreground">{stringifyValue(row.namespace)}</td>
               <td className="truncate px-3 py-2 text-muted-foreground">{stringifyValue(row.source)}</td>


### PR DESCRIPTION
Sidebar navigation in `ui/frontend` was using a mix of manual history handling, raw anchors, and `window.location.href`, causing full document reloads.\n\nReplace the custom route state layer with `react-router-dom`, wire `/ui` routes through `BrowserRouter`, and convert internal navigation to `Link`/`NavLink`.\n\nThe sidebar now stays mounted during navigation; only active selection/content changes update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds client-side routing support (new routing dependency and app router) for smoother navigation.

* **Refactor**
  * Unified navigation across the app using routing primitives and a single AppLink wrapper.
  * Sidebars, lists, tables, breadcrumbs, playbooks, settings and detail pages now use client-side links and navigation (no full page reloads).
  * URL/query handling moved to router-driven mechanisms for consistent back/forward and parameter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->