### PR TITLE
fix(plugins): Validate selector during k8s reconciliation

### DIFF
--- a/plugin/registry/reconciler.go
+++ b/plugin/registry/reconciler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flanksource/deps"
 	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/query/grammar"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/google/uuid"
@@ -43,6 +44,9 @@ func PersistPluginFromCRD(ctx context.Context, p *v1.Plugin) error {
 	}
 	if p.Spec.Source == "" {
 		return fmt.Errorf("plugin %s: spec.source is required", p.Name)
+	}
+	if err := validatePluginSelector(p); err != nil {
+		return err
 	}
 
 	binDir := PluginPath()
@@ -164,6 +168,26 @@ func DeleteStalePlugin(ctx context.Context, newer *v1.Plugin) error {
 		}
 		Default.Remove(e.ID)
 	}
+	return nil
+}
+
+func validatePluginSelector(p *v1.Plugin) error {
+	selector := p.Spec.Selector
+	if selector.IsEmpty() {
+		return nil
+	}
+
+	peg, err := selector.ToPeg(true)
+	if err != nil {
+		return fmt.Errorf("plugin %s: invalid spec.selector: %w", p.Name, err)
+	}
+	if peg == "" {
+		return nil
+	}
+	if _, err := grammar.ParsePEG(peg); err != nil {
+		return fmt.Errorf("plugin %s: invalid spec.selector: %w", p.Name, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
```yaml
...
status:
  conditions:
  - lastTransitionTime: "2026-05-22T10:29:13Z"
    message: 'plugin postgres: invalid spec.selector: failed to convert labels to
      selector: unable to parse requirement: <nil>: Invalid value: "missionControl/connection-type":
      prefix part a lowercase RFC 1123 subdomain must consist of lower case alphanumeric
      characters, ''-'' or ''.'', and must start and end with an alphanumeric character
      (e.g. ''example.com'', regex used for validation is ''[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'')'
    observedGeneration: 3
    reason: PersistFailed
    status: "False"
    type: Ready
  installedPath: /Users/aditya/projects/flanksource/local-setup/plugins/postgres
  observedGeneration: 2
  pluginVersion: v1.0.0+ede4db8e built 2026-05-19 09:54:00
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of plugin selectors during installation to detect invalid selector syntax earlier.
  * Empty selectors are now handled gracefully, avoiding unnecessary validation steps.
  * Error messages for invalid selectors are now clearer and scoped to the affected plugin for easier troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->