### PR TITLE
feat(plugin): resolve connections by id

### DIFF
--- a/plugin/host/connection.go
+++ b/plugin/host/connection.go
@@ -47,6 +47,18 @@ func (s *Service) getConnectionByRef(ctx dutyContext.Context, ref string) (*plug
 	return cloneResolvedConnection(resolved), nil
 }
 
+func (s *Service) getConnectionByID(ctx dutyContext.Context, connectionID string) (*pluginpb.ResolvedConnection, error) {
+	if connectionID == "" {
+		return nil, fmt.Errorf("connection id is required")
+	}
+
+	conn, err := dutyConn.Get(ctx, connectionID)
+	if err != nil {
+		return nil, fmt.Errorf("get connection %s: %w", connectionID, err)
+	}
+	return pluginpb.ConnectionToProto(conn), nil
+}
+
 func (s *Service) getConnectionForConfig(ctx dutyContext.Context, configItemID string) (*pluginpb.ResolvedConnection, error) {
 	scraper, err := models.FindScraperByConfigId(ctx.DB(), configItemID)
 	if err != nil {

--- a/plugin/host/service.go
+++ b/plugin/host/service.go
@@ -154,6 +154,9 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginpb.GetConnection
 	case *pluginpb.GetConnectionRequest_ConfigItemId:
 		return s.getConnectionForConfig(pluginCtx, lookup.ConfigItemId)
 
+	case *pluginpb.GetConnectionRequest_ConnectionId:
+		return s.getConnectionByID(pluginCtx, lookup.ConnectionId)
+
 	default:
 		return nil, fmt.Errorf("connection lookup is required")
 	}

--- a/plugin/proto/plugin.pb.go
+++ b/plugin/proto/plugin.pb.go
@@ -1415,10 +1415,16 @@ func (x *ListConfigsRequest) GetCursor() string {
 	return ""
 }
 
-// GetConnectionRequest asks the host to resolve a connection by one of three
-// supported lookups: type, config item, or plugin-defined label. Type and label
-// lookups use spec.connections mappings from the Plugin CRD. Config lookups use
-// the scraper that created the config item.
+// GetConnectionRequest asks the host to resolve a connection by one of four
+// supported lookups: type, scraper config item, plugin-defined label, or direct
+// connection id.
+//
+// Type and label lookups use spec.connections mappings from the Plugin CRD.
+// config_item_id preserves the existing behavior: it resolves the connection
+// used by the scraper that created the config item. connection_id resolves a
+// Mission Control connection by id; plugins attached to MissionControl::Connection
+// config items can pass their config_item_id because connection config item ids
+// are the same as the underlying connection ids.
 type GetConnectionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Lookup:
@@ -1426,6 +1432,7 @@ type GetConnectionRequest struct {
 	//	*GetConnectionRequest_Type
 	//	*GetConnectionRequest_ConfigItemId
 	//	*GetConnectionRequest_Label
+	//	*GetConnectionRequest_ConnectionId
 	Lookup        isGetConnectionRequest_Lookup `protobuf_oneof:"lookup"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1495,12 +1502,21 @@ func (x *GetConnectionRequest) GetLabel() string {
 	return ""
 }
 
+func (x *GetConnectionRequest) GetConnectionId() string {
+	if x != nil {
+		if x, ok := x.Lookup.(*GetConnectionRequest_ConnectionId); ok {
+			return x.ConnectionId
+		}
+	}
+	return ""
+}
+
 type isGetConnectionRequest_Lookup interface {
 	isGetConnectionRequest_Lookup()
 }
 
 type GetConnectionRequest_Type struct {
-	Type string `protobuf:"bytes,1,opt,name=type,proto3,oneof"` // e.g. "sql", "aws", "kubernetes", "gcp", "azure"
+	Type string `protobuf:"bytes,1,opt,name=type,proto3,oneof"` // e.g. "sql", "aws", "kubernetes", "gcp", "azure", "s3"
 }
 
 type GetConnectionRequest_ConfigItemId struct {
@@ -1511,11 +1527,17 @@ type GetConnectionRequest_Label struct {
 	Label string `protobuf:"bytes,3,opt,name=label,proto3,oneof"` // resolve a plugin-defined connection label mapping
 }
 
+type GetConnectionRequest_ConnectionId struct {
+	ConnectionId string `protobuf:"bytes,4,opt,name=connection_id,json=connectionId,proto3,oneof"` // resolve a Mission Control connection by id
+}
+
 func (*GetConnectionRequest_Type) isGetConnectionRequest_Lookup() {}
 
 func (*GetConnectionRequest_ConfigItemId) isGetConnectionRequest_Lookup() {}
 
 func (*GetConnectionRequest_Label) isGetConnectionRequest_Lookup() {}
+
+func (*GetConnectionRequest_ConnectionId) isGetConnectionRequest_Lookup() {}
 
 type ResolvedConnection struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1938,11 +1960,12 @@ const file_plugin_proto_rawDesc = "" +
 	"\x12ListConfigsRequest\x12F\n" +
 	"\bselector\x18\x01 \x01(\v2*.missioncontrol.plugin.v1.ResourceSelectorR\bselector\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12\x16\n" +
-	"\x06cursor\x18\x03 \x01(\tR\x06cursor\"v\n" +
+	"\x06cursor\x18\x03 \x01(\tR\x06cursor\"\x9d\x01\n" +
 	"\x14GetConnectionRequest\x12\x14\n" +
 	"\x04type\x18\x01 \x01(\tH\x00R\x04type\x12&\n" +
 	"\x0econfig_item_id\x18\x02 \x01(\tH\x00R\fconfigItemId\x12\x16\n" +
-	"\x05label\x18\x03 \x01(\tH\x00R\x05labelB\b\n" +
+	"\x05label\x18\x03 \x01(\tH\x00R\x05label\x12%\n" +
+	"\rconnection_id\x18\x04 \x01(\tH\x00R\fconnectionIdB\b\n" +
 	"\x06lookup\"\x9e\x02\n" +
 	"\x12ResolvedConnection\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x10\n" +
@@ -2104,6 +2127,7 @@ func file_plugin_proto_init() {
 		(*GetConnectionRequest_Type)(nil),
 		(*GetConnectionRequest_ConfigItemId)(nil),
 		(*GetConnectionRequest_Label)(nil),
+		(*GetConnectionRequest_ConnectionId)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/plugin/proto/plugin.proto
+++ b/plugin/proto/plugin.proto
@@ -164,15 +164,22 @@ message ListConfigsRequest {
   string cursor             = 3;
 }
 
-// GetConnectionRequest asks the host to resolve a connection by one of three
-// supported lookups: type, config item, or plugin-defined label. Type and label
-// lookups use spec.connections mappings from the Plugin CRD. Config lookups use
-// the scraper that created the config item.
+// GetConnectionRequest asks the host to resolve a connection by one of four
+// supported lookups: type, scraper config item, plugin-defined label, or direct
+// connection id.
+//
+// Type and label lookups use spec.connections mappings from the Plugin CRD.
+// config_item_id preserves the existing behavior: it resolves the connection
+// used by the scraper that created the config item. connection_id resolves a
+// Mission Control connection by id; plugins attached to MissionControl::Connection
+// config items can pass their config_item_id because connection config item ids
+// are the same as the underlying connection ids.
 message GetConnectionRequest {
   oneof lookup {
-    string type           = 1; // e.g. "sql", "aws", "kubernetes", "gcp", "azure"
+    string type           = 1; // e.g. "sql", "aws", "kubernetes", "gcp", "azure", "s3"
     string config_item_id = 2; // resolve the connection used by this config item's scraper
     string label          = 3; // resolve a plugin-defined connection label mapping
+    string connection_id  = 4; // resolve a Mission Control connection by id
   }
 }
 

--- a/plugin/sdk/host_client.go
+++ b/plugin/sdk/host_client.go
@@ -28,6 +28,9 @@ type HostClient interface {
 	// GetConnectionForConfig resolves the connection used by the scraper that created the config item.
 	GetConnectionForConfig(ctx context.Context, configItemID string) (*pluginpb.ResolvedConnection, error)
 
+	// GetConnectionByID resolves a Mission Control connection by id.
+	GetConnectionByID(ctx context.Context, connectionID string) (*pluginpb.ResolvedConnection, error)
+
 	// GetConnectionByLabel resolves a connection using spec.connections.labels.
 	GetConnectionByLabel(ctx context.Context, label string) (*pluginpb.ResolvedConnection, error)
 
@@ -74,6 +77,10 @@ func (h *hostClient) GetConnectionByType(ctx context.Context, typ ConnectionType
 
 func (h *hostClient) GetConnectionForConfig(ctx context.Context, configItemID string) (*pluginpb.ResolvedConnection, error) {
 	return h.c.GetConnection(h.authContext(ctx), &pluginpb.GetConnectionRequest{Lookup: &pluginpb.GetConnectionRequest_ConfigItemId{ConfigItemId: configItemID}})
+}
+
+func (h *hostClient) GetConnectionByID(ctx context.Context, connectionID string) (*pluginpb.ResolvedConnection, error) {
+	return h.c.GetConnection(h.authContext(ctx), &pluginpb.GetConnectionRequest{Lookup: &pluginpb.GetConnectionRequest_ConnectionId{ConnectionId: connectionID}})
 }
 
 func (h *hostClient) GetConnectionByLabel(ctx context.Context, label string) (*pluginpb.ResolvedConnection, error) {


### PR DESCRIPTION
Add a direct `connection_id` lookup to the plugin HostService API.

This keeps `config_item_id` scoped to scraper-derived connections, while allowing plugins attached to `MissionControl::Connection` items to resolve the underlying connection id.

The host implementation uses duty's connection lookup so hydration and RBAC stay centralized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for resolving connections by ID through the plugin host API. Users can now retrieve connections directly using their connection ID as an alternative to existing lookup methods such as config item ID, type, or label-based resolution, providing a more direct way to access specific connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->