### PR TITLE
test(plugins): add end-to-end plugin authorization coverage

### DIFF
--- a/plugin/runtime/invoke.go
+++ b/plugin/runtime/invoke.go
@@ -172,6 +172,9 @@ func EnforceInvokePermission(ctx dutyContext.Context, subject string, entry *reg
 			return ctx.Oops().Wrapf(err, "get config item %s", configID)
 		}
 		attr.Config = item
+		if !dutyRBAC.HasPermission(ctx, subject, attr, policy.ActionRead) {
+			return ctx.Oops().Code(dutyAPI.EFORBIDDEN).Errorf("not allowed to read config %s", configID)
+		}
 	}
 
 	if CanInvokePluginOperation(ctx, subject, attr, entry.Name, op) {

--- a/tests/e2e/plugins/helpers_test.go
+++ b/tests/e2e/plugins/helpers_test.go
@@ -1,0 +1,106 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	dutyRBAC "github.com/flanksource/duty/rbac"
+
+	"github.com/flanksource/duty/rbac/policy"
+	"github.com/flanksource/duty/types"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/auth"
+	"github.com/google/uuid"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+)
+
+func applyHasherPlugin() {
+	plugin := &v1.Plugin{
+		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Plugin"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pluginName,
+			Namespace: pluginNamespace,
+		},
+		Spec: v1.PluginSpec{Source: pluginName},
+	}
+	Expect(k8sClient.Create(context.Background(), plugin)).To(Succeed())
+}
+
+func applyUserPermissions(configID string) {
+	permissions := []*v1.Permission{
+		permissionCRD("good-config-read", goodUser.Email, []string{policy.ActionRead}, configID),
+		permissionCRD("good-plugin-invoke", goodUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
+		permissionCRD("no-invoke-config-read", noInvokeUser.Email, []string{policy.ActionRead}, configID),
+		permissionCRD("no-config-plugin-invoke", noConfigUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
+	}
+	for _, permission := range permissions {
+		Expect(k8sClient.Create(context.Background(), permission)).To(Succeed())
+	}
+}
+
+func permissionCRD(name, email string, actions []string, configID string) *v1.Permission {
+	return &v1.Permission{
+		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Permission"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pluginNamespace,
+			UID:       ktypes.UID(uuid.NewString()),
+		},
+		Spec: v1.PermissionSpec{
+			Subject: v1.PermissionSubject{Person: email},
+			Actions: actions,
+			Object: v1.PermissionObject{Selectors: dutyRBAC.Selectors{
+				Configs: []types.ResourceSelector{{ID: configID}},
+			}},
+		},
+	}
+}
+
+func waitForHasherPlugin(configID string) {
+	Eventually(func(g Gomega) {
+		resp := doPluginRequest(http.MethodGet, fmt.Sprintf("/api/plugins?config_id=%s", configID), nil, auth.AdminEmail, auth.DefaultAdminPassword)
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK), resp.Body)
+		g.Expect(resp.Body).To(ContainSubstring(pluginName))
+		g.Expect(resp.Body).To(ContainSubstring(pluginOperation))
+	}).WithTimeout(90 * time.Second).WithPolling(time.Second).Should(Succeed())
+}
+
+type pluginHTTPResponse struct {
+	StatusCode int
+	Body       string
+}
+
+func doPluginRequest(method, path string, body []byte, username, password string) pluginHTTPResponse {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, serverURL+path, reader)
+	Expect(err).ToNot(HaveOccurred())
+	req.SetBasicAuth(username, password)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).ToNot(HaveOccurred())
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	Expect(err).ToNot(HaveOccurred())
+	return pluginHTTPResponse{StatusCode: resp.StatusCode, Body: string(respBody)}
+}
+
+func expectedHash(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
+}

--- a/tests/e2e/plugins/plugins_test.go
+++ b/tests/e2e/plugins/plugins_test.go
@@ -1,27 +1,13 @@
 package plugins
 
 import (
-	"bytes"
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"time"
 
-	dutyRBAC "github.com/flanksource/duty/rbac"
-	"github.com/flanksource/duty/rbac/policy"
 	"github.com/flanksource/duty/tests/fixtures/dummy"
-	"github.com/flanksource/duty/types"
-	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/flanksource/incident-commander/auth"
-	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -77,84 +63,3 @@ var _ = ginkgo.Describe("Plugins E2E", ginkgo.Ordered, func() {
 		}
 	})
 })
-
-func applyHasherPlugin() {
-	plugin := &v1.Plugin{
-		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Plugin"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pluginName,
-			Namespace: pluginNamespace,
-		},
-		Spec: v1.PluginSpec{Source: pluginName},
-	}
-	Expect(k8sClient.Create(context.Background(), plugin)).To(Succeed())
-}
-
-func applyUserPermissions(configID string) {
-	permissions := []*v1.Permission{
-		permissionCRD("good-config-read", goodUser.Email, []string{policy.ActionRead}, configID),
-		permissionCRD("good-plugin-invoke", goodUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
-		permissionCRD("no-invoke-config-read", noInvokeUser.Email, []string{policy.ActionRead}, configID),
-		permissionCRD("no-config-plugin-invoke", noConfigUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
-	}
-	for _, permission := range permissions {
-		Expect(k8sClient.Create(context.Background(), permission)).To(Succeed())
-	}
-}
-
-func permissionCRD(name, email string, actions []string, configID string) *v1.Permission {
-	return &v1.Permission{
-		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Permission"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: pluginNamespace,
-			UID:       ktypes.UID(uuid.NewString()),
-		},
-		Spec: v1.PermissionSpec{
-			Subject: v1.PermissionSubject{Person: email},
-			Actions: actions,
-			Object: v1.PermissionObject{Selectors: dutyRBAC.Selectors{
-				Configs: []types.ResourceSelector{{ID: configID}},
-			}},
-		},
-	}
-}
-
-func waitForHasherPlugin(configID string) {
-	Eventually(func(g Gomega) {
-		resp := doPluginRequest(http.MethodGet, fmt.Sprintf("/api/plugins?config_id=%s", configID), nil, auth.AdminEmail, auth.DefaultAdminPassword)
-		g.Expect(resp.StatusCode).To(Equal(http.StatusOK), resp.Body)
-		g.Expect(resp.Body).To(ContainSubstring(pluginName))
-		g.Expect(resp.Body).To(ContainSubstring(pluginOperation))
-	}).WithTimeout(90 * time.Second).WithPolling(time.Second).Should(Succeed())
-}
-
-type pluginHTTPResponse struct {
-	StatusCode int
-	Body       string
-}
-
-func doPluginRequest(method, path string, body []byte, username, password string) pluginHTTPResponse {
-	var reader io.Reader
-	if body != nil {
-		reader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequest(method, serverURL+path, reader)
-	Expect(err).ToNot(HaveOccurred())
-	req.SetBasicAuth(username, password)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	Expect(err).ToNot(HaveOccurred())
-	defer resp.Body.Close()
-	respBody, err := io.ReadAll(resp.Body)
-	Expect(err).ToNot(HaveOccurred())
-	return pluginHTTPResponse{StatusCode: resp.StatusCode, Body: string(respBody)}
-}
-
-func expectedHash(name string) string {
-	sum := sha256.Sum256([]byte(name))
-	return hex.EncodeToString(sum[:])
-}

--- a/tests/e2e/plugins/plugins_test.go
+++ b/tests/e2e/plugins/plugins_test.go
@@ -1,0 +1,160 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	dutyRBAC "github.com/flanksource/duty/rbac"
+	"github.com/flanksource/duty/rbac/policy"
+	"github.com/flanksource/duty/tests/fixtures/dummy"
+	"github.com/flanksource/duty/types"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/auth"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	pluginNamespace = "default"
+	pluginName      = "hasher"
+	pluginOperation = "sha256"
+)
+
+type hashResponse struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+}
+
+var _ = ginkgo.Describe("Plugins E2E", ginkgo.Ordered, func() {
+	config := dummy.LogisticsAPIPodConfig
+
+	ginkgo.BeforeAll(func() {
+		applyHasherPlugin()
+		applyUserPermissions(config.ID.String())
+		waitForHasherPlugin(config.ID.String())
+	})
+
+	ginkgo.It("authorizes /invoke and /proxy plugin operations", func() {
+		expected := expectedHash(*config.Name)
+
+		for _, endpoint := range []struct {
+			name   string
+			method string
+			path   string
+			body   []byte
+		}{
+			{name: "invoke", method: http.MethodPost, path: fmt.Sprintf("/api/plugins/%s/invoke/%s?config_id=%s", pluginName, pluginOperation, config.ID), body: []byte(`{}`)},
+			{name: "proxy", method: http.MethodGet, path: fmt.Sprintf("/api/plugins/%s/proxy/%s?config_id=%s", pluginName, pluginOperation, config.ID)},
+		} {
+			ginkgo.By(endpoint.name + " allows user with config read and plugin invoke")
+			resp := doPluginRequest(endpoint.method, endpoint.path, endpoint.body, goodUser.Email, "test-password")
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), resp.Body)
+			var payload hashResponse
+			Expect(json.Unmarshal([]byte(resp.Body), &payload)).To(Succeed())
+			Expect(payload).To(Equal(hashResponse{Name: *config.Name, SHA256: expected}))
+
+			ginkgo.By(endpoint.name + " rejects user without plugin invoke")
+			resp = doPluginRequest(endpoint.method, endpoint.path, endpoint.body, noInvokeUser.Email, "test-password")
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden), resp.Body)
+
+			ginkgo.By(endpoint.name + " rejects user without config read")
+			resp = doPluginRequest(endpoint.method, endpoint.path, endpoint.body, noConfigUser.Email, "test-password")
+			Expect(resp.StatusCode).ToNot(Equal(http.StatusOK), resp.Body)
+
+			ginkgo.By(endpoint.name + " rejects invalid credentials")
+			resp = doPluginRequest(endpoint.method, endpoint.path, endpoint.body, goodUser.Email, "wrong-password")
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized), resp.Body)
+		}
+	})
+})
+
+func applyHasherPlugin() {
+	plugin := &v1.Plugin{
+		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Plugin"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pluginName,
+			Namespace: pluginNamespace,
+		},
+		Spec: v1.PluginSpec{Source: pluginName},
+	}
+	Expect(k8sClient.Create(context.Background(), plugin)).To(Succeed())
+}
+
+func applyUserPermissions(configID string) {
+	permissions := []*v1.Permission{
+		permissionCRD("good-config-read", goodUser.Email, []string{policy.ActionRead}, configID),
+		permissionCRD("good-plugin-invoke", goodUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
+		permissionCRD("no-invoke-config-read", noInvokeUser.Email, []string{policy.ActionRead}, configID),
+		permissionCRD("no-config-plugin-invoke", noConfigUser.Email, []string{policy.NewPluginInvokeAction(pluginName, pluginOperation)}, configID),
+	}
+	for _, permission := range permissions {
+		Expect(k8sClient.Create(context.Background(), permission)).To(Succeed())
+	}
+}
+
+func permissionCRD(name, email string, actions []string, configID string) *v1.Permission {
+	return &v1.Permission{
+		TypeMeta: metav1.TypeMeta{APIVersion: "mission-control.flanksource.com/v1", Kind: "Permission"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pluginNamespace,
+			UID:       ktypes.UID(uuid.NewString()),
+		},
+		Spec: v1.PermissionSpec{
+			Subject: v1.PermissionSubject{Person: email},
+			Actions: actions,
+			Object: v1.PermissionObject{Selectors: dutyRBAC.Selectors{
+				Configs: []types.ResourceSelector{{ID: configID}},
+			}},
+		},
+	}
+}
+
+func waitForHasherPlugin(configID string) {
+	Eventually(func(g Gomega) {
+		resp := doPluginRequest(http.MethodGet, fmt.Sprintf("/api/plugins?config_id=%s", configID), nil, auth.AdminEmail, auth.DefaultAdminPassword)
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK), resp.Body)
+		g.Expect(resp.Body).To(ContainSubstring(pluginName))
+		g.Expect(resp.Body).To(ContainSubstring(pluginOperation))
+	}).WithTimeout(90 * time.Second).WithPolling(time.Second).Should(Succeed())
+}
+
+type pluginHTTPResponse struct {
+	StatusCode int
+	Body       string
+}
+
+func doPluginRequest(method, path string, body []byte, username, password string) pluginHTTPResponse {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, serverURL+path, reader)
+	Expect(err).ToNot(HaveOccurred())
+	req.SetBasicAuth(username, password)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).ToNot(HaveOccurred())
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	Expect(err).ToNot(HaveOccurred())
+	return pluginHTTPResponse{StatusCode: resp.StatusCode, Body: string(respBody)}
+}
+
+func expectedHash(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
+}

--- a/tests/e2e/plugins/suite_test.go
+++ b/tests/e2e/plugins/suite_test.go
@@ -50,7 +50,6 @@ func TestPluginsE2E(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	tmpDir = ginkgo.GinkgoT().TempDir()
 	Expect(os.Unsetenv(setup.DUTY_DB_URL)).To(Succeed())
 	defaultContext = setup.BeforeSuiteFn()
 
@@ -58,6 +57,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	noInvokeUser = createPerson("Plugin No Invoke", "plugin-no-invoke@test.local")
 	noConfigUser = createPerson("Plugin No Config", "plugin-no-config@test.local")
 
+	tmpDir = ginkgo.GinkgoT().TempDir()
 	pluginBinDir = filepath.Join(tmpDir, "plugins")
 	Expect(os.MkdirAll(pluginBinDir, 0750)).To(Succeed())
 	buildHasherPlugin(pluginBinDir)

--- a/tests/e2e/plugins/suite_test.go
+++ b/tests/e2e/plugins/suite_test.go
@@ -1,0 +1,213 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/tests/setup"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/auth"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/bcrypt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	defaultContext dutyContext.Context
+	serverURL      string
+	serverCmd      *exec.Cmd
+	testEnv        *envtest.Environment
+	k8sClient      client.Client
+	tmpDir         string
+	pluginBinDir   string
+
+	goodUser     models.Person
+	noInvokeUser models.Person
+	noConfigUser models.Person
+)
+
+func TestPluginsE2E(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Plugins E2E")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	tmpDir = ginkgo.GinkgoT().TempDir()
+	Expect(os.Unsetenv(setup.DUTY_DB_URL)).To(Succeed())
+	defaultContext = setup.BeforeSuiteFn()
+
+	goodUser = createPerson("Plugin Good", "plugin-good@test.local")
+	noInvokeUser = createPerson("Plugin No Invoke", "plugin-no-invoke@test.local")
+	noConfigUser = createPerson("Plugin No Config", "plugin-no-config@test.local")
+
+	pluginBinDir = filepath.Join(tmpDir, "plugins")
+	Expect(os.MkdirAll(pluginBinDir, 0750)).To(Succeed())
+	buildHasherPlugin(pluginBinDir)
+
+	kubeconfigPath := startEnvtest()
+	startMissionControl(kubeconfigPath)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	if serverCmd != nil && serverCmd.Process != nil {
+		_ = syscall.Kill(-serverCmd.Process.Pid, syscall.SIGTERM)
+		_ = serverCmd.Wait()
+	}
+	if testEnv != nil {
+		_ = testEnv.Stop()
+	}
+	setup.AfterSuiteFn()
+})
+
+func createPerson(name, email string) models.Person {
+	person := models.Person{ID: uuid.New(), Name: name, Email: email}
+	Expect(defaultContext.DB().Create(&person).Error).To(Succeed())
+	return person
+}
+
+func buildHasherPlugin(binDir string) {
+	repoRoot := findRepoRoot()
+	cmd := exec.Command("go", "build", "-o", filepath.Join(binDir, "hasher"), "./tests/e2e/plugins/testdata/plugins/hasher")
+	cmd.Dir = repoRoot
+	cmd.Stdout = ginkgo.GinkgoWriter
+	cmd.Stderr = ginkgo.GinkgoWriter
+	Expect(cmd.Run()).To(Succeed())
+}
+
+func startEnvtest() string {
+	repoRoot := findRepoRoot()
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(v1.AddToScheme(scheme)).To(Succeed())
+
+	binaryAssetsDir, err := envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
+	Expect(err).ToNot(HaveOccurred())
+	testEnv = &envtest.Environment{
+		Scheme:                scheme,
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crds")},
+		ErrorIfCRDPathMissing: true,
+		DownloadBinaryAssets:  true,
+		BinaryAssetsDirectory: binaryAssetsDir,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).ToNot(HaveOccurred())
+	ensureNamespace("default")
+
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	Expect(os.WriteFile(kubeconfigPath, testEnv.KubeConfig, 0600)).To(Succeed())
+	return kubeconfigPath
+}
+
+func ensureNamespace(name string) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := k8sClient.Create(context.Background(), ns)
+	if client.IgnoreAlreadyExists(err) != nil {
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func startMissionControl(kubeconfigPath string) {
+	htpasswdPath := filepath.Join(tmpDir, "htpasswd")
+	Expect(os.WriteFile(htpasswdPath, []byte(htpasswdContent()), 0600)).To(Succeed())
+
+	serverPort := freePort()
+	serverURL = fmt.Sprintf("http://127.0.0.1:%d", serverPort)
+
+	binPath := filepath.Join(findRepoRoot(), ".bin", "incident-commander")
+	Expect(binPath).To(BeAnExistingFile(), "binary not found — run `make dev` first")
+
+	dbURL := defaultContext.Value("db_url").(string)
+	serverCmd = exec.Command(binPath, "serve",
+		"--db", dbURL,
+		"--auth", "basic",
+		"--htpasswd-file", htpasswdPath,
+		"--frontend-url", serverURL,
+		"--public-endpoint", serverURL,
+		"--httpPort", strconv.Itoa(serverPort),
+		"--disable-postgrest",
+		"--postgrest-uri", "",
+	)
+	serverCmd.Stdout = ginkgo.GinkgoWriter
+	serverCmd.Stderr = ginkgo.GinkgoWriter
+	serverCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	serverCmd.Env = append(os.Environ(),
+		"KUBECONFIG="+kubeconfigPath,
+		"MISSION_CONTROL_PLUGIN_PATH="+pluginBinDir,
+	)
+	Expect(serverCmd.Start()).To(Succeed())
+
+	Eventually(func() error {
+		resp, err := http.Get(serverURL + "/health")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("health returned %d", resp.StatusCode)
+		}
+		return nil
+	}).WithTimeout(90 * time.Second).WithPolling(time.Second).Should(Succeed())
+}
+
+func htpasswdContent() string {
+	users := []struct {
+		username string
+		password string
+	}{
+		{auth.AdminEmail, auth.DefaultAdminPassword},
+		{goodUser.Email, "test-password"},
+		{noInvokeUser.Email, "test-password"},
+		{noConfigUser.Email, "test-password"},
+	}
+
+	var out string
+	for _, user := range users {
+		hash, err := bcrypt.GenerateFromPassword([]byte(user.password), bcrypt.DefaultCost)
+		Expect(err).ToNot(HaveOccurred())
+		out += fmt.Sprintf("%s:%s\n", user.username, string(hash))
+	}
+	return out
+}
+
+func freePort() int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).ToNot(HaveOccurred())
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func findRepoRoot() string {
+	dir, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		Expect(parent).ToNot(Equal(dir), "could not find repo root from %s", dir)
+		dir = parent
+	}
+}

--- a/tests/e2e/plugins/testdata/plugins/hasher/main.go
+++ b/tests/e2e/plugins/testdata/plugins/hasher/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	pluginpb "github.com/flanksource/incident-commander/plugin/proto"
+	"github.com/flanksource/incident-commander/plugin/sdk"
+)
+
+type hasherPlugin struct{}
+
+type hashResult struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+}
+
+func (hasherPlugin) Manifest() *pluginpb.PluginManifest {
+	return &pluginpb.PluginManifest{
+		Name:        "hasher",
+		Version:     "1.0.0",
+		Description: "E2E test plugin that hashes config names",
+	}
+}
+
+func (hasherPlugin) Configure(context.Context, map[string]any) error { return nil }
+
+func (hasherPlugin) Operations() []sdk.Operation {
+	def := &pluginpb.OperationDef{
+		Name:        "sha256",
+		Description: "returns the sha256 of the config name",
+		ResultMime:  "application/json",
+		Http:        []*pluginpb.HTTPBinding{{Method: http.MethodGet}},
+	}
+
+	return []sdk.Operation{{
+		Def: def,
+		Handler: func(ctx context.Context, req sdk.InvokeCtx) (any, error) {
+			return hashConfigName(ctx, req.Host, req.ConfigItemID)
+		},
+		HTTPHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			result, err := hashConfigName(r.Context(), sdk.HostClientFromContext(r.Context()), sdk.ConfigItemIDFromContext(r.Context()))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(result)
+		}),
+	}}
+}
+
+func hashConfigName(ctx context.Context, host sdk.HostClient, configID string) (hashResult, error) {
+	if host == nil {
+		return hashResult{}, fmt.Errorf("host client is nil")
+	}
+	item, err := host.GetConfigItem(ctx, configID)
+	if err != nil {
+		return hashResult{}, err
+	}
+	sum := sha256.Sum256([]byte(item.Name))
+	return hashResult{Name: item.Name, SHA256: hex.EncodeToString(sum[:])}, nil
+}
+
+func main() {
+	sdk.Serve(&hasherPlugin{})
+}


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3126

Plugin invocation needs to enforce both catalog access and plugin operation permissions.

Add a full plugin E2E suite that starts Mission Control with real basic auth, envtest Kubernetes API, embedded Postgres, and a real `hasher` plugin process. The test applies Plugin and Permission CRDs, then verifies `/invoke/` and `/proxy/` for allowed users, bad credentials, missing plugin invoke permission, and missing config read permission.

Also require config read permission before invoking plugin operations for a specific config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced plugin invocation security with additional role-based access control checks. Users must now have both config read and plugin invoke permissions to execute plugin operations.

* **Tests**
  * Added comprehensive end-to-end tests validating plugin authorization and permission enforcement across multiple user roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->