### PR TITLE
fix(oidc): bind login callbacks to authorize transaction

### DIFF
--- a/auth/oidc/login.go
+++ b/auth/oidc/login.go
@@ -18,6 +18,10 @@ type LoginHandler struct {
 	externalLoginProvider ExternalLoginProvider
 	PersonLookup          PersonLookup
 	issuerURL             string
+
+	// validates the transaction cookie created when the OIDC flow is initiated
+	// to bind callbacks to the browser that started the flow.
+	oidcTxCookieValidator *transactionCookieManager
 }
 
 type PasswordLoginChecker interface {
@@ -55,6 +59,9 @@ func (h *LoginHandler) ShowForm(c echo.Context) error {
 	if id == "" {
 		return c.String(http.StatusBadRequest, "missing auth_request_id")
 	}
+	if err := h.validateTransaction(c, id); err != nil {
+		return c.String(http.StatusUnauthorized, "invalid oidc transaction")
+	}
 
 	if h.externalLoginProvider != nil {
 		redirectURL, err := h.externalLoginProvider.LoginRedirectURL(id)
@@ -86,6 +93,9 @@ func (h *LoginHandler) HandleSubmit(c echo.Context) error {
 	if id == "" || username == "" || password == "" {
 		return renderForm("All fields required")
 	}
+	if err := h.validateTransaction(c, id); err != nil {
+		return c.String(http.StatusUnauthorized, "invalid oidc transaction")
+	}
 
 	if h.passwordLoginChecker == nil || h.PersonLookup == nil {
 		return c.String(http.StatusNotFound, "password login is not configured")
@@ -114,6 +124,9 @@ func (h *LoginHandler) HandleExternalCallback(c echo.Context) error {
 	if id == "" {
 		return c.String(http.StatusBadRequest, "missing auth_request_id")
 	}
+	if err := h.validateTransaction(c, id); err != nil {
+		return c.String(http.StatusUnauthorized, "invalid oidc transaction")
+	}
 
 	if h.externalLoginProvider == nil {
 		return c.String(http.StatusNotFound, "external callback is not configured")
@@ -131,4 +144,12 @@ func (h *LoginHandler) HandleExternalCallback(c echo.Context) error {
 	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
 	callbackURL := op.AuthCallbackURL(h.provider)(issuerCtx, id)
 	return c.Redirect(http.StatusFound, callbackURL)
+}
+
+func (h *LoginHandler) validateTransaction(c echo.Context, authRequestID string) error {
+	if h.oidcTxCookieValidator == nil {
+		return nil
+	}
+
+	return h.oidcTxCookieValidator.validateEcho(c, authRequestID)
 }

--- a/auth/oidc/provider.go
+++ b/auth/oidc/provider.go
@@ -26,14 +26,17 @@ type Provider struct {
 // It loads or generates the RSA signing key, upserts the public key to DB,
 // and returns a Provider containing the OpenIDProvider and http.Handler.
 func NewProvider(ctx context.Context, issuerURL, signingKeyPath string) (*Provider, error) {
-	privateKey, keyID, err := loadOrGenerateKey(ctx, signingKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("oidc signing key: %w", err)
-	}
-
 	cryptoKey, err := loadOrGenerateCryptoKey(signingKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("oidc crypto key: %w", err)
+	}
+	return newProviderWithCryptoKey(ctx, issuerURL, signingKeyPath, cryptoKey)
+}
+
+func newProviderWithCryptoKey(ctx context.Context, issuerURL, signingKeyPath string, cryptoKey [32]byte) (*Provider, error) {
+	privateKey, keyID, err := loadOrGenerateKey(ctx, signingKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("oidc signing key: %w", err)
 	}
 
 	signer := &signingKey{

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -1,6 +1,7 @@
 package oidc
 
 import (
+	"fmt"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -16,10 +17,17 @@ import (
 // A convenience redirect from /.well-known/openid-configuration is provided for standard discovery.
 func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath string, passwordChecker PasswordLoginChecker, externalProvider ExternalLoginProvider, lookup PersonLookup) error {
 	oidcIssuer := strings.TrimRight(issuerURL, "/")
-	provider, err := NewProvider(ctx, oidcIssuer, signingKeyPath)
+	cryptoKey, err := loadOrGenerateCryptoKey(signingKeyPath)
+	if err != nil {
+		return fmt.Errorf("oidc crypto key: %w", err)
+	}
+
+	provider, err := newProviderWithCryptoKey(ctx, oidcIssuer, signingKeyPath, cryptoKey)
 	if err != nil {
 		return err
 	}
+
+	oidcTxCookierManager := newTransactionCookieManager(cryptoKey, oidcIssuer)
 
 	var loginHandler *LoginHandler
 	if externalProvider != nil {
@@ -27,6 +35,7 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath st
 	} else {
 		loginHandler = NewPasswordLoginHandler(provider.Storage, provider.OpenIDProvider, passwordChecker, lookup, oidcIssuer)
 	}
+	loginHandler.oidcTxCookieValidator = oidcTxCookierManager
 
 	// Custom login form (not part of the standard OIDC protocol paths).
 	e.GET("/oidc/login", loginHandler.ShowForm)
@@ -41,9 +50,11 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL, signingKeyPath st
 	// Standard OIDC protocol endpoints — mounted at the root so that the issuer URL
 	// and the authorization_endpoint/token_endpoint values in the discovery document
 	// resolve to real routes on this server.
+	authorizeHandler := echo.WrapHandler(oidcTxCookierManager.issueOnAuthorize(provider.Handler))
+	callbackHandler := echo.WrapHandler(oidcTxCookierManager.requireOnAuthorizeCallback(provider.Handler))
 	h := echo.WrapHandler(provider.Handler)
-	e.Any("/authorize", h)
-	e.Any("/authorize/*", h)
+	e.Any("/authorize", authorizeHandler)
+	e.Any("/authorize/*", callbackHandler)
 	e.Any("/oauth/token", h)
 	e.Any("/oauth/introspect", h)
 	e.Any("/userinfo", h)

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -262,12 +262,20 @@ func (s *Storage) populateUserinfo(userinfo *oidc.UserInfo, subject string) erro
 // SetAuthRequestSubject sets the subject on an auth request after login.
 func (s *Storage) SetAuthRequestSubject(id, subject string) error {
 	now := time.Now()
-	return s.ctx.DB().Model(&AuthRequest{}).Where("id = ?", id).
+	result := s.ctx.DB().Model(&AuthRequest{}).
+		Where("id = ? AND expires_at > NOW() AND (subject = '' OR subject IS NULL)", id).
 		Updates(map[string]any{
 			"subject":   subject,
 			"auth_time": now,
 			"done":      true,
-		}).Error
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("auth request not found or already completed")
+	}
+	return nil
 }
 
 // CleanupExpired removes expired auth requests and refresh tokens.

--- a/auth/oidc/transaction_cookie.go
+++ b/auth/oidc/transaction_cookie.go
@@ -1,0 +1,233 @@
+package oidc
+
+// This file binds an OIDC authorization request to the browser that initiated
+// it. The Zitadel OIDC library creates the auth request and redirects to the
+// login UI with an auth_request_id in the URL. URL parameters are attacker
+// controlled, so completing login from only auth_request_id plus an upstream
+// Kratos/Clerk session would allow login CSRF: a victim could be tricked into
+// completing an attacker's pending authorization request.
+//
+// To prevent that, /authorize issues a short-lived, HMAC-signed transaction
+// cookie when the auth request is first created. Subsequent login and callback
+// steps must present a cookie whose embedded auth_request_id matches the URL.
+// The cookie is HttpOnly, SameSite=Lax, per-auth-request, and expires with the
+// auth request window.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+const oidcTransactionCookieTTL = 10 * time.Minute
+
+var (
+	errOIDCTransactionCookieMissing = errors.New("oidc transaction cookie missing")
+	errOIDCTransactionCookieInvalid = errors.New("oidc transaction cookie invalid")
+)
+
+type transactionCookieManager struct {
+	key    [32]byte
+	secure bool
+	ttl    time.Duration
+}
+
+type transactionCookiePayload struct {
+	AuthRequestID string `json:"auth_request_id"`
+	IssuedAt      int64  `json:"iat"`
+	ExpiresAt     int64  `json:"exp"`
+}
+
+func newTransactionCookieManager(key [32]byte, issuerURL string) *transactionCookieManager {
+	return &transactionCookieManager{
+		key:    key,
+		secure: strings.HasPrefix(strings.ToLower(issuerURL), "https://"),
+		ttl:    oidcTransactionCookieTTL,
+	}
+}
+
+func (m *transactionCookieManager) issueOnAuthorize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&transactionCookieResponseWriter{ResponseWriter: w, manager: m}, r)
+	})
+}
+
+func (m *transactionCookieManager) requireOnAuthorizeCallback(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		if id == "" {
+			http.Error(w, "missing auth request id", http.StatusBadRequest)
+			return
+		}
+		if err := m.validateRequest(r, id); err != nil {
+			http.Error(w, "invalid oidc transaction", http.StatusUnauthorized)
+			return
+		}
+		m.clearCookie(w, id)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *transactionCookieManager) validateEcho(c echo.Context, authRequestID string) error {
+	if authRequestID == "" {
+		return errOIDCTransactionCookieInvalid
+	}
+	return m.validateRequest(c.Request(), authRequestID)
+}
+
+func (m *transactionCookieManager) validateRequest(r *http.Request, authRequestID string) error {
+	cookie, err := r.Cookie(m.cookieName(authRequestID))
+	if err != nil || cookie.Value == "" {
+		return errOIDCTransactionCookieMissing
+	}
+
+	payload, err := m.parse(cookie.Value)
+	if err != nil {
+		return err
+	}
+	if payload.AuthRequestID != authRequestID {
+		return errOIDCTransactionCookieInvalid
+	}
+	if time.Now().Unix() > payload.ExpiresAt {
+		return errOIDCTransactionCookieInvalid
+	}
+	return nil
+}
+
+func (m *transactionCookieManager) issueCookie(w http.ResponseWriter, authRequestID string) {
+	token, err := m.sign(authRequestID)
+	if err != nil {
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     m.cookieName(authRequestID),
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(m.ttl.Seconds()),
+		Expires:  time.Now().Add(m.ttl),
+		HttpOnly: true,
+		Secure:   m.secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (m *transactionCookieManager) clearCookie(w http.ResponseWriter, authRequestID string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     m.cookieName(authRequestID),
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+		HttpOnly: true,
+		Secure:   m.secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (m *transactionCookieManager) sign(authRequestID string) (string, error) {
+	now := time.Now()
+	payload := transactionCookiePayload{
+		AuthRequestID: authRequestID,
+		IssuedAt:      now.Unix(),
+		ExpiresAt:     now.Add(m.ttl).Unix(),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	sig := m.signature(encodedPayload)
+	return encodedPayload + "." + sig, nil
+}
+
+func (m *transactionCookieManager) parse(token string) (*transactionCookiePayload, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return nil, errOIDCTransactionCookieInvalid
+	}
+
+	expectedSig := m.signature(parts[0])
+	if !hmac.Equal([]byte(expectedSig), []byte(parts[1])) {
+		return nil, errOIDCTransactionCookieInvalid
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, errOIDCTransactionCookieInvalid
+	}
+
+	var payload transactionCookiePayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, errOIDCTransactionCookieInvalid
+	}
+	if payload.AuthRequestID == "" || payload.ExpiresAt == 0 {
+		return nil, errOIDCTransactionCookieInvalid
+	}
+	return &payload, nil
+}
+
+func (m *transactionCookieManager) signature(encodedPayload string) string {
+	mac := hmac.New(sha256.New, m.key[:])
+	_, _ = mac.Write([]byte(encodedPayload))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (m *transactionCookieManager) cookieName(authRequestID string) string {
+	prefix := "mc_oidc_tx_"
+	if m.secure {
+		prefix = "__Host-mc_oidc_tx_"
+	}
+	sum := sha256.Sum256([]byte(authRequestID))
+	return prefix + base64.RawURLEncoding.EncodeToString(sum[:])[:22]
+}
+
+type transactionCookieResponseWriter struct {
+	http.ResponseWriter
+	manager *transactionCookieManager
+	wrote   bool
+}
+
+func (w *transactionCookieResponseWriter) WriteHeader(statusCode int) {
+	if !w.wrote {
+		w.wrote = true
+		if statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest {
+			if id := authRequestIDFromLoginRedirect(w.Header().Get("Location")); id != "" {
+				w.manager.issueCookie(w.ResponseWriter, id)
+			}
+		}
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *transactionCookieResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func authRequestIDFromLoginRedirect(location string) string {
+	if location == "" {
+		return ""
+	}
+
+	u, err := url.Parse(location)
+	if err != nil {
+		return ""
+	}
+	if u.Path != "/oidc/login" {
+		return ""
+	}
+	return u.Query().Get("auth_request_id")
+}

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -538,6 +538,62 @@ var _ = ginkgo.Describe("OIDC", func() {
 		})
 	})
 
+	ginkgo.It("requires an OIDC transaction cookie after authorize creates an auth request", func() {
+		e := newEchoInstance(DefaultContext)
+		Expect(oidc.MountRoutes(e, DefaultContext, "http://localhost:8080", keyPath, &mockChecker{}, nil, mockLookup)).To(Succeed())
+
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":             {oidc.ClientID},
+			"response_type":         {"code"},
+			"redirect_uri":          {"http://localhost:6274/oauth/callback"},
+			"scope":                 {"openid profile email"},
+			"state":                 {"state-1"},
+			"nonce":                 {"nonce-1"},
+			"code_challenge":        {"challenge-1"},
+			"code_challenge_method": {"S256"},
+		}.Encode()
+
+		req := httptest.NewRequest(http.MethodGet, authorizeURL, nil)
+		req = req.WithContext(DefaultContext.Wrap(req.Context()))
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusFound))
+		loginURL := rec.Header().Get("Location")
+		Expect(loginURL).To(ContainSubstring("/oidc/login?auth_request_id="))
+		cookies := rec.Result().Cookies()
+		Expect(cookies).ToNot(BeEmpty())
+		parsedLoginURL, err := url.Parse(loginURL)
+		Expect(err).ToNot(HaveOccurred())
+		authRequestID := parsedLoginURL.Query().Get("auth_request_id")
+		Expect(authRequestID).ToNot(BeEmpty())
+
+		externalCallbackReq := httptest.NewRequest(http.MethodGet, "/oidc/kratos/callback?auth_request_id="+authRequestID, nil)
+		externalCallbackReq = externalCallbackReq.WithContext(DefaultContext.Wrap(externalCallbackReq.Context()))
+		externalCallbackRec := httptest.NewRecorder()
+		e.ServeHTTP(externalCallbackRec, externalCallbackReq)
+		Expect(externalCallbackRec.Code).To(Equal(http.StatusUnauthorized))
+
+		callbackReq := httptest.NewRequest(http.MethodGet, "/authorize/callback?id="+authRequestID, nil)
+		callbackReq = callbackReq.WithContext(DefaultContext.Wrap(callbackReq.Context()))
+		callbackRec := httptest.NewRecorder()
+		e.ServeHTTP(callbackRec, callbackReq)
+		Expect(callbackRec.Code).To(Equal(http.StatusUnauthorized))
+
+		loginReq := httptest.NewRequest(http.MethodGet, loginURL, nil)
+		loginReq = loginReq.WithContext(DefaultContext.Wrap(loginReq.Context()))
+		loginRec := httptest.NewRecorder()
+		e.ServeHTTP(loginRec, loginReq)
+		Expect(loginRec.Code).To(Equal(http.StatusUnauthorized))
+
+		loginReq = httptest.NewRequest(http.MethodGet, loginURL, nil)
+		loginReq = loginReq.WithContext(DefaultContext.Wrap(loginReq.Context()))
+		loginReq.AddCookie(cookies[0])
+		loginRec = httptest.NewRecorder()
+		e.ServeHTTP(loginRec, loginReq)
+		Expect(loginRec.Code).To(Equal(http.StatusOK))
+	})
+
 	ginkgo.It("mounts basic-auth OIDC discovery with the public endpoint issuer", func() {
 		oldAuthMode := vars.AuthMode
 		oldOIDCEnabled := OIDCEnabled


### PR DESCRIPTION
OIDC external login callbacks completed auth requests using only auth_request_id from the URL plus the current Kratos/Clerk browser session.

That allowed login CSRF where a logged-in user could be tricked into completing another pending authorization request.

Add a short-lived signed transaction cookie issued during /authorize and require it on login/callback continuation endpoints so the flow is bound to the browser that initiated it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented transaction cookie validation mechanism for OIDC authorization flows, binding authorization requests to user browser sessions to enhance security and prevent unauthorized access.

* **Bug Fixes**
  * Improved auth request validation to check for expiration and completion state, ensuring invalid or already-processed requests return appropriate error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->