### PR TITLE
fix: expire internal PostgREST JWTs

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/api"
@@ -32,6 +33,18 @@ var (
 )
 
 const basicAuthCookieName = "authorization"
+
+func setBasicAuthCookie(c echo.Context, token string) {
+	c.SetCookie(&http.Cookie{
+		Name:     basicAuthCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(jwtTokenLifetime.Seconds()),
+		Expires:  time.Now().Add(jwtTokenLifetime),
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
 
 func UseBasic(e *echo.Echo) {
 	logger.Infof("Using basic authentication with htpasswd file: %s", HtpasswdFile)
@@ -167,6 +180,9 @@ func authenticateFromCookie(c echo.Context) bool {
 
 	if err := InjectToken(ctx, c, &person, ""); err != nil {
 		return false
+	}
+	if token, ok := extractBearerAuthToken(c.Request().Header); ok && token != cookie.Value {
+		setBasicAuthCookie(c, token)
 	}
 
 	ctx = ctx.WithUser(&person)
@@ -353,13 +369,7 @@ func BasicLogin(c echo.Context) error {
 		return loginErr(http.StatusInternalServerError, "failed to generate token")
 	}
 
-	c.SetCookie(&http.Cookie{
-		Name:     basicAuthCookieName,
-		Value:    token,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
-	})
+	setBasicAuthCookie(c, token)
 
 	AddLoginContext(c, person)
 

--- a/auth/tokens.go
+++ b/auth/tokens.go
@@ -41,6 +41,9 @@ var tokenCache = cache.New(1*time.Hour, 1*time.Hour)
 var deletedTokensCache = cache.New(24*time.Hour, 24*time.Hour)
 
 const (
+	jwtTokenLifetime = time.Hour
+	jwtTokenCacheTTL = 55 * time.Minute
+
 	// If token is expiring within 15 days we update it's expiry
 	preExpiryWindow = 15 * 24 * time.Hour
 
@@ -68,11 +71,15 @@ func GetOrCreateJWTToken(ctx context.Context, user *models.Person, sessionId str
 		return token.(string), nil
 	}
 
+	now := time.Now()
+
 	// Postgrest makes this jwt available as a session parameter inside postgres.
 	// We inject the rls payload here and then access it inside postgres using request.jwt.claims parameter.
 	claims := jwt.MapClaims{
 		"role": config.Postgrest.DBRole,
 		"id":   user.ID.String(),
+		"iat":  jwt.NewNumericDate(now),
+		"exp":  jwt.NewNumericDate(now.Add(jwtTokenLifetime)),
 	}
 
 	if rlsPayload, err := GetRLSPayload(ctx.WithUser(user)); err != nil {
@@ -90,7 +97,7 @@ func GetOrCreateJWTToken(ctx context.Context, user *models.Person, sessionId str
 		ctx.Errorf("Error updating last login for user[%s]: %v", user, err)
 	}
 
-	tokenCache.SetDefault(key, token)
+	tokenCache.Set(key, token, jwtTokenCacheTTL)
 	return token, nil
 }
 

--- a/auth/tokens_test.go
+++ b/auth/tokens_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/flanksource/duty/api"
+	"github.com/flanksource/duty/models"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("GetOrCreateJWTToken", func() {
+	ginkgo.BeforeEach(func() {
+		FlushTokenCache()
+		api.DefaultConfig.Postgrest.JWTSecret = "test-secret"
+		api.DefaultConfig.Postgrest.DBRole = "postgrest_api"
+	})
+
+	ginkgo.It("adds expiry claims to internal PostgREST JWTs", func() {
+		user := &models.Person{ID: uuid.New(), Name: "token-test"}
+
+		tokenString, err := GetOrCreateJWTToken(DefaultContext, user, "session")
+		Expect(err).NotTo(HaveOccurred())
+
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+			return []byte(api.DefaultConfig.Postgrest.JWTSecret), nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token.Valid).To(BeTrue())
+
+		claims := token.Claims.(jwt.MapClaims)
+		Expect(claims["id"]).To(Equal(user.ID.String()))
+		Expect(claims["role"]).To(Equal("postgrest_api"))
+		Expect(claims["exp"]).NotTo(BeNil())
+		Expect(claims["iat"]).NotTo(BeNil())
+
+		exp, ok := claims["exp"].(float64)
+		Expect(ok).To(BeTrue())
+		Expect(time.Until(time.Unix(int64(exp), 0))).To(BeNumerically("~", jwtTokenLifetime, 5*time.Second))
+	})
+})


### PR DESCRIPTION
Internal PostgREST/session JWTs were signed without an `exp` claim, so leaked tokens remained valid until JWT secret rotation.

Add `iat`/`exp` claims with a 1h lifetime and cache tokens for 55m so Mission Control refreshes them before expiry. Basic-auth cookies now use the same lifetime and refresh when a renewed token is issued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * JWT authentication tokens now include additional security-relevant claims to improve token validation robustness and session reliability.
  * Session synchronization and consistency improved when users employ multiple authentication methods simultaneously or in sequence.

* **Tests**
  * Added comprehensive test suite for JWT token generation and validation to ensure authentication system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/mission-control/pull/3144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->