### PR TITLE
feat: Yamux tunnels

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	gocontext "context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -176,8 +177,25 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 	return nil
 }
 
+type trustedUpstreamContextKey struct{}
+
+func WithTrustedUpstream(ctx gocontext.Context) gocontext.Context {
+	return gocontext.WithValue(ctx, trustedUpstreamContextKey{}, true)
+}
+
+func IsTrustedUpstream(ctx gocontext.Context) bool {
+	v, _ := ctx.Value(trustedUpstreamContextKey{}).(bool)
+	return v
+}
+
 // TODO: Use regex supported path matching
 func canSkipAuth(c echo.Context) bool {
+	if IsTrustedUpstream(c.Request().Context()) {
+		// Incoming requests from upstream can bypass authentication.
+		// At the moment we do not have a way for the upstream to authenticate itself against agents.
+		return true
+	}
+
 	requestPath := c.Request().URL.Path
 	// Use the request path instead of c.Path(), which can be empty or contain route
 	// patterns while global middleware is evaluating a request.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/flanksource/incident-commander/metrics"
 	"github.com/flanksource/incident-commander/notification"
 	pluginReconciler "github.com/flanksource/incident-commander/plugin/reconciler"
+	"github.com/flanksource/incident-commander/upstream/tunnel"
 	echov4 "github.com/labstack/echo/v4"
 
 	// register event handlers & echo routers
@@ -245,6 +246,10 @@ var Serve = &cobra.Command{
 
 		ctx.WithTracer(otel.GetTracerProvider().Tracer("mission-control"))
 		ctx = ctx.WithNamespace(api.Namespace)
+
+		if api.UpstreamConf.Valid() {
+			go tunnel.StartAgentTunnel(ctx, api.UpstreamConf, e)
+		}
 
 		go jobs.Start(ctx, mcpServer.Server)
 

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hashicorp/yamux v0.1.2
 	github.com/henvic/httpretty v0.1.4
 	github.com/invopop/jsonschema v0.14.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
@@ -254,7 +255,6 @@ require (
 	github.com/hairyhenderson/yaml v0.0.0-20220618171115-2d35fca545ce // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
-	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hirochachacha/go-smb2 v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.19 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect

--- a/upstream/controllers.go
+++ b/upstream/controllers.go
@@ -1,6 +1,7 @@
 package upstream
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/flanksource/incident-commander/playbook/runner"
 	"github.com/flanksource/incident-commander/push"
 	"github.com/flanksource/incident-commander/rbac"
+	"github.com/flanksource/incident-commander/upstream/tunnel"
 )
 
 var agentCache = cache.New(3*24*time.Hour, 12*time.Hour)
@@ -39,6 +41,7 @@ func RegisterRoutes(e *echo.Echo) {
 		upstream.AgentAuthMiddleware(agentCache),
 	)
 	upstreamGroup.GET("/ping", upstream.PingHandler)
+	upstreamGroup.GET(fmt.Sprintf("/%s", tunnel.SessionCreateHTTPEndpoint), tunnel.YamuxSessionCreate)
 	upstreamGroup.POST("/list-views", upstream.ListViewsHandler)
 	upstreamGroup.POST("/push", upstream.NewPushHandler(upstream.NewStatusRingStore(job.EvictedJobs)))
 	upstreamGroup.DELETE("/push", upstream.DeleteHandler)

--- a/upstream/tunnel/controller.go
+++ b/upstream/tunnel/controller.go
@@ -1,0 +1,58 @@
+package tunnel
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/yamux"
+	"github.com/labstack/echo/v4"
+
+	dutyAPI "github.com/flanksource/duty/api"
+	"github.com/flanksource/duty/context"
+)
+
+const SessionCreateHTTPEndpoint = "yamux-create-session"
+
+func YamuxSessionCreate(c echo.Context) error {
+	ctx := c.Request().Context().(context.Context)
+	agent := ctx.Agent()
+	if agent == nil || agent.ID == uuid.Nil {
+		return dutyAPI.WriteError(c, ctx.Oops().
+			Code(dutyAPI.EUNAUTHORIZED).
+			Errorf("authenticated agent is required"))
+	}
+
+	hijacker, ok := c.Response().Writer.(http.Hijacker)
+	if !ok {
+		return dutyAPI.WriteError(c, ctx.Oops().
+			Code(dutyAPI.EINTERNAL).
+			Errorf("response writer does not support hijacking"))
+	}
+
+	conn, rw, err := hijacker.Hijack()
+	if err != nil {
+		return dutyAPI.WriteError(c, ctx.Oops().Wrap(err))
+	}
+
+	_, _ = rw.WriteString(
+		"HTTP/1.1 101 Switching Protocols\r\n" +
+			"Connection: Upgrade\r\n" +
+			"Upgrade: yamux\r\n\r\n",
+	)
+	_ = rw.Flush()
+
+	session, err := yamux.Server(conn, nil)
+	if err != nil {
+		_ = conn.Close()
+		return err
+	}
+
+	defaultManager.Register(agent.ID, session)
+
+	go func() {
+		<-session.CloseChan()
+		defaultManager.DeleteIfSame(agent.ID, session)
+	}()
+
+	return nil
+}

--- a/upstream/tunnel/controller.go
+++ b/upstream/tunnel/controller.go
@@ -34,12 +34,18 @@ func YamuxSessionCreate(c echo.Context) error {
 		return dutyAPI.WriteError(c, ctx.Oops().Wrap(err))
 	}
 
-	_, _ = rw.WriteString(
+	if _, err := rw.WriteString(
 		"HTTP/1.1 101 Switching Protocols\r\n" +
 			"Connection: Upgrade\r\n" +
 			"Upgrade: yamux\r\n\r\n",
-	)
-	_ = rw.Flush()
+	); err != nil {
+		_ = conn.Close()
+		return nil
+	}
+	if err := rw.Flush(); err != nil {
+		_ = conn.Close()
+		return nil
+	}
 
 	session, err := yamux.Server(conn, nil)
 	if err != nil {

--- a/upstream/tunnel/dial.go
+++ b/upstream/tunnel/dial.go
@@ -1,0 +1,264 @@
+package tunnel
+
+import (
+	"bufio"
+	gocontext "context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/flanksource/duty/api"
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/upstream"
+	"github.com/hashicorp/yamux"
+	"github.com/sethvargo/go-retry"
+
+	"github.com/flanksource/incident-commander/auth"
+)
+
+func hasHeaderToken(value, token string) bool {
+	for part := range strings.SplitSeq(value, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), token) {
+			return true
+		}
+	}
+	return false
+}
+
+// tunnelAddr is a minimal net.Addr implementation required by net.Listener.
+// The HTTP server only uses it for logging/metadata; yamux streams do not have
+// a meaningful local network address.
+type tunnelAddr string
+
+func (a tunnelAddr) Network() string { return string(a) }
+func (a tunnelAddr) String() string  { return string(a) }
+
+// yamuxListener adapts a yamux session to net.Listener so http.Server can serve
+// normal HTTP requests over each yamux stream opened by upstream.
+type yamuxListener struct {
+	session *yamux.Session
+}
+
+func (l yamuxListener) Accept() (net.Conn, error) {
+	return l.session.Accept()
+}
+
+func (l yamuxListener) Close() error {
+	return l.session.Close()
+}
+
+func (l yamuxListener) Addr() net.Addr {
+	return tunnelAddr("yamux-agent-tunnel")
+}
+
+// trustedUpstreamHandler marks requests received over the agent tunnel as
+// trusted because the tunnel itself was established by an authenticated upstream.
+// Agent-side handlers can use this marker to skip normal end-user auth/RBAC for
+// requests that upstream has already authorized.
+func trustedUpstreamHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.WithTrustedUpstream(r.Context())
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func StartAgentTunnel(ctx dutyContext.Context, upstreamConfig upstream.UpstreamConfig, handler http.Handler) {
+	backoff := retry.NewConstant(2 * time.Second)
+	_ = retry.Do(ctx, backoff, func(retryCtx gocontext.Context) error {
+		if err := runAgentTunnelSession(retryCtx, upstreamConfig, handler); err != nil {
+			if errors.Is(err, gocontext.Canceled) || retryCtx.Err() != nil {
+				return retryCtx.Err()
+			}
+			ctx.Warnf("agent tunnel disconnected: %v", err)
+		}
+		return retry.RetryableError(fmt.Errorf("agent tunnel disconnected"))
+	})
+}
+
+func runAgentTunnelSession(ctx gocontext.Context, upstreamConfig upstream.UpstreamConfig, handler http.Handler) error {
+	conn, err := dialUpgrade(ctx, upstreamConfig, fmt.Sprintf("/upstream/%s", SessionCreateHTTPEndpoint))
+	if err != nil {
+		return err
+	}
+
+	session, err := yamux.Client(conn, nil)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("start yamux client: %w", err)
+	}
+	defer session.Close()
+
+	go func() {
+		<-ctx.Done()
+		_ = session.Close()
+	}()
+
+	server := &http.Server{
+		Handler:           trustedUpstreamHandler(handler),
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	err = server.Serve(yamuxListener{session: session})
+	if err == nil || errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) || errors.Is(err, yamux.ErrSessionShutdown) {
+		return nil
+	}
+	return err
+}
+
+func dialUpgrade(ctx gocontext.Context, upstreamConfig upstream.UpstreamConfig, connectPath string) (net.Conn, error) {
+	u, err := tunnelURL(upstreamConfig, connectPath)
+	if err != nil {
+		return nil, api.Errorf(api.EINVALID, "failed to create upstream yamux endpoint: %v", err)
+	}
+
+	conn, err := dialTunnelConn(ctx, u, upstreamConfig.InsecureSkipVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	_ = conn.SetDeadline(deadline)
+
+	if err := writeUpgradeRequest(conn, u, upstreamConfig); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("read tunnel upgrade response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		var body string
+		if resp.Body != nil {
+			b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			_ = resp.Body.Close()
+			body = strings.TrimSpace(string(b))
+		}
+
+		_ = conn.Close()
+		if body != "" {
+			return nil, fmt.Errorf("tunnel upgrade failed: HTTP %d: %s", resp.StatusCode, body)
+		}
+
+		return nil, fmt.Errorf("tunnel upgrade failed: HTTP %d", resp.StatusCode)
+	}
+
+	if !hasHeaderToken(resp.Header.Get("Connection"), "upgrade") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("tunnel upgrade response missing Connection: Upgrade")
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(resp.Header.Get("Upgrade")), "yamux") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("tunnel upgrade response has invalid Upgrade header %q", resp.Header.Get("Upgrade"))
+	}
+
+	_ = conn.SetDeadline(time.Time{})
+	return bufferedConn{Conn: conn, reader: reader}, nil
+}
+
+func tunnelURL(upstreamConfig upstream.UpstreamConfig, connectPath string) (*url.URL, error) {
+	base := strings.TrimRight(upstreamConfig.Host, "/")
+	if base == "" {
+		return nil, fmt.Errorf("upstream host is required")
+	}
+
+	u, err := url.Parse(base + connectPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse upstream tunnel URL: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported upstream scheme %q", u.Scheme)
+	}
+
+	q := u.Query()
+	q.Set(upstream.AgentNameQueryParam, upstreamConfig.AgentName)
+	u.RawQuery = q.Encode()
+	return u, nil
+}
+
+func dialTunnelConn(ctx gocontext.Context, u *url.URL, insecureSkipVerify bool) (net.Conn, error) {
+	addr := canonicalAddr(u)
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	if u.Scheme == "https" {
+		tlsDialer := tls.Dialer{
+			NetDialer: dialer,
+			Config: &tls.Config{
+				ServerName:         u.Hostname(),
+				InsecureSkipVerify: insecureSkipVerify, //nolint:gosec
+			},
+		}
+
+		conn, err := tlsDialer.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("dial upstream tunnel: %w", err)
+		}
+		return conn, nil
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial upstream tunnel: %w", err)
+	}
+	return conn, nil
+}
+
+func canonicalAddr(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return net.JoinHostPort(u.Hostname(), port)
+	}
+	if u.Scheme == "https" {
+		return net.JoinHostPort(u.Hostname(), "443")
+	}
+	return net.JoinHostPort(u.Hostname(), "80")
+}
+
+func writeUpgradeRequest(conn net.Conn, u *url.URL, upstreamConfig upstream.UpstreamConfig) error {
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Host = u.Host
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "yamux")
+	if upstreamConfig.Username != "" || upstreamConfig.Password != "" {
+		req.SetBasicAuth(upstreamConfig.Username, upstreamConfig.Password)
+	}
+
+	if err := req.Write(conn); err != nil {
+		return fmt.Errorf("write tunnel upgrade request: %w", err)
+	}
+
+	return nil
+}
+
+type bufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c bufferedConn) Read(p []byte) (int, error) {
+	if c.reader != nil && c.reader.Buffered() > 0 {
+		return c.reader.Read(p)
+	}
+	return c.Conn.Read(p)
+}

--- a/upstream/tunnel/dial.go
+++ b/upstream/tunnel/dial.go
@@ -94,9 +94,15 @@ func runAgentTunnelSession(ctx gocontext.Context, upstreamConfig upstream.Upstre
 	}
 	defer session.Close()
 
+	done := make(chan struct{})
+	defer close(done)
+
 	go func() {
-		<-ctx.Done()
-		_ = session.Close()
+		select {
+		case <-ctx.Done():
+			_ = session.Close()
+		case <-done:
+		}
 	}()
 
 	server := &http.Server{

--- a/upstream/tunnel/manager.go
+++ b/upstream/tunnel/manager.go
@@ -57,28 +57,37 @@ func (t *manager) DeleteIfSame(agentID uuid.UUID, session *yamux.Session) bool {
 
 func (t *manager) Open(ctx context.Context, agentID uuid.UUID) (net.Conn, error) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	session, ok := t.sessions[agentID]
 	if !ok {
+		t.mu.Unlock()
 		return nil, ErrSessionNotFound
 	}
 
 	if session.IsClosed() {
+		t.mu.Unlock()
 		return nil, ErrSessionClosed
 	}
+	t.mu.Unlock()
 
 	ch := make(chan struct {
 		conn net.Conn
 		err  error
-	}, 1)
+	})
 
 	go func() {
 		conn, err := session.Open()
-		ch <- struct {
+		res := struct {
 			conn net.Conn
 			err  error
 		}{conn, err}
+
+		select {
+		case ch <- res:
+		case <-ctx.Done():
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
 	}()
 
 	select {

--- a/upstream/tunnel/manager.go
+++ b/upstream/tunnel/manager.go
@@ -1,0 +1,90 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/yamux"
+)
+
+var (
+	ErrSessionNotFound = errors.New("a yamux session was not found for the agent")
+	ErrSessionClosed   = errors.New("yamux session is already closed")
+)
+
+type manager struct {
+	mu       sync.Mutex
+	sessions map[uuid.UUID]*yamux.Session
+}
+
+var defaultManager = newManager()
+
+func newManager() *manager {
+	return &manager{sessions: map[uuid.UUID]*yamux.Session{}}
+}
+
+func (t *manager) Register(agentID uuid.UUID, session *yamux.Session) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if s, ok := t.sessions[agentID]; ok {
+		s.Close()
+	}
+	t.sessions[agentID] = session
+}
+
+// DeleteIfSame deletes the agent yamux session.
+// Returns true if the session was actually deleted.
+func (t *manager) DeleteIfSame(agentID uuid.UUID, session *yamux.Session) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	s, ok := t.sessions[agentID]
+	if !ok {
+		return false
+	}
+
+	if s == session {
+		delete(t.sessions, agentID)
+		return true
+	}
+
+	return false
+}
+
+func (t *manager) Open(ctx context.Context, agentID uuid.UUID) (net.Conn, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	session, ok := t.sessions[agentID]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+
+	if session.IsClosed() {
+		return nil, ErrSessionClosed
+	}
+
+	ch := make(chan struct {
+		conn net.Conn
+		err  error
+	}, 1)
+
+	go func() {
+		conn, err := session.Open()
+		ch <- struct {
+			conn net.Conn
+			err  error
+		}{conn, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		return res.conn, res.err
+	}
+}

--- a/upstream/tunnel/tunnel.go
+++ b/upstream/tunnel/tunnel.go
@@ -1,0 +1,15 @@
+// package tunnel is about the infrastructure that allows an agent to
+// establish an HTTP tunnel via hashicorp/yamux on which upstream can talk back to the agents.
+package tunnel
+
+import (
+	"context"
+	"net"
+
+	"github.com/google/uuid"
+)
+
+// Opens a new yamux session on the agent
+func Open(ctx context.Context, agentID uuid.UUID) (net.Conn, error) {
+	return defaultManager.Open(ctx, agentID)
+}


### PR DESCRIPTION
package tunnel exposes an `Open(ctx, agentID)` method that returns a net.Conn built over a yamux session. All agents establishes a yamux session with the usptream on startup.

Plugins and potentially playbooks can use those session to hit the agent echo server directly like this. The agent doesn't authenticate any requests over the yamux connection. The yamux session is taken to be already authenticated.

```go
agentID := uuid.MustParse("019e6fb4-76f5-97c2-30ec-3db6763b114b")
client := &http.Client{
	Transport: &http.Transport{
		ForceAttemptHTTP2: false,
		DisableKeepAlives: true,
		DialContext: func(ctx gocontext.Context, network, addr string) (net.Conn, error) {
			return tunnel.Open(ctx, agentID)
		},
	},
	Timeout: 10 * time.Second,
}

req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://agent.local/properties", nil)
if err != nil {
	ctx.Warnf("agent tunnel health check request failed: %v", err)
	return
}

resp, err := client.Do(req)
if err != nil {
	ctx.Warnf("agent tunnel health check failed for agent %s: %v", agentID, err)
	return
}
defer resp.Body.Close()

body, err := io.ReadAll(resp.Body)
if err != nil {
	ctx.Warnf("agent tunnel health check request failed: %v", err)
	return
}

fmt.Println(string(body))
ctx.Infof("agent tunnel health check succeeded for agent %s: %s", agentID, fmt.Sprintf("HTTP %d", resp.StatusCode))
```