### PR TITLE
fix(ui): allow downloads from plugin iframes

### DIFF
--- a/ui/frontend/src/config-detail/PluginTab.tsx
+++ b/ui/frontend/src/config-detail/PluginTab.tsx
@@ -44,7 +44,7 @@ export function PluginTab({ pluginName, tabPath, configId }: PluginTabProps) {
         src={pluginIframeSrc(pluginName, tabPath, configId)}
         title={`${pluginName} – ${tabPath}`}
         className="h-full w-full border-0"
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
         onLoad={() => setReady(true)}
       />
     </div>


### PR DESCRIPTION
Plugin UIs can expose downloadable artifacts such as captured pprof profiles. The iframe sandbox did not include `allow-downloads`, so browser-initiated downloads from plugins could be blocked even when the backend returned the file.

`Download is disallowed. The frame initiating or instantiating the download is sandboxed, but the flag ‘allow-downloads’ is not set. See https://www.chromestatus.com/feature/5706745674465280 for more details.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin tabs now support file downloads, enabling users to export and save data from plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->