### PR TITLE
fix: replace deprecated API scheme builder

### DIFF
--- a/api/v1/application.go
+++ b/api/v1/application.go
@@ -190,7 +190,3 @@ type ApplicationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Application `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Application{}, &ApplicationList{})
-}

--- a/api/v1/connection_types.go
+++ b/api/v1/connection_types.go
@@ -431,7 +431,3 @@ type ConnectionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Connection `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Connection{}, &ConnectionList{})
-}

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -4,17 +4,38 @@
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "mission-control.flanksource.com", Version: "v1"}
+	// groupVersion is group version used to register these objects
+	groupVersion = schema.GroupVersion{Group: "mission-control.flanksource.com", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	// schemeBuilder is used to add go types to the GroupVersionKind scheme
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(groupVersion,
+		&Application{}, &ApplicationList{},
+		&Connection{}, &ConnectionList{},
+		&IncidentRule{}, &IncidentRuleList{},
+		&Notification{}, &NotificationList{},
+		&NotificationSilence{}, &NotificationSilenceList{},
+		&Permission{}, &PermissionList{},
+		&PermissionGroup{}, &PermissionGroupList{},
+		&Playbook{}, &PlaybookList{},
+		&Plugin{}, &PluginList{},
+		&Scope{}, &ScopeList{},
+		&Team{}, &TeamList{},
+		&View{}, &ViewList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, groupVersion)
+	return nil
+}

--- a/api/v1/incident_rule_types.go
+++ b/api/v1/incident_rule_types.go
@@ -69,7 +69,3 @@ type IncidentRuleList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []IncidentRule `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&IncidentRule{}, &IncidentRuleList{})
-}

--- a/api/v1/notification_silence_types.go
+++ b/api/v1/notification_silence_types.go
@@ -88,7 +88,3 @@ type NotificationSilenceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []NotificationSilence `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&NotificationSilence{}, &NotificationSilenceList{})
-}

--- a/api/v1/notification_types.go
+++ b/api/v1/notification_types.go
@@ -213,7 +213,3 @@ type NotificationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Notification `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Notification{}, &NotificationList{})
-}

--- a/api/v1/permission_group_types.go
+++ b/api/v1/permission_group_types.go
@@ -106,7 +106,3 @@ type PermissionGroupList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []PermissionGroup `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&PermissionGroup{}, &PermissionGroupList{})
-}

--- a/api/v1/permission_types.go
+++ b/api/v1/permission_types.go
@@ -362,7 +362,3 @@ type PermissionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Permission `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Permission{}, &PermissionList{})
-}

--- a/api/v1/playbook_types.go
+++ b/api/v1/playbook_types.go
@@ -451,7 +451,3 @@ type PlaybookList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Playbook `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Playbook{}, &PlaybookList{})
-}

--- a/api/v1/plugin_types.go
+++ b/api/v1/plugin_types.go
@@ -141,7 +141,3 @@ type PluginList struct {
 	metav1.ListMeta `json:"metadata"`
 	Items           []Plugin `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Plugin{}, &PluginList{})
-}

--- a/api/v1/scope_types.go
+++ b/api/v1/scope_types.go
@@ -128,7 +128,3 @@ type ScopeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Scope `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Scope{}, &ScopeList{})
-}

--- a/api/v1/team_types.go
+++ b/api/v1/team_types.go
@@ -83,7 +83,3 @@ type TeamList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Team `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Team{}, &TeamList{})
-}

--- a/api/v1/view_types.go
+++ b/api/v1/view_types.go
@@ -372,7 +372,3 @@ func ViewFromModel(model *models.View) (*View, error) {
 
 	return &view, nil
 }
-
-func init() {
-	SchemeBuilder.Register(&View{}, &ViewList{})
-}


### PR DESCRIPTION
Lint surfaced a staticcheck warning for the deprecated controller-runtime scheme builder in the v1 API package.

Replace it with the apimachinery `runtime.SchemeBuilder` and centralize CRD type registration in `groupversion_info.go`.
This keeps the public `AddToScheme` behavior unchanged while removing the deprecated dependency path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal type registration mechanisms for improved code organization and maintainability. No user-facing functionality changes; the system continues to operate as expected with all existing features intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->