### PR TITLE
ci(plugin): release plugin modules independently

### DIFF
--- a/.github/workflows/plugin-modules-release.yml
+++ b/.github/workflows/plugin-modules-release.yml
@@ -1,0 +1,82 @@
+name: Release Plugin Modules
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - plugin/api/**
+      - plugin/sdk/**
+permissions:
+  contents: write
+
+# Serialize tag creation so concurrent main merges don't compute and push the same next tag.
+concurrency:
+  group: plugin-modules-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: v1.26.x
+          cache: false
+
+      - name: Release changed plugin modules
+        env:
+          GOPROXY: direct
+        run: |
+          set -euo pipefail
+
+          git fetch --force --tags origin
+
+          next_version() {
+            local latest_tag="$1"
+            local version="v0.0.0"
+
+            if [ -n "$latest_tag" ]; then
+              version="${latest_tag##*/}"
+            fi
+
+            local raw="${version#v}"
+            IFS=. read -r major minor patch <<< "$raw"
+            echo "v${major}.${minor}.$((patch + 1))"
+          }
+
+          release_module() {
+            local module="$1"
+            local latest_tag
+            latest_tag="$(git tag --list "${module}/v*" --sort=-v:refname | head -n1)"
+
+            if [ -n "$latest_tag" ] && git diff --quiet "${latest_tag}..HEAD" -- "$module"; then
+              echo "No ${module} changes since ${latest_tag}; skipping"
+              return
+            fi
+
+            local version
+            version="$(next_version "$latest_tag")"
+            local tag="${module}/${version}"
+
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "Tag ${tag} already exists; skipping"
+              return
+            fi
+
+            echo "Validating ${module}"
+            (cd "$module" && go mod download && go list ./...)
+
+            echo "Creating ${tag}"
+            git tag "$tag" HEAD
+            git push origin "refs/tags/${tag}"
+          }
+
+          release_module plugin/api
+          release_module plugin/sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set version
-        # Always use git tags as semantic release can fail due to rate limit
+        # Always use root git tags as semantic release can fail due to rate limit
         run: |
           git fetch --prune --unshallow
-          echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags | sed -e 's/^v//')" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags --match 'v[0-9]*' | sed -e 's/^v//')" >> $GITHUB_ENV
 
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@a173d53c3077a33d5877ca4d93d853a1de31f357 # v5
@@ -116,10 +116,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set version
-        # Always use git tags as semantic release can fail due to rate limit
+        # Always use root git tags as semantic release can fail due to rate limit
         run: |
           git fetch --prune --unshallow
-          echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags | sed -e 's/^v//')" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags --match 'v[0-9]*' | sed -e 's/^v//')" >> $GITHUB_ENV
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "${{ github.repository_owner }}/mission-control-chart"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OS   = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH = $(shell uname -m | sed 's/x86_64/amd64/')
 DATE = $(shell date  "+%Y-%m-%d %H:%M:%S")
 ifeq ($(VERSION),)
-  VERSION_TAG=$(shell git describe --abbrev=0 --tags --exact-match 2>/dev/null || echo latest)
+  VERSION_TAG=$(shell git describe --abbrev=0 --tags --exact-match --match 'v[0-9]*' 2>/dev/null || echo latest)
 else
   VERSION_TAG=$(VERSION)
 endif


### PR DESCRIPTION
Add a workflow that tags plugin/api and plugin/sdk only when their module paths change, using path-prefixed Go module tags.

Limit root version detection to root v* tags so plugin module tags do not affect app, image, or chart releases.
