### PR TITLE
feat: add plugin shutdown hook

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/flanksource/incident-commander/mcp"
 	"github.com/flanksource/incident-commander/metrics"
 	"github.com/flanksource/incident-commander/notification"
+	"github.com/flanksource/incident-commander/plugin/machinery"
 	pluginReconciler "github.com/flanksource/incident-commander/plugin/reconciler"
 	"github.com/flanksource/incident-commander/upstream/tunnel"
 	echov4 "github.com/labstack/echo/v4"
@@ -238,6 +239,10 @@ var Serve = &cobra.Command{
 				}
 			})
 		}
+
+		shutdown.AddHookWithPriority("plugins", shutdown.PriorityIngress, func() {
+			machinery.StopAll(ctx)
+		})
 
 		shutdown.AddHookWithPriority("database", shutdown.PriorityCritical, stop)
 

--- a/plugin/machinery/machinery.go
+++ b/plugin/machinery/machinery.go
@@ -94,6 +94,7 @@ func StopPlugin(id uuid.UUID) error {
 }
 
 func Invoke(ctx dutyContext.Context, pluginID uuid.UUID, req *api.InvokeRequest) (*api.InvokeResponse, error) {
+
 	entry := plugin.DefaultRegistry.Get(pluginID)
 	if entry == nil {
 		return nil, ctx.Oops().Code(dutyAPI.ENOTFOUND).Errorf("plugin %s not registered", pluginID)
@@ -107,6 +108,21 @@ func Invoke(ctx dutyContext.Context, pluginID uuid.UUID, req *api.InvokeRequest)
 		return entry.Runtime.Invoke(ctx, req)
 	default:
 		return nil, ctx.Oops().Code(dutyAPI.EINVALID).Errorf("plugin %s has unsupported connection kind %q", pluginID, entry.Kind)
+	}
+}
+
+// StopAll gracefully stops every running plugin. It is wired into the host's
+// shutdown sequence so plugin binaries are torn down with the host instead of
+// being left as orphans.
+func StopAll(ctx dutyContext.Context) {
+	for _, entry := range plugin.DefaultRegistry.List() {
+		if entry.Runtime == nil {
+			continue
+		}
+		ctx.Logger.Infof("stopping plugin %s", entry.ID)
+		if err := StopPlugin(entry.ID); err != nil {
+			ctx.Logger.Warnf("plugin %s: stop on shutdown: %v", entry.ID, err)
+		}
 	}
 }
 

--- a/plugin/machinery/machinery_test.go
+++ b/plugin/machinery/machinery_test.go
@@ -11,13 +11,14 @@ import (
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/plugin"
+	"github.com/flanksource/incident-commander/plugin/api"
 )
 
 type fakeRuntime struct {
 	stopped atomic.Bool
 }
 
-func (f *fakeRuntime) Invoke(context.Context, *plugin.InvokeRequest) (*plugin.InvokeResponse, error) {
+func (f *fakeRuntime) Invoke(context.Context, *api.InvokeRequest) (*api.InvokeResponse, error) {
 	return nil, nil
 }
 func (f *fakeRuntime) UIPort() uint32 { return 0 }

--- a/plugin/machinery/machinery_test.go
+++ b/plugin/machinery/machinery_test.go
@@ -1,0 +1,63 @@
+package machinery
+
+import (
+	"context"
+	"sync/atomic"
+
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/plugin"
+)
+
+type fakeRuntime struct {
+	stopped atomic.Bool
+}
+
+func (f *fakeRuntime) Invoke(context.Context, *plugin.InvokeRequest) (*plugin.InvokeResponse, error) {
+	return nil, nil
+}
+func (f *fakeRuntime) UIPort() uint32 { return 0 }
+func (f *fakeRuntime) Stop()          { f.stopped.Store(true) }
+
+var _ = ginkgo.Describe("StopAll", func() {
+	ginkgo.It("stops every running plugin and clears their runtimes", func() {
+		reg := plugin.DefaultRegistry
+		id1, id2 := uuid.New(), uuid.New()
+
+		_, err := reg.Upsert(id1, "default", "p1", v1.PluginSpec{})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reg.Upsert(id2, "default", "p2", v1.PluginSpec{})
+		Expect(err).ToNot(HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			reg.Remove(id1)
+			reg.Remove(id2)
+		})
+
+		r1, r2 := &fakeRuntime{}, &fakeRuntime{}
+		Expect(reg.SetRuntime(id1, r1)).To(Succeed())
+		Expect(reg.SetRuntime(id2, r2)).To(Succeed())
+
+		StopAll(dutyContext.NewContext(context.Background()))
+
+		Expect(r1.stopped.Load()).To(BeTrue())
+		Expect(r2.stopped.Load()).To(BeTrue())
+		Expect(reg.Get(id1).Runtime).To(BeNil())
+		Expect(reg.Get(id2).Runtime).To(BeNil())
+	})
+
+	ginkgo.It("skips plugins that are not running", func() {
+		reg := plugin.DefaultRegistry
+		id := uuid.New()
+		_, err := reg.Upsert(id, "default", "idle", v1.PluginSpec{})
+		Expect(err).ToNot(HaveOccurred())
+		ginkgo.DeferCleanup(func() { reg.Remove(id) })
+
+		Expect(func() {
+			StopAll(dutyContext.NewContext(context.Background()))
+		}).ToNot(Panic())
+	})
+})

--- a/plugin/machinery/suite_test.go
+++ b/plugin/machinery/suite_test.go
@@ -1,0 +1,13 @@
+package machinery
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMachinery(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Machinery")
+}

--- a/plugin/sdk/serve.go
+++ b/plugin/sdk/serve.go
@@ -44,6 +44,29 @@ func shutdownSignal() {
 	shutdownOnce.Do(func() { close(shutdownCh) })
 }
 
+// parentPollInterval is how often the plugin checks whether its host is still
+// alive.
+const parentPollInterval = time.Second
+
+// watchParentDeath calls onDeath the first time the parent pid changes from
+// original. The host launches the plugin as a direct child, so a changed ppid
+// means the host process is gone — it died abruptly (crash/SIGKILL) before it
+// could send the graceful Shutdown RPC. go-plugin offers no protection against
+// this, so without it an abruptly-killed host leaves orphaned plugin processes
+// holding their ports. Polling getppid works identically on Linux and macOS,
+// where there is no kernel mechanism (Pdeathsig is Linux-only) to tear a child
+// down with its parent.
+func watchParentDeath(original int, interval time.Duration, getppid func() int, onDeath func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if getppid() != original {
+			onDeath()
+			return
+		}
+	}
+}
+
 // Serve is the entry point for plugin binaries. It:
 //
 //  1. validates the magic-cookie env var (exits 1 if not set);
@@ -70,6 +93,11 @@ func Serve(impl Plugin, opts ...Option) {
 	srv := newPluginServer(impl, 0)
 	uiPort, httpServer := startHTTPServer(cfg, srv)
 	srv.uiPort = uiPort
+
+	go watchParentDeath(os.Getppid(), parentPollInterval, os.Getppid, func() {
+		fmt.Fprintln(os.Stderr, "plugin: host process exited; shutting down")
+		os.Exit(1)
+	})
 
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: api.Handshake,

--- a/plugin/sdk/serve_test.go
+++ b/plugin/sdk/serve_test.go
@@ -1,0 +1,38 @@
+package sdk
+
+import (
+	"sync/atomic"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("watchParentDeath", func() {
+	ginkgo.It("invokes onDeath once the parent pid changes", func() {
+		var ppid atomic.Int64
+		ppid.Store(100)
+
+		var calls atomic.Int32
+		done := make(chan struct{})
+		go watchParentDeath(100, time.Millisecond, func() int { return int(ppid.Load()) }, func() {
+			calls.Add(1)
+			close(done)
+		})
+
+		// Simulate the host dying: the plugin gets reparented to init/launchd.
+		ppid.Store(1)
+
+		Eventually(done, "1s").Should(BeClosed())
+		Expect(calls.Load()).To(Equal(int32(1)))
+	})
+
+	ginkgo.It("does not fire while the parent is alive", func() {
+		var calls atomic.Int32
+		go watchParentDeath(100, time.Millisecond, func() int { return 100 }, func() {
+			calls.Add(1)
+		})
+
+		Consistently(calls.Load, "200ms", "20ms").Should(Equal(int32(0)))
+	})
+})


### PR DESCRIPTION
Fixes: #3169 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins are now properly stopped during server shutdown to ensure clean termination.
  * Plugin processes now detect when the host process exits and automatically terminate gracefully.

* **Tests**
  * Added comprehensive test coverage for plugin shutdown and host process monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->