### PR TITLE
build(docker): Add Facet PDF rendering support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Container
         run: make docker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # Node (with npm/npx) is needed to install Puppeteer's Chrome. deps is already
-# present in the base image and is the same installer the Makefile uses.
-RUN deps install node@${NODE_VERSION} --bin-dir /usr/bin --app-dir /usr/lib/node --tmp-dir /tmp
+# present in the base image and is the same installer the Makefile uses. The
+# GITHUB_TOKEN secret lifts the GitHub API rate limit deps hits resolving
+# nodejs/node releases.
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    deps install node@${NODE_VERSION} --bin-dir /usr/bin --app-dir /usr/lib/node --tmp-dir /tmp
 
 # Install the facet standalone binary (bun-compiled, self-contained). The npm
 # package has no bin entry and unbundled deps, so the release binary is the

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,84 @@ RUN make build
 FROM flanksource/base-image:0.6.0@sha256:6cae0a4bbba7e7e16674a55751c8161c11d5ebdd23f596f93e669f835ee1e034
 WORKDIR /app
 
+ARG TARGETARCH
+ARG NODE_VERSION=24.11.0
+ARG FACET_VERSION=v0.1.40
+
+# Facet renders report PDFs via a headless Chrome launched by Puppeteer.
+# Install the shared libraries Chrome needs plus fonts for correct rendering.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libgtk-3-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxtst6 \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/* && apt-get clean
+
+# Node (with npm/npx) is needed to install Puppeteer's Chrome. deps is already
+# present in the base image and is the same installer the Makefile uses.
+RUN deps install node@${NODE_VERSION} --bin-dir /usr/bin --app-dir /usr/lib/node --tmp-dir /tmp
+
+# Install the facet standalone binary (bun-compiled, self-contained). The npm
+# package has no bin entry and unbundled deps, so the release binary is the
+# supported way to run `facet`. A GITHUB_TOKEN secret is used (when present) to
+# avoid GitHub API/download rate limits.
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    FACET_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo x64 || echo "${TARGETARCH}") && \
+    CURL_CFG=$(mktemp) && \
+    [ -n "${GITHUB_TOKEN}" ] && printf 'header = "Authorization: Bearer %s"\n' "${GITHUB_TOKEN}" > "${CURL_CFG}"; \
+    if [ "${FACET_VERSION}" = "latest" ]; then \
+      FACET_URL=$(curl -fsSL -K "${CURL_CFG}" https://api.github.com/repos/flanksource/facet/releases/latest | jq -r ".assets[] | select(.name == \"facet-linux-${FACET_ARCH}\") | .browser_download_url"); \
+    else \
+      FACET_URL="https://github.com/flanksource/facet/releases/download/${FACET_VERSION}/facet-linux-${FACET_ARCH}"; \
+    fi && \
+    curl -fsSL -K "${CURL_CFG}" "${FACET_URL}" -o /usr/local/bin/facet && \
+    rm -f "${CURL_CFG}" && \
+    chmod +x /usr/local/bin/facet && \
+    facet --version
+
+# Install Chrome for Puppeteer and symlink it to a stable path (the install dir
+# is version-specific, so ENV can't reference it with a glob).
+ENV PUPPETEER_CACHE_DIR=/opt/puppeteer
+RUN npx --yes puppeteer browsers install chrome --path /opt/puppeteer && \
+    ln -sf "$(ls /opt/puppeteer/chrome/linux-*/chrome-linux64/chrome)" /usr/local/bin/chrome
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/bin/chrome
+
+# Verify facet can render a PDF inside the container.
+COPY fixtures/facet/SimpleReport.tsx fixtures/facet/simple-data.json /tmp/facet/
+RUN cd /tmp/facet && \
+    facet pdf SimpleReport.tsx --data simple-data.json --output /tmp/facet/out.pdf && \
+    test -s /tmp/facet/out.pdf && \
+    [ "$(stat -c%s /tmp/facet/out.pdf)" -ge 1024 ] && \
+    echo "facet PDF render OK: $(stat -c%s /tmp/facet/out.pdf) bytes" && \
+    rm -rf /tmp/facet
+
 COPY --from=builder /app/.bin/incident-commander /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # present in the base image and is the same installer the Makefile uses. The
 # GITHUB_TOKEN secret lifts the GitHub API rate limit deps hits resolving
 # nodejs/node releases.
+# facet installs report template deps with pnpm at render time, so it must be
+# on PATH. Symlink it into /usr/bin since npm's global bin dir is not.
+ARG PNPM_VERSION=9.15.9
 RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
-    deps install node@${NODE_VERSION} --bin-dir /usr/bin --app-dir /usr/lib/node --tmp-dir /tmp
+    deps install node@${NODE_VERSION} --bin-dir /usr/bin --app-dir /usr/lib/node --tmp-dir /tmp && \
+    npm install -g pnpm@${PNPM_VERSION} && \
+    ln -sf "$(npm prefix -g)/bin/pnpm" /usr/bin/pnpm && \
+    pnpm --version
 
 # Install the facet standalone binary (bun-compiled, self-contained). The npm
 # package has no bin entry and unbundled deps, so the release binary is the

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ WORKDIR /app
 
 ARG TARGETARCH
 ARG NODE_VERSION=24.11.0
-ARG FACET_VERSION=v0.1.40
+# Pin to a version where both the release binary and the matching
+# @flanksource/facet npm package (installed into .facet/ at render time) exist.
+# v0.1.40 ships a binary but no npm package, so the render-time pnpm install fails.
+ARG FACET_VERSION=v0.1.39
 
 # Facet renders report PDFs via a headless Chrome launched by Puppeteer.
 # Install the shared libraries Chrome needs plus fonts for correct rendering.

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ modernize: ## Run modernize against code.
 	$(MODERNIZE) ./...
 
 docker:
-	docker build . -t ${IMG}
+	DOCKER_BUILDKIT=1 docker build . -t ${IMG} $(if $(GITHUB_TOKEN),--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN)
 
 # Build the docker image
 docker-dev: linux

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= docker.io/flanksource/$(NAME):${VERSION_TAG}
+COMMA := ,
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -91,7 +92,7 @@ modernize: ## Run modernize against code.
 	$(MODERNIZE) ./...
 
 docker:
-	DOCKER_BUILDKIT=1 docker build . -t ${IMG} $(if $(GITHUB_TOKEN),--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN)
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} $(if $(GITHUB_TOKEN),--secret id=GITHUB_TOKEN$(COMMA)env=GITHUB_TOKEN) .
 
 # Build the docker image
 docker-dev: linux

--- a/fixtures/facet/SimpleReport.tsx
+++ b/fixtures/facet/SimpleReport.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface ReportData {
+  name: string;
+  title: string;
+  sections: Array<{
+    title: string;
+    content: string;
+  }>;
+}
+
+export default function SimpleReport({ data }: { data: ReportData }) {
+  return (
+    <html>
+      <head>
+        <title>{data.title}</title>
+        <style>{`
+          body {
+            font-family: system-ui, -apple-system, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            color: #333;
+          }
+          h1 {
+            color: #2563eb;
+            border-bottom: 3px solid #2563eb;
+            padding-bottom: 0.5rem;
+          }
+          h2 {
+            color: #1e40af;
+            margin-top: 2rem;
+          }
+          section {
+            margin-bottom: 2rem;
+          }
+        `}</style>
+      </head>
+      <body>
+        <h1>{data.title}</h1>
+        {data.sections.map((section, index) => (
+          <section key={index}>
+            <h2>{section.title}</h2>
+            <p>{section.content}</p>
+          </section>
+        ))}
+      </body>
+    </html>
+  );
+}

--- a/fixtures/facet/simple-data.json
+++ b/fixtures/facet/simple-data.json
@@ -1,0 +1,22 @@
+{
+  "name": "Q4-Report-2024",
+  "title": "Q4 2024 Business Review",
+  "sections": [
+    {
+      "title": "Executive Summary",
+      "content": "This quarter showed significant growth across all key metrics. Revenue increased by 25% compared to Q3, and customer satisfaction scores reached an all-time high."
+    },
+    {
+      "title": "Financial Performance",
+      "content": "Total revenue for Q4 was $1.2M, representing 25% growth. Operating expenses were well-controlled at $800K, resulting in a healthy profit margin of 33%."
+    },
+    {
+      "title": "Customer Metrics",
+      "content": "We acquired 150 new customers this quarter, bringing our total customer base to 1,200. Net Promoter Score improved from 72 to 78."
+    },
+    {
+      "title": "Next Steps",
+      "content": "For Q1 2025, we're focusing on product innovation and expanding our sales team to capitalize on market momentum."
+    }
+  ]
+}


### PR DESCRIPTION
**What**
- Install Node.js, Puppeteer, Chrome, and Facet standalone binary
- Add system libraries required by headless Chrome
- Include test PDF render verification

**Why**
- Enable incident-commander to generate PDF reports using Facet's rendering capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled headless PDF rendering in the container runtime.
  * Added a sample report template and example data for PDF generation.

* **Chores**
  * Updated build to install required system libraries, fonts, Node and Chrome for rendering.
  * Build and CI adjustments to enable BuildKit and securely pass build-time secrets for dependency installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->