### PR TITLE
feat(plugin): add support for plugin.interval and re-resolve latest plugin

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/flanksource/incident-commander/notification"
 	"github.com/flanksource/incident-commander/playbook"
+	"github.com/flanksource/incident-commander/plugin/machinery"
 	"github.com/flanksource/incident-commander/shorturl"
 )
 
@@ -123,6 +124,14 @@ func Start(ctx context.Context, mcpServer *server.MCPServer) {
 	if err := job.NewJob(ctx, "Cleanup Short URLs", CleanupExpiredShortURLsSchedule, shorturl.CleanupExpired).
 		AddToScheduler(FuncScheduler); err != nil {
 		logger.Errorf("Failed to schedule job for cleaning up short URLs: %v", err)
+	}
+
+	if interval := ctx.Properties().Duration("plugin.interval", 0); interval > 0 {
+		if err := job.NewJob(ctx, "Plugin Refresh", fmt.Sprintf("@every %s", interval), func(jr job.JobRuntime) error {
+			return machinery.RefreshLatestPlugins(jr.Context)
+		}).AddToScheduler(FuncScheduler); err != nil {
+			logger.Errorf("Failed to schedule Plugin Refresh job: %v", err)
+		}
 	}
 
 	for _, job := range query.Jobs {

--- a/plugin/machinery/local/install.go
+++ b/plugin/machinery/local/install.go
@@ -2,11 +2,49 @@ package local
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/flanksource/deps"
 	dutyContext "github.com/flanksource/duty/context"
 )
+
+// IsLatest reports whether a plugin version pins to a moving "latest" target
+// rather than a concrete version.
+func IsLatest(version string) bool {
+	return version == "" || version == "latest"
+}
+
+// binaryName returns the on-disk name used for a plugin's binary and version
+// directories. The deps package name (source) is preferred, falling back to
+// the plugin name.
+func binaryName(name, source string) string {
+	if source != "" {
+		return source
+	}
+	return name
+}
+
+// VersionFromBinaryPath returns the resolved version a binary was installed
+// under, which is the name of the directory containing the binary.
+func VersionFromBinaryPath(binPath string) string {
+	if binPath == "" {
+		return ""
+	}
+	return filepath.Base(filepath.Dir(binPath))
+}
+
+// RemoveVersion deletes the version directory for one plugin version. It
+// refuses to delete the moving "latest" target so a half-resolved install
+// can't wipe an unrelated directory.
+func RemoveVersion(name, source, version string) error {
+	if IsLatest(version) {
+		return fmt.Errorf("refusing to remove plugin %s version dir for %q", name, version)
+	}
+	return os.RemoveAll(VersionedBinDirFor(binaryName(name, source), version))
+}
 
 func InstallPlugin(ctx dutyContext.Context, name, source, version string) (string, error) {
 	binDir := PluginPath()
@@ -14,10 +52,7 @@ func InstallPlugin(ctx dutyContext.Context, name, source, version string) (strin
 		return "", fmt.Errorf("create plugin dir %s: %w", binDir, err)
 	}
 
-	binName := source
-	if binName == "" {
-		binName = name
-	}
+	binName := binaryName(name, source)
 	versionedBinDir := VersionedBinDirFor(binName, version)
 	if err := os.MkdirAll(versionedBinDir, 0o755); err != nil {
 		return "", fmt.Errorf("create plugin version dir %s: %w", versionedBinDir, err)
@@ -44,4 +79,79 @@ func InstallPlugin(ctx dutyContext.Context, name, source, version string) (strin
 	}
 
 	return binPath, nil
+}
+
+// ResolveAndInstallLatest re-resolves a plugin's "latest" target to a concrete
+// version and pins it under that version's directory. It returns the installed
+// binary path and the resolved version so callers can detect when a newer
+// version has become available.
+//
+// The resolution installs "latest" into a persistent staging directory. deps
+// always reports the resolved concrete version, and only re-downloads when the
+// staged binary is behind the upstream latest, so repeated calls are cheap when
+// nothing has changed. The staged binary is then copied into its versioned
+// directory, leaving staging warm for the next check.
+func ResolveAndInstallLatest(ctx dutyContext.Context, name, source string) (string, string, error) {
+	binName := binaryName(name, source)
+	staging := VersionedBinDirFor(binName, "latest")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		return "", "", fmt.Errorf("create plugin staging dir %s: %w", staging, err)
+	}
+
+	res, err := deps.InstallWithContext(ctx, source, "latest", deps.WithBinDir(staging))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve latest for plugin %s: %w", name, err)
+	}
+	if res != nil && res.Error != nil {
+		return "", "", fmt.Errorf("resolve latest for plugin %s: %w", name, res.Error)
+	}
+
+	version := strings.TrimSpace(res.Version.String())
+	if IsLatest(version) {
+		return "", "", fmt.Errorf("plugin %s: deps did not resolve latest to a concrete version", name)
+	}
+
+	target, err := pinVersion(binName, version)
+	if err != nil {
+		return "", "", err
+	}
+
+	return target, version, nil
+}
+
+// pinVersion copies the freshly staged binary into its versioned directory and
+// returns the binary's path. When that version is already pinned the existing
+// binary is reused and the staged copy is left untouched.
+func pinVersion(binName, version string) (string, error) {
+	target := BinaryPathFor(binName, version)
+	if info, err := os.Stat(target); err == nil && !info.IsDir() {
+		return target, nil
+	}
+
+	if err := os.MkdirAll(VersionedBinDirFor(binName, version), 0o755); err != nil {
+		return "", fmt.Errorf("create plugin version dir for %s@%s: %w", binName, version, err)
+	}
+	if err := copyExecutable(BinaryPathFor(binName, "latest"), target); err != nil {
+		return "", fmt.Errorf("pin plugin %s@%s: %w", binName, version, err)
+	}
+
+	return target, nil
+}
+
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/plugin/machinery/local/install.go
+++ b/plugin/machinery/local/install.go
@@ -17,6 +17,12 @@ func IsLatest(version string) bool {
 	return version == "" || version == "latest"
 }
 
+// isFile reports whether path exists and is a regular file (not a directory).
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
 // binaryName returns the on-disk name used for a plugin's binary and version
 // directories. The deps package name (source) is preferred, falling back to
 // the plugin name.
@@ -59,7 +65,7 @@ func InstallPlugin(ctx dutyContext.Context, name, source, version string) (strin
 	}
 
 	binPath := BinaryPathFor(binName, version)
-	if info, err := os.Stat(binPath); err == nil && !info.IsDir() {
+	if isFile(binPath) {
 		ctx.Logger.V(3).Infof("plugin %s@%s: using existing binary at %s, skipping install", name, version, binPath)
 		return binPath, nil
 	}
@@ -99,11 +105,18 @@ func ResolveAndInstallLatest(ctx dutyContext.Context, name, source string) (stri
 	}
 
 	res, err := deps.InstallWithContext(ctx, source, "latest", deps.WithBinDir(staging))
-	if err != nil {
-		return "", "", fmt.Errorf("resolve latest for plugin %s: %w", name, err)
+	if err == nil && res != nil {
+		err = res.Error
 	}
-	if res != nil && res.Error != nil {
-		return "", "", fmt.Errorf("resolve latest for plugin %s: %w", name, res.Error)
+	if err != nil {
+		// deps can't resolve this source (e.g. a locally-built plugin that
+		// isn't in any registry). Fall back to a binary already staged in the
+		// plugin path so local development and pre-installed plugins still run.
+		if staged := BinaryPathFor(binName, "latest"); isFile(staged) {
+			ctx.Logger.V(3).Infof("plugin %s: deps could not resolve latest (%v); using staged binary %s", name, err, staged)
+			return staged, "latest", nil
+		}
+		return "", "", fmt.Errorf("resolve latest for plugin %s: %w", name, err)
 	}
 
 	version := strings.TrimSpace(res.Version.String())
@@ -124,7 +137,7 @@ func ResolveAndInstallLatest(ctx dutyContext.Context, name, source string) (stri
 // binary is reused and the staged copy is left untouched.
 func pinVersion(binName, version string) (string, error) {
 	target := BinaryPathFor(binName, version)
-	if info, err := os.Stat(target); err == nil && !info.IsDir() {
+	if isFile(target) {
 		return target, nil
 	}
 

--- a/plugin/machinery/local/refresh_test.go
+++ b/plugin/machinery/local/refresh_test.go
@@ -1,0 +1,115 @@
+// ABOUTME: Tests for the latest-version resolution helpers used by the plugin
+// ABOUTME: refresh job: version detection, path math, and old-version removal.
+package local
+
+import (
+	"os"
+	"path/filepath"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("IsLatest", func() {
+	cases := []struct {
+		version string
+		expect  bool
+	}{
+		{"", true},
+		{"latest", true},
+		{"v1.2.3", false},
+		{"1.2.3", false},
+	}
+	for _, tt := range cases {
+		ginkgo.It(tt.version, func() {
+			Expect(IsLatest(tt.version)).To(Equal(tt.expect))
+		})
+	}
+})
+
+var _ = ginkgo.Describe("VersionFromBinaryPath", func() {
+	ginkgo.It("returns the version directory name", func() {
+		Expect(VersionFromBinaryPath("/plugins/kubernetes-logs/v1.3.0/kubernetes-logs")).To(Equal("v1.3.0"))
+	})
+
+	ginkgo.It("returns empty for an empty path", func() {
+		Expect(VersionFromBinaryPath("")).To(Equal(""))
+	})
+})
+
+var _ = ginkgo.Describe("RemoveVersion", func() {
+	var root string
+
+	ginkgo.BeforeEach(func() {
+		root = ginkgo.GinkgoT().TempDir()
+		Expect(os.Setenv(EnvPluginPath, root)).To(Succeed())
+		ginkgo.DeferCleanup(func() { _ = os.Unsetenv(EnvPluginPath) })
+	})
+
+	ginkgo.It("removes the version directory for a plugin", func() {
+		versionDir := VersionedBinDirFor("kubernetes-logs", "v1.3.0")
+		Expect(os.MkdirAll(versionDir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(versionDir, "kubernetes-logs"), []byte("bin"), 0o755)).To(Succeed())
+
+		Expect(RemoveVersion("kubernetes-logs", "", "v1.3.0")).To(Succeed())
+		Expect(versionDir).ToNot(BeADirectory())
+	})
+
+	ginkgo.It("refuses to remove an empty version", func() {
+		Expect(RemoveVersion("kubernetes-logs", "", "")).ToNot(Succeed())
+	})
+
+	ginkgo.It("refuses to remove the latest version", func() {
+		Expect(RemoveVersion("kubernetes-logs", "", "latest")).ToNot(Succeed())
+	})
+})
+
+var _ = ginkgo.Describe("pinVersion", func() {
+	var root string
+
+	stage := func(binName string, content []byte) {
+		staging := VersionedBinDirFor(binName, "latest")
+		Expect(os.MkdirAll(staging, 0o755)).To(Succeed())
+		Expect(os.WriteFile(BinaryPathFor(binName, "latest"), content, 0o755)).To(Succeed())
+	}
+
+	ginkgo.BeforeEach(func() {
+		root = ginkgo.GinkgoT().TempDir()
+		Expect(os.Setenv(EnvPluginPath, root)).To(Succeed())
+		ginkgo.DeferCleanup(func() { _ = os.Unsetenv(EnvPluginPath) })
+	})
+
+	ginkgo.It("copies the staged binary into its version directory", func() {
+		stage("kubernetes-logs", []byte("v2-binary"))
+
+		target, err := pinVersion("kubernetes-logs", "v2.0.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(target).To(Equal(BinaryPathFor("kubernetes-logs", "v2.0.0")))
+
+		Expect(os.ReadFile(target)).To(Equal([]byte("v2-binary")))
+
+		info, err := os.Stat(target)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode().Perm() & 0o111).ToNot(BeZero())
+	})
+
+	ginkgo.It("leaves staging intact so the next check stays warm", func() {
+		stage("kubernetes-logs", []byte("v2-binary"))
+
+		_, err := pinVersion("kubernetes-logs", "v2.0.0")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(BinaryPathFor("kubernetes-logs", "latest")).To(BeARegularFile())
+	})
+
+	ginkgo.It("reuses an already-pinned version without overwriting it", func() {
+		versionDir := VersionedBinDirFor("kubernetes-logs", "v2.0.0")
+		Expect(os.MkdirAll(versionDir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(BinaryPathFor("kubernetes-logs", "v2.0.0"), []byte("already-here"), 0o755)).To(Succeed())
+		stage("kubernetes-logs", []byte("newly-staged"))
+
+		target, err := pinVersion("kubernetes-logs", "v2.0.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.ReadFile(target)).To(Equal([]byte("already-here")))
+	})
+})

--- a/plugin/machinery/local/refresh_test.go
+++ b/plugin/machinery/local/refresh_test.go
@@ -64,6 +64,37 @@ var _ = ginkgo.Describe("RemoveVersion", func() {
 	})
 })
 
+var _ = ginkgo.Describe("ResolveAndInstallLatest", func() {
+	var root string
+
+	ginkgo.BeforeEach(func() {
+		root = ginkgo.GinkgoT().TempDir()
+		Expect(os.Setenv(EnvPluginPath, root)).To(Succeed())
+		ginkgo.DeferCleanup(func() { _ = os.Unsetenv(EnvPluginPath) })
+	})
+
+	ginkgo.It("falls back to a staged binary when deps cannot resolve the source", func() {
+		Expect(os.MkdirAll(VersionedBinDirFor("local-only", "latest"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(BinaryPathFor("local-only", "latest"), []byte("staged"), 0o755)).To(Succeed())
+
+		ctx, cancel := newTestContext()
+		defer cancel()
+
+		path, version, err := ResolveAndInstallLatest(ctx, "local-only", "local-only")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(path).To(Equal(BinaryPathFor("local-only", "latest")))
+		Expect(version).To(Equal("latest"))
+	})
+
+	ginkgo.It("errors when deps cannot resolve and nothing is staged", func() {
+		ctx, cancel := newTestContext()
+		defer cancel()
+
+		_, _, err := ResolveAndInstallLatest(ctx, "local-only", "local-only")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
 var _ = ginkgo.Describe("pinVersion", func() {
 	var root string
 

--- a/plugin/machinery/local/supervisor.go
+++ b/plugin/machinery/local/supervisor.go
@@ -270,14 +270,16 @@ func (s *Supervisor) watchBinary(ctx dutyContext.Context) {
 			ctx.Logger.Warnf("plugin %s: fsnotify error: %v", s.Name, err)
 
 		case <-fire:
-			ctx.Logger.Infof("plugin %s: binary changed, restarting", s.Name)
+			ctx.Logger.Infof("plugin %s: binary changed on disk, restarting via file watcher", s.Name)
 			restartFn := s.restartFn
 			if restartFn == nil {
 				restartFn = s.restart
 			}
 			if err := restartFn(ctx); err != nil {
 				ctx.Logger.Errorf("plugin %s: restart failed: %v", s.Name, err)
+				return
 			}
+			ctx.Logger.Infof("plugin %s: restarted after binary change", s.Name)
 			return
 		}
 	}

--- a/plugin/machinery/machinery.go
+++ b/plugin/machinery/machinery.go
@@ -31,7 +31,13 @@ func StartPlugin(ctx dutyContext.Context, id uuid.UUID) error {
 }
 
 func startLocalPlugin(ctx dutyContext.Context, entry *plugin.Entry) error {
-	installedPath, err := local.InstallPlugin(ctx, entry.Name, entry.Spec.Source, entry.Spec.Version)
+	var installedPath string
+	var err error
+	if local.IsLatest(entry.Spec.Version) {
+		installedPath, _, err = local.ResolveAndInstallLatest(ctx, entry.Name, entry.Spec.Source)
+	} else {
+		installedPath, err = local.InstallPlugin(ctx, entry.Name, entry.Spec.Source, entry.Spec.Version)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to install plugin %s: %w", entry.Name, err)
 	}

--- a/plugin/machinery/refresh.go
+++ b/plugin/machinery/refresh.go
@@ -1,0 +1,90 @@
+// ABOUTME: Re-resolves plugins pinned to "latest", swapping the running
+// ABOUTME: process to a newly published binary and removing the old version.
+package machinery
+
+import (
+	"errors"
+	"fmt"
+
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/google/uuid"
+
+	"github.com/flanksource/incident-commander/plugin"
+	"github.com/flanksource/incident-commander/plugin/api"
+	"github.com/flanksource/incident-commander/plugin/machinery/local"
+)
+
+// refreshOps are the side-effecting operations the refresh flow performs. They
+// are injectable so tests can substitute the network install and the real
+// process restart with fakes while still exercising the swap orchestration.
+type refreshOps struct {
+	resolveLatest func(ctx dutyContext.Context, name, source string) (string, string, error)
+	stop          func(id uuid.UUID) error
+	start         func(ctx dutyContext.Context, id uuid.UUID) error
+	removeVersion func(name, source, version string) error
+}
+
+func defaultRefreshOps() refreshOps {
+	return refreshOps{
+		resolveLatest: local.ResolveAndInstallLatest,
+		stop:          StopPlugin,
+		start:         StartPlugin,
+		removeVersion: local.RemoveVersion,
+	}
+}
+
+// RefreshLatestPlugins re-resolves every plugin pinned to "latest" and restarts
+// any whose resolved version has changed. Plugins pinned to a concrete version
+// are left untouched. A failure on one plugin is logged and does not stop the
+// others; all failures are joined into the returned error.
+func RefreshLatestPlugins(ctx dutyContext.Context) error {
+	return refreshLatestPlugins(ctx, defaultRefreshOps())
+}
+
+func refreshLatestPlugins(ctx dutyContext.Context, ops refreshOps) error {
+	var errs []error
+	for _, entry := range plugin.DefaultRegistry.List() {
+		switch entry.Kind {
+		case "", api.PluginKindLocal:
+		default:
+			continue
+		}
+		if !local.IsLatest(entry.Spec.Version) {
+			continue
+		}
+		if err := ops.refreshPlugin(ctx, entry); err != nil {
+			ctx.Logger.Errorf("plugin %s: refresh failed: %v", entry.Name, err)
+			errs = append(errs, fmt.Errorf("plugin %s: %w", entry.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (ops refreshOps) refreshPlugin(ctx dutyContext.Context, entry *plugin.Entry) error {
+	_, newVersion, err := ops.resolveLatest(ctx, entry.Name, entry.Spec.Source)
+	if err != nil {
+		return err
+	}
+
+	oldVersion := local.VersionFromBinaryPath(entry.InstalledPath)
+	if newVersion == oldVersion {
+		ctx.Logger.V(3).Infof("plugin %s: already at latest version %s", entry.Name, newVersion)
+		return nil
+	}
+
+	ctx.Logger.Infof("plugin %s: new version %s available (was %s); restarting", entry.Name, newVersion, oldVersion)
+	if err := ops.stop(entry.ID); err != nil {
+		return fmt.Errorf("stop plugin %s: %w", entry.Name, err)
+	}
+	if err := ops.start(ctx, entry.ID); err != nil {
+		return fmt.Errorf("start plugin %s: %w", entry.Name, err)
+	}
+
+	if oldVersion != "" && oldVersion != newVersion {
+		if err := ops.removeVersion(entry.Name, entry.Spec.Source, oldVersion); err != nil {
+			ctx.Logger.Warnf("plugin %s: remove old version %s: %v", entry.Name, oldVersion, err)
+		}
+	}
+
+	return nil
+}

--- a/plugin/machinery/refresh_test.go
+++ b/plugin/machinery/refresh_test.go
@@ -1,0 +1,104 @@
+// ABOUTME: Tests the latest-plugin refresh orchestration: version-change
+// ABOUTME: detection and the stop/start/remove swap sequence, using fake ops.
+package machinery
+
+import (
+	"context"
+	"fmt"
+
+	dutyContext "github.com/flanksource/duty/context"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/plugin"
+)
+
+var _ = ginkgo.Describe("RefreshLatestPlugins", func() {
+	var (
+		ctx    dutyContext.Context
+		reg    *plugin.Registry
+		id     uuid.UUID
+		events []string
+	)
+
+	ginkgo.BeforeEach(func() {
+		ctx = dutyContext.NewContext(context.Background())
+		reg = plugin.DefaultRegistry
+		id = uuid.New()
+		events = nil
+	})
+
+	register := func(version, installedPath string) {
+		_, err := reg.Upsert(id, "default", "foo", v1.PluginSpec{Source: "foo", Version: version})
+		Expect(err).ToNot(HaveOccurred())
+		if installedPath != "" {
+			Expect(reg.SetInstalledPath(id, installedPath)).To(Succeed())
+		}
+		ginkgo.DeferCleanup(func() { reg.Remove(id) })
+	}
+
+	opsWith := func(resolvedVersion string, resolveErr error) refreshOps {
+		return refreshOps{
+			resolveLatest: func(_ dutyContext.Context, name, _ string) (string, string, error) {
+				events = append(events, "resolve:"+name)
+				if resolveErr != nil {
+					return "", "", resolveErr
+				}
+				return fmt.Sprintf("/plugins/foo/%s/foo", resolvedVersion), resolvedVersion, nil
+			},
+			stop: func(pid uuid.UUID) error {
+				events = append(events, "stop:"+pid.String())
+				return nil
+			},
+			start: func(_ dutyContext.Context, pid uuid.UUID) error {
+				events = append(events, "start:"+pid.String())
+				return nil
+			},
+			removeVersion: func(name, _, version string) error {
+				events = append(events, "remove:"+name+":"+version)
+				return nil
+			},
+		}
+	}
+
+	ginkgo.It("stops, restarts and removes the old version when a newer one is resolved", func() {
+		register("latest", "/plugins/foo/v1.0.0/foo")
+
+		Expect(refreshLatestPlugins(ctx, opsWith("v2.0.0", nil))).To(Succeed())
+
+		Expect(events).To(Equal([]string{
+			"resolve:foo",
+			"stop:" + id.String(),
+			"start:" + id.String(),
+			"remove:foo:v1.0.0",
+		}))
+	})
+
+	ginkgo.It("does nothing when already at the latest version", func() {
+		register("latest", "/plugins/foo/v1.0.0/foo")
+
+		Expect(refreshLatestPlugins(ctx, opsWith("v1.0.0", nil))).To(Succeed())
+
+		Expect(events).To(Equal([]string{"resolve:foo"}))
+	})
+
+	ginkgo.It("skips plugins pinned to a concrete version", func() {
+		register("v1.2.3", "/plugins/foo/v1.2.3/foo")
+
+		Expect(refreshLatestPlugins(ctx, opsWith("v2.0.0", nil))).To(Succeed())
+
+		Expect(events).To(BeEmpty())
+	})
+
+	ginkgo.It("reports the error and does not restart when resolution fails", func() {
+		register("latest", "/plugins/foo/v1.0.0/foo")
+
+		err := refreshLatestPlugins(ctx, opsWith("", fmt.Errorf("network down")))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("network down"))
+
+		Expect(events).To(Equal([]string{"resolve:foo"}))
+	})
+})


### PR DESCRIPTION
Fixes: #3194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled plugin refresh capability that automatically updates plugins pinned to the latest version on a configurable interval.
  * Plugins can now be configured to dynamically track the latest available version instead of being locked to a specific version.

* **Bug Fixes**
  * Improved plugin restart handling when binary changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->