### PR TITLE
fix(ci): make release docker/binary jobs succeed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       - run: make release
         env:
           VERSION: v${{ needs.semantic-release.outputs.release-version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload binaries to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,15 +75,14 @@ jobs:
           git fetch --prune --unshallow
           echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags --match 'v[0-9]*' | sed -e 's/^v//')" >> $GITHUB_ENV
 
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@a173d53c3077a33d5877ca4d93d853a1de31f357 # v5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          name: flanksource/incident-commander
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          snapshot: true
-          tags: "latest,v${{ env.RELEASE_VERSION }}"
-          cache: true
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v5
@@ -97,15 +97,24 @@ jobs:
         with:
           registry-type: public
 
-      - name: Publish to ECR Public
-        env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REGISTRY_ALIAS: k4y9r6y5
-          REPOSITORY: incident-commander
-          IMAGE_TAG: "v${{ env.RELEASE_VERSION }}"
-        run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+      # Build once and push to both registries. The GITHUB_TOKEN BuildKit secret
+      # lifts the GitHub API rate limit that `deps install node` (facet/Chrome
+      # provisioning) hits resolving nodejs/node releases; the Dockerfile reads
+      # it via --mount=type=secret,id=GITHUB_TOKEN.
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: true
+          provenance: false
+          tags: |
+            flanksource/incident-commander:latest
+            flanksource/incident-commander:v${{ env.RELEASE_VERSION }}
+            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/incident-commander:v${{ env.RELEASE_VERSION }}
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   update-incident-commander-chart:
     if: needs.semantic-release.outputs.new-release-published == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,10 +69,18 @@ jobs:
           /usr/local/bin/bun --version
 
       - name: Install facet
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/flanksource/facet/releases/latest | jq -r '.assets[] | select(.name == "facet-linux-x64") | .browser_download_url') -o /usr/local/bin/facet
+          set -euo pipefail
+          # Authenticate the API call so it doesn't hit the anonymous rate limit
+          # (which returns an HTML error page that then gets saved as the binary).
+          url=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/flanksource/facet/releases/latest \
+            | jq -r '.assets[] | select(.name == "facet-linux-x64") | .browser_download_url')
+          [ -n "$url" ] || { echo "::error::could not resolve facet download URL"; exit 1; }
+          curl -fsSL "$url" -o /usr/local/bin/facet
           chmod +x /usr/local/bin/facet
-          facet --help
           facet --version
 
       - name: Inject GEMINI_API_KEY

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ windows:
 binaries: linux darwin windows compress
 
 .PHONY: release
-release: binaries
+release: ui binaries
 	mkdir -p .release
 	cp .bin/incident-commander* .release/
 


### PR DESCRIPTION
## Problem

The `Create Release` workflow has been failing on every push to `main`. Two distinct failures in run [27114960623](https://github.com/flanksource/mission-control/actions/runs/27114960623):

### `docker` job (regression from #3196)
The facet/Chrome work added a `deps install node@24.11.0` step to the Dockerfile, which calls the GitHub API to resolve `nodejs/node` releases. In CI this hit the **anonymous rate limit (403 Forbidden)**:

```
failed to list releases for nodejs/node: non-200 OK status code: 403 Forbidden
API rate limit exceeded for 52.225.25.102
```

The Dockerfile already expects the token via `--mount=type=secret,id=GITHUB_TOKEN`, but neither the `elgohr/Publish-Docker-Github-Action` step nor the raw `docker build` for ECR passed the secret. The PR `build` check passes because it uses `make docker`, which *does* pass `--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN`.

### `binary` job (pre-existing)
`make release` cross-compiled the Go binary without first building the embedded UI:

```
ui/assets.go:14:12: pattern all:frontend/dist: no matching files found
```

## Fix

- **docker:** Replace the `elgohr` action + raw `docker build` with a single `docker/build-push-action@v6` that sets up buildx, logs into Docker Hub + ECR Public, and passes `GITHUB_TOKEN` as a BuildKit secret (`id=GITHUB_TOKEN`). Same tags as before (Docker Hub `latest` + `v<version>`, ECR `v<version>`).
- **binary:** Add `ui` as a prerequisite of the `release` Makefile target so `ui/frontend/dist` exists before the cross-compile, and pass `GITHUB_TOKEN` to the `make release` step so the UI's own node install is authenticated.

## Verification

- Built `ui/frontend/dist` locally and confirmed `GOOS=linux go build ./main.go` compiles the `frontend/dist` + `tailwind.min.js` embeds cleanly (the exact step that failed in CI).
- The docker secret path is the same one already exercised by the passing `build` check on #3196.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow and build process for improved efficiency and consistency across deployment platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->