### PR TITLE
fix(build): make windows cross-build compile in release binary job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       - run: make release
         env:
           VERSION: v${{ needs.semantic-release.outputs.release-version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload binaries to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,15 +75,14 @@ jobs:
           git fetch --prune --unshallow
           echo "RELEASE_VERSION=$(git describe --abbrev=0 --tags --match 'v[0-9]*' | sed -e 's/^v//')" >> $GITHUB_ENV
 
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@a173d53c3077a33d5877ca4d93d853a1de31f357 # v5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          name: flanksource/incident-commander
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          snapshot: true
-          tags: "latest,v${{ env.RELEASE_VERSION }}"
-          cache: true
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v5
@@ -97,15 +97,24 @@ jobs:
         with:
           registry-type: public
 
-      - name: Publish to ECR Public
-        env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REGISTRY_ALIAS: k4y9r6y5
-          REPOSITORY: incident-commander
-          IMAGE_TAG: "v${{ env.RELEASE_VERSION }}"
-        run: |
-          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+      # Build once and push to both registries. The GITHUB_TOKEN BuildKit secret
+      # lifts the GitHub API rate limit that `deps install node` (facet/Chrome
+      # provisioning) hits resolving nodejs/node releases; the Dockerfile reads
+      # it via --mount=type=secret,id=GITHUB_TOKEN.
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: true
+          provenance: false
+          tags: |
+            flanksource/incident-commander:latest
+            flanksource/incident-commander:v${{ env.RELEASE_VERSION }}
+            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/incident-commander:v${{ env.RELEASE_VERSION }}
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   update-incident-commander-chart:
     if: needs.semantic-release.outputs.new-release-published == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,10 +69,18 @@ jobs:
           /usr/local/bin/bun --version
 
       - name: Install facet
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/flanksource/facet/releases/latest | jq -r '.assets[] | select(.name == "facet-linux-x64") | .browser_download_url') -o /usr/local/bin/facet
+          set -euo pipefail
+          # Authenticate the API call so it doesn't hit the anonymous rate limit
+          # (which returns an HTML error page that then gets saved as the binary).
+          url=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/flanksource/facet/releases/latest \
+            | jq -r '.assets[] | select(.name == "facet-linux-x64") | .browser_download_url')
+          [ -n "$url" ] || { echo "::error::could not resolve facet download URL"; exit 1; }
+          curl -fsSL "$url" -o /usr/local/bin/facet
           chmod +x /usr/local/bin/facet
-          facet --help
           facet --version
 
       - name: Inject GEMINI_API_KEY

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ windows:
 binaries: linux darwin windows compress
 
 .PHONY: release
-release: binaries
+release: ui binaries
 	mkdir -p .release
 	cp .bin/incident-commander* .release/
 

--- a/cmd/connection_browser.go
+++ b/cmd/connection_browser.go
@@ -7,12 +7,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"os/signal"
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	gocontext "context"
@@ -222,13 +220,8 @@ func launchBrowserAndCapture(ctx gocontext.Context, flags browserLoginFlags) (*b
 		// Put Chromium in its own process group so we can signal the whole
 		// group (including renderers/helpers) during teardown. Linux already
 		// sets Pdeathsig=SIGKILL; darwin does nothing, so Setpgid is required
-		// there for pgid-kill to be meaningful.
-		chromedp.ModifyCmdFunc(func(cmd *exec.Cmd) {
-			if cmd.SysProcAttr == nil {
-				cmd.SysProcAttr = &syscall.SysProcAttr{}
-			}
-			cmd.SysProcAttr.Setpgid = true
-		}),
+		// there for pgid-kill to be meaningful. No-op on Windows.
+		browserProcessGroupOption(),
 	)
 
 	allocCtx, allocCancel := chromedp.NewExecAllocator(ctx, opts...)

--- a/cmd/connection_browser_teardown.go
+++ b/cmd/connection_browser_teardown.go
@@ -64,15 +64,6 @@ func browserProcess(ctx gocontext.Context) *os.Process {
 	return c.Browser.Process()
 }
 
-func signalProcess(proc *os.Process, sig syscall.Signal) {
-	if pgid, err := syscall.Getpgid(proc.Pid); err == nil {
-		if err := syscall.Kill(-pgid, sig); err == nil {
-			return
-		}
-	}
-	_ = proc.Signal(sig)
-}
-
 func waitProcessExit(proc *os.Process, d time.Duration) bool {
 	done := make(chan struct{})
 	go func() {

--- a/cmd/connection_browser_unix.go
+++ b/cmd/connection_browser_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/chromedp/chromedp"
+)
+
+// browserProcessGroupOption puts Chromium in its own process group so the whole
+// group (renderers/helpers) can be signalled together during teardown.
+func browserProcessGroupOption() chromedp.ExecAllocatorOption {
+	return chromedp.ModifyCmdFunc(func(cmd *exec.Cmd) {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.Setpgid = true
+	})
+}
+
+// signalProcess signals the browser's process group, falling back to the single
+// process if the group lookup fails.
+func signalProcess(proc *os.Process, sig syscall.Signal) {
+	if pgid, err := syscall.Getpgid(proc.Pid); err == nil {
+		if err := syscall.Kill(-pgid, sig); err == nil {
+			return
+		}
+	}
+	_ = proc.Signal(sig)
+}

--- a/cmd/connection_browser_windows.go
+++ b/cmd/connection_browser_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/chromedp/chromedp"
+)
+
+// browserProcessGroupOption is a no-op on Windows, which has no POSIX process
+// groups; chromedp's own teardown handles the browser process.
+func browserProcessGroupOption() chromedp.ExecAllocatorOption {
+	return chromedp.ModifyCmdFunc(func(cmd *exec.Cmd) {})
+}
+
+// signalProcess signals the process directly on Windows; there is no process
+// group to fan the signal out to.
+func signalProcess(proc *os.Process, sig syscall.Signal) {
+	_ = proc.Signal(sig)
+}

--- a/ui/dev.go
+++ b/ui/dev.go
@@ -106,7 +106,7 @@ func devServerCommand(ctx gocontext.Context, frontendDir string, port int, backe
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		_ = signalProcessGroup(cmd.Process, syscall.SIGTERM)
 		return nil
@@ -148,18 +148,6 @@ func waitProcessExit(wait *processWait, timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
-}
-
-func signalProcessGroup(proc *os.Process, sig syscall.Signal) error {
-	if proc == nil {
-		return nil
-	}
-	if pgid, err := syscall.Getpgid(proc.Pid); err == nil {
-		if err := syscall.Kill(-pgid, sig); err == nil {
-			return nil
-		}
-	}
-	return proc.Signal(sig)
 }
 
 func findFrontendDir() (string, error) {

--- a/ui/dev_test.go
+++ b/ui/dev_test.go
@@ -21,8 +21,7 @@ var _ = ginkgo.Describe("UI dev server helpers", func() {
 		Expect(cmd.Args).To(Equal([]string{
 			"pnpm", "exec", "vite", "--host", viteHost, "--port", "4321", "--strictPort",
 		}))
-		Expect(cmd.SysProcAttr).NotTo(BeNil())
-		Expect(cmd.SysProcAttr.Setpgid).To(BeTrue())
+		expectProcessGroupSet(cmd)
 		Expect(cmd.Env).To(ContainElement("INCIDENT_COMMANDER_API_URL=http://127.0.0.1:8080"))
 	})
 

--- a/ui/dev_unix.go
+++ b/ui/dev_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts the vite child in its own process group so that the
+// whole group (vite plus any node workers it spawns) can be signalled together.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// signalProcessGroup sends sig to the child's process group, falling back to
+// the process itself if the group lookup fails.
+func signalProcessGroup(proc *os.Process, sig syscall.Signal) error {
+	if proc == nil {
+		return nil
+	}
+	if pgid, err := syscall.Getpgid(proc.Pid); err == nil {
+		if err := syscall.Kill(-pgid, sig); err == nil {
+			return nil
+		}
+	}
+	return proc.Signal(sig)
+}

--- a/ui/dev_unix_test.go
+++ b/ui/dev_unix_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package ui
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/gomega"
+)
+
+// expectProcessGroupSet asserts the dev command runs in its own process group
+// on Unix, which is required for group-wide teardown signalling.
+func expectProcessGroupSet(cmd *exec.Cmd) {
+	Expect(cmd.SysProcAttr).NotTo(BeNil())
+	Expect(cmd.SysProcAttr.Setpgid).To(BeTrue())
+}

--- a/ui/dev_windows.go
+++ b/ui/dev_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup is a no-op on Windows, which has no POSIX process groups.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// signalProcessGroup signals the process directly on Windows; there is no
+// process group to fan the signal out to.
+func signalProcessGroup(proc *os.Process, sig syscall.Signal) error {
+	if proc == nil {
+		return nil
+	}
+	return proc.Signal(sig)
+}

--- a/ui/dev_windows_test.go
+++ b/ui/dev_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package ui
+
+import (
+	"os/exec"
+)
+
+// expectProcessGroupSet is a no-op on Windows, where setProcessGroup does not
+// configure a process group.
+func expectProcessGroupSet(cmd *exec.Cmd) {}


### PR DESCRIPTION
## Problem

After #3200 fixed the release `docker` job and the missing-UI failure in the `binary` job, the `binary` job now gets further but fails at the **`make windows`** cross-build (run [27125395483](https://github.com/flanksource/mission-control/actions/runs/27125395483)):

```
ui/dev.go:109:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr
ui/dev.go:157:26: undefined: syscall.Getpgid
ui/dev.go:158:21: undefined: syscall.Kill
make: *** [Makefile:134: windows] Error 1
```

`ui/dev.go` and `cmd/connection_browser*.go` use POSIX-only process-group syscalls (`SysProcAttr.Setpgid`, `syscall.Getpgid`, `syscall.Kill`) that don't exist on Windows. This was **latent** — the binary job previously failed earlier (missing embedded `frontend/dist`), so it never reached `make windows`. With that fixed, the Windows incompatibility surfaced.

## Fix

Split the process-group handling into build-tagged files, the standard Go idiom for OS-specific syscalls:

- `ui/dev_unix.go` / `ui/dev_windows.go`
- `cmd/connection_browser_unix.go` / `cmd/connection_browser_windows.go`
- `ui/dev_unix_test.go` / `ui/dev_windows_test.go` (platform-specific test assertion)

Unix keeps the pgid-based group signalling (`Setpgid` + `Kill(-pgid)`). Windows, which has no POSIX process groups, signals the process directly and makes the process-group setup a no-op.

## Verification

- `GOOS=windows`, `GOOS=linux`, `GOOS=darwin` `go build ./...` — all pass (the failing `make windows` target now compiles).
- `go vet ./ui/ ./cmd/` clean on both windows and unix.
- `go test ./ui/` passes; `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image publishing with multi-registry support and improved authentication to Docker Hub and ECR Public.
  * Strengthened GitHub Actions workflows with authenticated API requests for binary downloads.
  * UI build is now included in the release process.

* **Refactor**
  * Refactored process group handling for improved cross-platform compatibility.

* **Tests**
  * Added tests to validate process group configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->