### PR TITLE
feat(plugin): register cached plugin commands

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,10 +1,16 @@
 package cmd
 
 import (
+	gocontext "context"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/flanksource/incident-commander/plugin/machinery/local"
+	"github.com/flanksource/incident-commander/plugin/manifestcache"
 )
 
 // pluginParams accumulates repeated --param key=value flags.
@@ -53,14 +59,107 @@ var PluginCmd = &cobra.Command{
 	RunE:              runPluginOp,
 }
 
+var pluginRefreshCacheCmd = &cobra.Command{
+	Use:               "refresh-cache [plugin]",
+	Short:             "Refresh cached plugin command metadata",
+	Args:              cobra.MaximumNArgs(1),
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
+	RunE:              runPluginRefreshCache,
+}
+
 func init() {
 	PluginCmd.Flags().StringVar(&pluginOpts.ConfigID, "config-id", "", "Catalog/config item id passed to the operation")
 	PluginCmd.Flags().BoolVar(&pluginOpts.RawJSON, "json", false, "Emit raw response instead of pretty-printing JSON")
 	PluginCmd.Flags().Var(&pluginOpts.Params, "param", "Key=value parameters (repeatable)")
+	PluginCmd.AddCommand(pluginRefreshCacheCmd)
 	registerPluginHARFlag(Root)
 	Root.AddCommand(PluginCmd)
+	_ = registerCachedPluginCommands(PluginCmd, Root)
 }
 
 func runPluginOp(cmd *cobra.Command, args []string) error {
 	return dispatchOperation(cmd, args[0], args[1], pluginOpts.Params.values, pluginOpts.ConfigID, pluginOpts.RawJSON)
+}
+
+func runPluginRefreshCache(cmd *cobra.Command, args []string) error {
+	mode, mc, err := resolveMode()
+	if err != nil {
+		return err
+	}
+
+	var names []string
+	if len(args) == 0 {
+		if mode != modeAPI {
+			return fmt.Errorf("plugin name is required when refreshing from local binaries")
+		}
+		names, err = refreshPluginCacheFromServer(cmd, mc)
+	} else {
+		name := args[0]
+		switch mode {
+		case modeAPI:
+			names, err = refreshPluginCacheFromServer(cmd, mc)
+			if err == nil && !containsString(names, name) {
+				return fmt.Errorf("plugin %q was not returned by %s", name, mc.Server)
+			}
+		case modeLocal:
+			var entry *manifestcache.Entry
+			entry, err = refreshPluginCacheFromBinary(cmd, name)
+			if entry != nil && entry.Service.Name != "" {
+				names = []string{entry.Service.Name}
+			} else {
+				names = []string{name}
+			}
+		default:
+			return fmt.Errorf("unable to determine dispatch mode")
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	_ = registerCachedPluginCommands(PluginCmd, Root)
+	sort.Strings(names)
+	fmt.Fprintf(cmd.OutOrStdout(), "Refreshed plugin command cache: %s\n", strings.Join(names, ", "))
+	return nil
+}
+
+func refreshPluginCacheFromServer(cmd *cobra.Command, mc *MCContext) ([]string, error) {
+	if mc == nil || mc.Server == "" {
+		return nil, fmt.Errorf("no Mission Control server configured")
+	}
+	token, err := resolveContextToken(mc)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := gocontext.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+	collector, flush := startHAR()
+	defer func() {
+		if err := flush(); err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), err)
+		}
+	}()
+	return manifestcache.PopulateAPI(ctx, manifestcache.PopulateOptions{
+		Server: mc.Server,
+		Token:  token,
+		HAR:    collector,
+	})
+}
+
+func refreshPluginCacheFromBinary(cmd *cobra.Command, name string) (*manifestcache.Entry, error) {
+	ctx, cancel := gocontext.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+	return manifestcache.PopulateLocal(ctx, name, manifestcache.PopulateOptions{
+		BinaryDir: local.PluginPath(),
+	})
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/plugin_help.go
+++ b/cmd/plugin_help.go
@@ -7,7 +7,81 @@ import (
 
 	"github.com/flanksource/clicky/rpc"
 	"github.com/spf13/cobra"
+
+	"github.com/flanksource/incident-commander/plugin/manifestcache"
 )
+
+func registerCachedPluginCommands(pluginRoot, root *cobra.Command) error {
+	entries, err := manifestcache.List()
+	if err != nil {
+		return err
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Service.Name < entries[j].Service.Name
+	})
+	for _, entry := range entries {
+		if entry == nil || entry.Service.Name == "" {
+			continue
+		}
+		nested, top := buildPluginCommands(*entry)
+		if pluginRoot != nil && !commandExists(pluginRoot, nested.Name()) {
+			pluginRoot.AddCommand(nested)
+		}
+		if root != nil && !commandExists(root, top.Name()) {
+			root.AddCommand(top)
+		}
+	}
+	return nil
+}
+
+func commandExists(parent *cobra.Command, name string) bool {
+	if parent == nil || name == "" {
+		return false
+	}
+	for _, cmd := range parent.Commands() {
+		if cmd.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func buildPluginCommands(entry manifestcache.Entry) (nested, top *cobra.Command) {
+	return newPluginRoot(entry, false), newPluginRoot(entry, true)
+}
+
+func newPluginRoot(entry manifestcache.Entry, topLevel bool) *cobra.Command {
+	short := entry.Service.Description
+	if short == "" {
+		short = fmt.Sprintf("Operations for the %q plugin", entry.Service.Name)
+	}
+	var (
+		params   pluginParams
+		configID string
+		raw      bool
+	)
+	root := &cobra.Command{
+		Use:          entry.Service.Name + " <operation>",
+		Short:        short,
+		Long:         formatPluginLong(entry, topLevel),
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return dispatchOperation(cmd, entry.Service.Name, args[0], params.values, configID, raw)
+		},
+	}
+	root.Flags().Var(&params, "param", "Operation parameter (repeatable, key=value)")
+	root.Flags().StringVar(&configID, "config-id", "", "Catalog config item id passed to the operation")
+	root.Flags().BoolVar(&raw, "json", false, "Emit raw JSON instead of pretty-printing")
+	for _, op := range entry.Service.Operations {
+		root.AddCommand(newOperationCommand(entry.Service.Name, op))
+	}
+	return root
+}
+
+func newOperationCommand(plugin string, op rpc.RPCOperation) *cobra.Command {
+	return newOperationCommandWithDispatcher(plugin, op, dispatchOperation)
+}
 
 type operationDispatcher func(cmd *cobra.Command, plugin, op string, params map[string]string, configID string, raw bool) error
 
@@ -62,6 +136,30 @@ func operationRequiresConfigID(op rpc.RPCOperation) bool {
 		}
 	}
 	return false
+}
+
+func formatPluginLong(entry manifestcache.Entry, topLevel bool) string {
+	var b strings.Builder
+	if entry.Service.Description != "" {
+		b.WriteString(entry.Service.Description)
+		b.WriteString("\n\n")
+	}
+	if entry.Service.Version != "" {
+		fmt.Fprintf(&b, "Version: %s\n", entry.Service.Version)
+	}
+	switch entry.Source {
+	case manifestcache.SourceRemoteServer:
+		fmt.Fprintf(&b, "Source: remote server (%s)\n", entry.ServerURL)
+	case manifestcache.SourceLocalBinary:
+		fmt.Fprintf(&b, "Source: local binary (%s)\n", entry.BinaryPath)
+	}
+	if !entry.CachedAt.IsZero() {
+		fmt.Fprintf(&b, "Cached: %s\n", entry.CachedAt.Format("2006-01-02 15:04:05 MST"))
+	}
+	if !topLevel {
+		fmt.Fprintf(&b, "\nThe same operations are also reachable as `incident-commander %s <operation>`.\n", entry.Service.Name)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // formatOperationLong renders the per-op help: description, then a table

--- a/cmd/plugin_help_test.go
+++ b/cmd/plugin_help_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"path/filepath"
+
+	"github.com/flanksource/clicky/rpc"
+	"github.com/flanksource/incident-commander/plugin/manifestcache"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = ginkgo.Describe("cached plugin command registration", func() {
+	ginkgo.It("adds cached plugins under plugin and root help", func() {
+		cleanup := manifestcache.SetDirForTest(filepath.Join(ginkgo.GinkgoT().TempDir(), "plugins"))
+		defer cleanup()
+
+		Expect(manifestcache.Write(manifestcache.Entry{
+			Source:    manifestcache.SourceRemoteServer,
+			ServerURL: "http://localhost:8080",
+			Service: rpc.RPCService{
+				Name:        "kubernetes-logs",
+				Description: "Kubernetes logs",
+				Version:     "v1.2.3",
+				Operations: []rpc.RPCOperation{{
+					Name:        "tail",
+					Description: "Tail pod logs",
+				}},
+			},
+		})).To(Succeed())
+
+		root := &cobra.Command{Use: "incident-commander"}
+		plugin := &cobra.Command{Use: "plugin <name> <operation>"}
+		root.AddCommand(plugin)
+
+		Expect(registerCachedPluginCommands(plugin, root)).To(Succeed())
+		Expect(commandExists(plugin, "kubernetes-logs")).To(BeTrue())
+		Expect(commandExists(root, "kubernetes-logs")).To(BeTrue())
+
+		stdout, stderr, err := executeCommand(root, "plugin", "--help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("kubernetes-logs"))
+
+		stdout, stderr, err = executeCommand(root, "kubernetes-logs", "--help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("Tail pod logs"))
+		Expect(stdout).To(ContainSubstring("tail"))
+	})
+
+	ginkgo.It("does not replace existing static commands with plugin commands", func() {
+		cleanup := manifestcache.SetDirForTest(filepath.Join(ginkgo.GinkgoT().TempDir(), "plugins"))
+		defer cleanup()
+
+		Expect(manifestcache.Write(manifestcache.Entry{
+			Source: manifestcache.SourceRemoteServer,
+			Service: rpc.RPCService{
+				Name: "plugin",
+				Operations: []rpc.RPCOperation{{
+					Name: "run",
+				}},
+			},
+		})).To(Succeed())
+
+		root := &cobra.Command{Use: "incident-commander"}
+		plugin := &cobra.Command{Use: "plugin <name> <operation>"}
+		root.AddCommand(plugin)
+
+		Expect(registerCachedPluginCommands(plugin, root)).To(Succeed())
+		Expect(root.Commands()).To(HaveLen(1))
+		Expect(commandExists(plugin, "plugin")).To(BeTrue())
+	})
+})


### PR DESCRIPTION
Plugin manifests were cached but not wired into Cobra, so remote plugin operations did not appear in CLI help.

Load cached manifest entries during CLI setup and generate plugin/operation subcommands for both root and `plugin` help. Add `plugin refresh-cache` to populate local command metadata from the current API context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `plugin refresh-cache` subcommand to repopulate cached plugin command metadata from a configured server or local disk
  * Plugin commands now load from cache with available metadata including descriptions, versions, and operation details

* **Tests**
  * Added test coverage for cached plugin command registration and static command preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->