### PR TITLE
fix: update shutdown priority order 

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/flanksource/kopper"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
@@ -172,7 +171,7 @@ func launchKopper(ctx context.Context) {
 		ctx.Logger.Errorf("plugin replay from DB failed: %v", err)
 	}
 
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		shutdown.ShutdownAndExit(1, fmt.Sprintf("error running controller manager: %v", err))
 	}
 }
@@ -231,7 +230,7 @@ var Serve = &cobra.Command{
 		mcpServer := mcp.Server(ctx)
 		e.Any("/mcp", echov4.WrapHandler(mcpServer.HTTPHandler), mcp.AuthMiddleware)
 
-		shutdown.AddHookWithPriority("echo", shutdown.PriorityIngress, func() {
+		shutdown.AddHookWithPriority("echo", shutdown.PriorityCritical, func() {
 			echo.Shutdown(e)
 		})
 
@@ -244,11 +243,11 @@ var Serve = &cobra.Command{
 			})
 		}
 
-		shutdown.AddHookWithPriority("plugins", shutdown.PriorityIngress, func() {
+		shutdown.AddHookWithPriority("plugins", 0, func() {
 			machinery.StopAll(ctx)
 		})
 
-		shutdown.AddHookWithPriority("database", shutdown.PriorityCritical, stop)
+		shutdown.AddHookWithPriority("database", 0, stop)
 
 		shutdown.WaitForSignal()
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flanksource/kopper"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
@@ -171,7 +172,7 @@ func launchKopper(ctx context.Context) {
 		ctx.Logger.Errorf("plugin replay from DB failed: %v", err)
 	}
 
-	if err := mgr.Start(ctx); err != nil {
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		shutdown.ShutdownAndExit(1, fmt.Sprintf("error running controller manager: %v", err))
 	}
 }
@@ -243,16 +244,23 @@ var Serve = &cobra.Command{
 			})
 		}
 
-		shutdown.AddHookWithPriority("plugins", 0, func() {
+		shutdown.AddHookWithPriority("plugins", shutdown.PriorityJobs+1, func() {
 			machinery.StopAll(ctx)
 		})
 
-		shutdown.AddHookWithPriority("database", 0, stop)
+		// The database pool must close last (after workers have drained), but
+		// before echo unblocks main and the process exits.
+		shutdown.AddHookWithPriority("database", shutdown.PriorityCritical-1, stop)
 
 		shutdown.WaitForSignal()
 
 		ctx.WithTracer(otel.GetTracerProvider().Tracer("mission-control"))
 		ctx = ctx.WithNamespace(api.Namespace)
+
+		// Cancel the context on shutdown so background workers (jobs, event
+		// consumers, kopper) stop before the database pool is closed.
+		ctx, cancel := ctx.WithCancel()
+		shutdown.AddHookWithPriority("workers", shutdown.PriorityJobs, func() { cancel() })
 
 		if api.UpstreamConf.Valid() {
 			go tunnel.StartAgentTunnel(ctx, api.UpstreamConf, e)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured server shutdown ordering so HTTP, plugin, worker, and database shutdown steps occur in a safer sequence. Added a cancellation step to ensure background workers stop before database connections are closed, improving graceful termination and resource cleanup and reducing risk of dangling work during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->