### PR TITLE
docs(notifications): add inhibition fixtures

### DIFF
--- a/fixtures/notifications/node-with-inhibition.yaml
+++ b/fixtures/notifications/node-with-inhibition.yaml
@@ -1,7 +1,7 @@
 apiVersion: mission-control.flanksource.com/v1
 kind: Notification
 metadata:
-  name: pod-with-incoming-inhibition
+  name: node-with-pod-inhibition
 spec:
   events:
     - config.unhealthy
@@ -10,9 +10,9 @@ spec:
   to:
     connection: connection://mission-control/slack
   inhibitions:
-    - direction: incoming
-      from: Kubernetes::Pod
+    - direction: outgoing
+      from: Kubernetes::Node
       to:
-        - Kubernetes::Deployment
-        - Kubernetes::ReplicaSet
-      depth: 2
+        - Kubernetes::Pod
+      soft: true
+      depth: 1


### PR DESCRIPTION
Adds fixture-backed notification inhibition examples for docs.\n\nIncludes a pod-to-parent inhibition fixture with repeatInterval, and a Node-to-Pod soft relationship fixture for suppressing pod notifications after a node alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated existing notification fixtures to improve test coverage of pod inhibition scenarios with enhanced configuration handling and refined event processing capabilities
  * Added new test fixture for node-to-pod traffic inhibition notification scenarios, enabling comprehensive testing of Slack notification integration and automatic event retry management features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->