### PR TITLE
fix(playbook): read action status before result transforms erase it

### DIFF
--- a/playbook/runner/exec.go
+++ b/playbook/runner/exec.go
@@ -25,6 +25,17 @@ type StatusAccessor interface {
 	GetStatus() models.PlaybookActionStatus
 }
 
+// resultStatus returns the status reported by a typed action result,
+// defaulting to completed for results that don't implement StatusAccessor.
+func resultStatus(result any) models.PlaybookActionStatus {
+	// the interface can hold a typed nil, so a reflect check is needed.
+	if accessor, ok := result.(StatusAccessor); ok && !reflect.ValueOf(accessor).IsNil() {
+		return accessor.GetStatus()
+	}
+
+	return models.PlaybookActionStatusCompleted
+}
+
 // SecretScrubber can scrub secrets from action results.
 type SecretScrubber interface {
 	ScrubSecrets(output string) string

--- a/playbook/runner/exec_test.go
+++ b/playbook/runner/exec_test.go
@@ -1,0 +1,69 @@
+package runner
+
+import (
+	"github.com/flanksource/duty/models"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/flanksource/incident-commander/playbook/actions"
+)
+
+var _ = ginkgo.Describe("ResultStatus", func() {
+	tests := []struct {
+		name     string
+		result   any
+		expected models.PlaybookActionStatus
+	}{
+		{
+			name:     "ai action that triggered child runs",
+			result:   &actions.AIActionResult{ChildRunsTriggered: 1},
+			expected: models.PlaybookActionStatusWaitingChildren,
+		},
+		{
+			name:     "ai action with a diagnosis",
+			result:   &actions.AIActionResult{JSON: `{"headline": "OOMKilled"}`},
+			expected: models.PlaybookActionStatusCompleted,
+		},
+		{
+			name:     "exec action with non-zero exit code",
+			result:   &actions.ExecDetails{ExitCode: 1},
+			expected: models.PlaybookActionStatusFailed,
+		},
+		{
+			name:     "exec action with zero exit code",
+			result:   &actions.ExecDetails{Stdout: "ok"},
+			expected: models.PlaybookActionStatusCompleted,
+		},
+		{
+			name:     "typed nil result",
+			result:   (*actions.AIActionResult)(nil),
+			expected: models.PlaybookActionStatusCompleted,
+		},
+		{
+			name:     "nil result",
+			result:   nil,
+			expected: models.PlaybookActionStatusCompleted,
+		},
+		{
+			name:     "result without a status",
+			result:   &actions.NotificationResult{Message: "hello"},
+			expected: models.PlaybookActionStatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		ginkgo.It(tt.name, func() {
+			Expect(resultStatus(tt.result)).To(Equal(tt.expected))
+		})
+	}
+
+	// extractContentType marshals results into a generic map that no longer
+	// implements StatusAccessor, so the status must be read before it runs.
+	ginkgo.It("must be read before extractContentType transforms the result", func() {
+		result := any(&actions.AIActionResult{ChildRunsTriggered: 1})
+		Expect(resultStatus(result)).To(Equal(models.PlaybookActionStatusWaitingChildren))
+
+		transformed := extractContentType(result, "ai", "")
+		Expect(resultStatus(transformed)).To(Equal(models.PlaybookActionStatusCompleted))
+	})
+})

--- a/playbook/runner/runner.go
+++ b/playbook/runner/runner.go
@@ -377,6 +377,10 @@ func ExecuteAndSaveAction(ctx context.Context, playbookID any, action *models.Pl
 
 	result, err := executeAction(ctx, playbookID, action.PlaybookRunID, *action, actionSpec, templateEnv)
 
+	// The status must be read off the typed result before the transformations
+	// below marshal it into a generic map, which doesn't implement StatusAccessor.
+	status := resultStatus(result.data)
+
 	// Scrub secrets from action output before saving to DB
 	result.data = scrubActionResult(&templateEnv, result.data)
 	result.data = extractContentType(result.data, actionSpec.ActionType(), actionSpec.ContentType)
@@ -390,8 +394,8 @@ func ExecuteAndSaveAction(ctx context.Context, playbookID any, action *models.Pl
 		if err := action.Skip(db); err != nil {
 			return ctx.Oops("db").Wrap(err)
 		}
-	} else if accessor, ok := result.data.(StatusAccessor); ok {
-		switch accessor.GetStatus() {
+	} else {
+		switch status {
 		case models.PlaybookActionStatusFailed:
 			ctx.Warnf("action returned failure\n%v", logger.Pretty(result.data))
 			if err := action.Fail(db, result.data, nil); err != nil {
@@ -404,16 +408,11 @@ func ExecuteAndSaveAction(ctx context.Context, playbookID any, action *models.Pl
 				return ctx.Oops("db").Wrap(err)
 			}
 
-		case models.PlaybookActionStatusCompleted:
+		default:
 			ctx.Tracef("action completed\n%v", logger.Pretty(result.data))
 			if err := action.Complete(db, result.data); err != nil {
 				return ctx.Oops("db").Wrap(err)
 			}
-		}
-	} else {
-		ctx.Tracef("action completed\n%v", logger.Pretty(result.data))
-		if err := action.Complete(db, result.data); err != nil {
-			return ctx.Oops("db").Wrap(err)
 		}
 	}
 


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3206

`extractContentType` (0baa8b614) round-trips every action result through `json.Marshal` into a `map[string]any` before saving. This strips the typed result, so the `StatusAccessor` assertion in `ExecuteAndSaveAction` never matched and every action fell through to the "completed" branch.

Two statuses were silently lost:

- `waiting_children`: an AI action that triggers child runs (context provider playbooks) was immediately marked completed with an empty result `{}` instead of pausing. The run moved on to the next action, the LLM was never called, and templates like `$(getLastAction.result.recommendedPlaybooks)` rendered the literal "<no value>" (Go template missing-key default) which was then sent verbatim to Slack. The child run completed as an orphan since ResumeChildrenWaitingAction found no action left in waiting_children.

- `failed`: exec/pod actions with a non-zero exit code report failure via ExecDetails.GetStatus, so they were being marked completed instead of failed.

Fix: capture the status from the typed result before scrubActionResult/ extractContentType transform it, and switch on the captured status when persisting. Regression tests pin the status mapping and the ordering invariant (the transformed result no longer carries a status).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of edge cases when determining playbook action status, ensuring proper behavior with typed-nil values.

* **Refactor**
  * Enhanced playbook action status extraction to occur before data transformations, ensuring more reliable status handling.

* **Tests**
  * Added comprehensive test coverage for playbook action status determination across multiple result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->