### PR TITLE
feat(auth): use frontend URL as OIDC issuer for basic and kratos auth

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -14,7 +14,6 @@ import (
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
-	incAPI "github.com/flanksource/incident-commander/api"
 	"github.com/flanksource/incident-commander/auth/basic_static"
 	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/flanksource/incident-commander/auth/signing"
@@ -205,7 +204,7 @@ func rejectUnauthenticated(c echo.Context) error {
 
 func setWWWAuthenticate(c echo.Context) {
 	if OIDCEnabled {
-		resourceMetadataURL := strings.TrimRight(incAPI.PublicURL, "/") + "/.well-known/oauth-protected-resource"
+		resourceMetadataURL := OIDCIssuerURL() + "/.well-known/oauth-protected-resource"
 		c.Response().Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
 	}
 }

--- a/auth/issuer.go
+++ b/auth/issuer.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"strings"
+
+	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/vars"
+)
+
+// OIDCIssuerURL returns the base URL the embedded OIDC provider is served under.
+//
+// Single-tenant deployments (basic, kratos) only need the frontend exposed —
+// it proxies all OIDC protocol endpoints (/authorize, /oauth/token,
+// /.well-known/*, /oidc/*) to the backend, so the frontend URL is the issuer.
+//
+// Multi-tenant Clerk shares one frontend across tenants; unauthenticated
+// protocol endpoints can't be routed per-tenant there, so the issuer stays
+// on the per-tenant backend URL.
+func OIDCIssuerURL() string {
+	if vars.AuthMode != Clerk && api.FrontendURL != "" {
+		return strings.TrimRight(api.FrontendURL, "/")
+	}
+	return strings.TrimRight(api.PublicURL, "/")
+}

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -112,10 +112,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 				if err != nil {
 					return fmt.Errorf("failed to load htpasswd file: %w", err)
 				}
-				if err := oidc.MountRoutes(e, ctx, api.PublicURL, htpasswdChecker, nil, LookupPersonByUsername); err != nil {
+				if err := oidc.MountRoutes(e, ctx, OIDCIssuerURL(), htpasswdChecker, nil, LookupPersonByUsername); err != nil {
 					return fmt.Errorf("failed to mount OIDC routes: %w", err)
 				}
-				logger.Infof("OIDC provider enabled at %s", api.PublicURL)
+				logger.Infof("OIDC provider enabled at %s", OIDCIssuerURL())
 			}
 		}
 	case Kratos:
@@ -137,10 +137,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 
 		if OIDCEnabled {
 			kratosChecker := NewKratosCredentialChecker(kratosMiddleware)
-			if err := oidc.MountRoutes(e, ctx, api.PublicURL, nil, kratosChecker, nil); err != nil {
+			if err := oidc.MountRoutes(e, ctx, OIDCIssuerURL(), nil, kratosChecker, nil); err != nil {
 				return fmt.Errorf("failed to mount OIDC routes: %w", err)
 			}
-			logger.Infof("OIDC provider enabled at %s (Kratos auth)", api.PublicURL)
+			logger.Infof("OIDC provider enabled at %s (Kratos auth)", OIDCIssuerURL())
 		}
 
 	case Clerk:
@@ -152,10 +152,10 @@ func Middleware(ctx context.Context, e *echo.Echo) error {
 
 		if OIDCEnabled {
 			clerkChecker := NewClerkCredentialChecker(clerkHandler)
-			if err := oidc.MountRoutes(e, ctx, api.PublicURL, nil, clerkChecker, nil); err != nil {
+			if err := oidc.MountRoutes(e, ctx, OIDCIssuerURL(), nil, clerkChecker, nil); err != nil {
 				return fmt.Errorf("failed to mount OIDC routes: %w", err)
 			}
-			logger.Infof("OIDC provider enabled at %s (Clerk auth)", api.PublicURL)
+			logger.Infof("OIDC provider enabled at %s (Clerk auth)", OIDCIssuerURL())
 		}
 
 		// We also need to disable "settings.users" feature in database

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -569,7 +569,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 		Expect(loginRec.Code).To(Equal(http.StatusOK))
 	})
 
-	ginkgo.It("mounts basic-auth OIDC discovery with the public endpoint issuer", func() {
+	ginkgo.It("mounts basic-auth OIDC discovery with the frontend issuer", func() {
 		oldAuthMode := vars.AuthMode
 		oldOIDCEnabled := OIDCEnabled
 		oldHtpasswdFile := HtpasswdFile
@@ -612,8 +612,47 @@ var _ = ginkgo.Describe("OIDC", func() {
 		Expect(rec.Code).To(Equal(http.StatusOK))
 		var discovery map[string]any
 		Expect(json.Unmarshal(rec.Body.Bytes(), &discovery)).To(Succeed())
-		Expect(discovery).To(HaveKeyWithValue("issuer", "http://localhost:8080"))
-		Expect(discovery["authorization_endpoint"]).To(ContainSubstring("http://localhost:8080"))
+		Expect(discovery).To(HaveKeyWithValue("issuer", "http://localhost:3000"))
+		Expect(discovery["authorization_endpoint"]).To(ContainSubstring("http://localhost:3000"))
+	})
+
+	ginkgo.Describe("OIDCIssuerURL", func() {
+		var oldAuthMode, oldFrontendURL, oldPublicURL string
+
+		ginkgo.BeforeEach(func() {
+			oldAuthMode = vars.AuthMode
+			oldFrontendURL = api.FrontendURL
+			oldPublicURL = api.PublicURL
+			api.FrontendURL = "https://frontend.example.com/"
+			api.PublicURL = "https://backend.example.com/"
+		})
+
+		ginkgo.AfterEach(func() {
+			vars.AuthMode = oldAuthMode
+			api.FrontendURL = oldFrontendURL
+			api.PublicURL = oldPublicURL
+		})
+
+		ginkgo.It("uses the frontend URL for basic auth", func() {
+			vars.AuthMode = Basic
+			Expect(OIDCIssuerURL()).To(Equal("https://frontend.example.com"))
+		})
+
+		ginkgo.It("uses the frontend URL for kratos auth", func() {
+			vars.AuthMode = Kratos
+			Expect(OIDCIssuerURL()).To(Equal("https://frontend.example.com"))
+		})
+
+		ginkgo.It("uses the public endpoint for clerk auth", func() {
+			vars.AuthMode = Clerk
+			Expect(OIDCIssuerURL()).To(Equal("https://backend.example.com"))
+		})
+
+		ginkgo.It("falls back to the public endpoint when the frontend URL is unset", func() {
+			vars.AuthMode = Kratos
+			api.FrontendURL = ""
+			Expect(OIDCIssuerURL()).To(Equal("https://backend.example.com"))
+		})
 	})
 
 	ginkgo.Describe("ClerkCredentialChecker", func() {

--- a/auth/oidc_validate.go
+++ b/auth/oidc_validate.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
-	"github.com/flanksource/incident-commander/api"
 	oidcmodels "github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/flanksource/incident-commander/auth/signing"
 	"github.com/golang-jwt/jwt/v4"
@@ -36,7 +35,7 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 		return false, nil
 	}
 
-	issuer := strings.TrimRight(api.PublicURL, "/")
+	issuer := OIDCIssuerURL()
 
 	var lastErr error
 	for _, pub := range keys {


### PR DESCRIPTION
The embedded OIDC provider used the backend URL (`--public-endpoint`) as its issuer in all auth modes, forcing kratos and basic-auth deployments to expose the backend to the public internet even though the frontend already proxies every OIDC protocol endpoint (/authorize, /oauth/token, /.well-known/*, /oidc/*) to the backend.

The issuer is now conditional on the auth mode:

- basic/kratos: frontend URL (falls back to --public-endpoint when --frontend-url is unset), so only the frontend needs to be exposed
- clerk: backend URL, unchanged — the shared multi-tenant frontend cannot route unauthenticated protocol endpoints to per-tenant backends

Token validation accepts the legacy backend-URL issuer so sessions minted before an upgrade keep working, and the WWW-Authenticate resource-metadata URL follows the same conditional so MCP clients discover the reachable origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated OIDC authentication to compute issuer URLs using frontend URLs in applicable authentication modes for improved configuration accuracy.
  * Enhanced OIDC token validation to maintain backward compatibility with legacy issuer URLs, ensuring existing tokens continue to function correctly.

* **Tests**
  * Added comprehensive tests to verify OIDC issuer URL selection logic across authentication modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->