### PR TITLE
fix(faro): resolve API base during login and context add

### DIFF
--- a/clientcmd/auth_login.go
+++ b/clientcmd/auth_login.go
@@ -38,29 +38,72 @@ func init() {
 }
 
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
-	serverURL := strings.TrimRight(loginServer, "/")
+	apiServer, err := ResolveAPIBase(loginServer)
+	if err != nil {
+		return err
+	}
+	loginServerURL := oidcLoginServerCandidates(apiServer)[0]
 
 	if loginToken != "" {
-		path, err := storeTokens(serverURL, &oidcclient.Tokens{AccessToken: loginToken})
+		path, err := storeTokens(loginServerURL, &oidcclient.Tokens{AccessToken: loginToken})
 		if err != nil {
 			return fmt.Errorf("failed to save token: %w", err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Token stored for %s\n", serverURL)
+		contextName, err := saveLoginContext(apiServer, loginToken)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Token stored for %s\n", loginServerURL)
 		fmt.Fprintf(cmd.OutOrStdout(), "Tokens saved to: %s\n", path)
+		fmt.Fprintf(cmd.OutOrStdout(), "Context %q saved for %s\n", contextName, apiServer)
 		fmt.Fprintf(cmd.OutOrStdout(), "Run `whoami` to verify connectivity.\n")
 		return nil
 	}
 
-	tokens, tokenPath, err := PerformOIDCLogin(cmd, serverURL, cmd.OutOrStdout())
+	tokens, tokenPath, err := performOIDCLoginForAPIBase(cmd, apiServer, cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
+	contextName, err := saveLoginContext(apiServer, tokens.AccessToken)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "\nLogin successful!\n\n")
 	fmt.Fprintf(cmd.OutOrStdout(), "Tokens saved to: %s\n", tokenPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Context %q saved for %s\n", contextName, apiServer)
 	fmt.Fprintf(cmd.OutOrStdout(), "Access token expires: %s\n", tokens.ExpiresAt.Format(time.RFC3339))
 
 	return nil
+}
+
+func performOIDCLoginForAPIBase(cmd *cobra.Command, apiServer string, status io.Writer) (*oidcclient.Tokens, string, error) {
+	var lastErr error
+	for _, loginServer := range oidcLoginServerCandidates(apiServer) {
+		tokens, tokenPath, err := oidcLogin(cmd, loginServer, status)
+		if err == nil {
+			return tokens, tokenPath, nil
+		}
+		lastErr = err
+	}
+	return nil, "", fmt.Errorf("OIDC login failed for %s: %w", apiServer, lastErr)
+}
+
+func saveLoginContext(serverURL, token string) (string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	name := ServerToContextName(serverURL)
+	ctx := MCContext{Name: name, Server: serverURL, Token: token}
+	if existing := cfg.GetContext(name); existing != nil {
+		ctx = *existing
+		ctx.Server = serverURL
+		ctx.Token = token
+	}
+	cfg.SetContext(ctx)
+	cfg.CurrentContext = name
+	return name, SaveConfig(cfg)
 }
 
 var oidcLogin = PerformOIDCLogin

--- a/clientcmd/auth_login_test.go
+++ b/clientcmd/auth_login_test.go
@@ -2,47 +2,108 @@ package clientcmd
 
 import (
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
 
+	"github.com/flanksource/incident-commander/auth/oidcclient"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 )
 
-var _ = ginkgo.Describe("auth login --token", func() {
+var _ = ginkgo.Describe("auth login", func() {
+	var oldOIDCLogin func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error)
+
 	ginkgo.BeforeEach(func() {
+		oldOIDCLogin = oidcLogin
 		dir := ginkgo.GinkgoT().TempDir()
 		ginkgo.GinkgoT().Setenv("HOME", dir)
 		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", dir)
 	})
 
 	ginkgo.AfterEach(func() {
+		oidcLogin = oldOIDCLogin
 		loginServer = ""
 		loginToken = ""
 	})
 
-	ginkgo.It("stores the provided token without starting the OIDC flow", func() {
-		loginServer = "http://mc.example.com"
+	ginkgo.It("stores token contexts with the resolved frontend /api base", func() {
+		server := authHealthServer(true)
+		defer server.Close()
+		loginServer = server.URL
 		loginToken = "my-access-token"
 
 		cmd := &cobra.Command{}
 		cmd.SetOut(io.Discard)
 		Expect(runAuthLogin(cmd, nil)).To(Succeed())
 
-		stored, err := LoadStoredTokens("http://mc.example.com")
+		stored, err := LoadStoredTokens(server.URL)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stored.AccessToken).To(Equal("my-access-token"))
+		expectLoginContext(server.URL+"/api", "my-access-token")
 	})
 
-	ginkgo.It("trims a trailing slash from the server before storing", func() {
-		loginServer = "http://mc.example.com/"
+	ginkgo.It("stores token contexts with the direct backend base", func() {
+		server := authHealthServer(false)
+		defer server.Close()
+		loginServer = server.URL + "/"
 		loginToken = "tok2"
 
 		cmd := &cobra.Command{}
 		cmd.SetOut(io.Discard)
 		Expect(runAuthLogin(cmd, nil)).To(Succeed())
 
-		stored, err := LoadStoredTokens("http://mc.example.com")
+		stored, err := LoadStoredTokens(server.URL)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stored.AccessToken).To(Equal("tok2"))
+		expectLoginContext(server.URL, "tok2")
+	})
+
+	ginkgo.It("runs OIDC login against the frontend URL for resolved /api contexts", func() {
+		server := authHealthServer(true)
+		defer server.Close()
+		loginServer = server.URL
+
+		var gotLoginServer string
+		oidcLogin = func(_ *cobra.Command, server string, _ io.Writer) (*oidcclient.Tokens, string, error) {
+			gotLoginServer = server
+			return &oidcclient.Tokens{AccessToken: "oauth-token", ExpiresAt: time.Now().Add(time.Hour)}, "tokens.json", nil
+		}
+
+		cmd := &cobra.Command{}
+		cmd.SetOut(io.Discard)
+		Expect(runAuthLogin(cmd, nil)).To(Succeed())
+
+		Expect(gotLoginServer).To(Equal(server.URL))
+		expectLoginContext(server.URL+"/api", "oauth-token")
 	})
 })
+
+func authHealthServer(frontend bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/health":
+			if frontend {
+				_, _ = w.Write([]byte("OK"))
+				return
+			}
+			http.NotFound(w, r)
+		case "/health":
+			_, _ = w.Write([]byte("OK"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func expectLoginContext(serverURL, token string) {
+	cfg, err := LoadConfig()
+	Expect(err).ToNot(HaveOccurred())
+	name := ServerToContextName(serverURL)
+	Expect(cfg.CurrentContext).To(Equal(name))
+	ctx := cfg.GetContext(name)
+	Expect(ctx).ToNot(BeNil())
+	Expect(ctx.Server).To(Equal(serverURL))
+	Expect(ctx.Token).To(Equal(token))
+}

--- a/clientcmd/connection_test_cmd.go
+++ b/clientcmd/connection_test_cmd.go
@@ -1,14 +1,10 @@
 package clientcmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/flanksource/clicky"
 	"github.com/spf13/cobra"
-
-	"github.com/flanksource/incident-commander/sdk"
 )
 
 var ConnectionTest = &cobra.Command{
@@ -51,19 +47,6 @@ func runConnectionTestFromDB(name, namespace string, overrides *ConnectionFlags)
 }
 
 func runConnectionTestViaAPI(mcCtx *MCContext, name, namespace string) (any, error) {
-	result, err := callConnectionTestAPI(mcCtx, name, namespace)
-	if !errors.Is(err, sdk.ErrHTMLResponse) {
-		return result, err
-	}
-
-	upgraded, upErr := EnsureAPIBase(mcCtx)
-	if upErr != nil {
-		return nil, fmt.Errorf("%w (probe failed: %v)", err, upErr)
-	}
-	if !upgraded {
-		return nil, err
-	}
-	fmt.Fprintf(os.Stderr, "Upgraded context %q server to %s\n", mcCtx.Name, mcCtx.Server)
 	return callConnectionTestAPI(mcCtx, name, namespace)
 }
 

--- a/clientcmd/context.go
+++ b/clientcmd/context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -257,7 +258,11 @@ Examples:
 			ctx = *existingCtx
 		}
 		if cmd.Flags().Changed("server") {
-			ctx.Server = strings.TrimRight(contextAddServer, "/")
+			server, err := ResolveAPIBase(contextAddServer)
+			if err != nil {
+				return err
+			}
+			ctx.Server = server
 		}
 		if cmd.Flags().Changed("db-url") {
 			ctx.DB = contextAddDB
@@ -303,63 +308,97 @@ func EnsureContextToken(cmd *cobra.Command, ctx *MCContext, status io.Writer) er
 		return fmt.Errorf("failed to load stored tokens for %s: %w", ctx.Server, err)
 	}
 
-	fmt.Fprintf(status, "No token configured for context %q; starting OIDC login for %s\n", ctx.Name, ctx.Server)
-	tokens, _, err := oidcLogin(cmd, ctx.Server, status)
-	if err != nil {
-		return fmt.Errorf("OAuth login failed for %s: %w", ctx.Server, err)
+	var lastErr error
+	for _, loginServer := range oidcLoginServerCandidates(ctx.Server) {
+		fmt.Fprintf(status, "No token configured for context %q; starting OIDC login for %s\n", ctx.Name, loginServer)
+		tokens, _, err := oidcLogin(cmd, loginServer, status)
+		if err == nil {
+			ctx.Token = tokens.AccessToken
+			return nil
+		}
+		lastErr = err
 	}
-	ctx.Token = tokens.AccessToken
-	return nil
+	return fmt.Errorf("OAuth login failed for %s: %w", ctx.Server, lastErr)
 }
 
 func storedAccessToken(serverURL string) (string, error) {
-	tokens, err := LoadStoredTokens(serverURL)
+	stored, err := loadStoredOIDCTokens(serverURL)
 	if err != nil {
 		return "", err
 	}
-	if tokens.AccessToken == "" {
+	if stored == nil || stored.Tokens == nil || stored.Tokens.AccessToken == "" {
 		return "", nil
 	}
-	if !tokens.ExpiresAt.IsZero() && time.Until(tokens.ExpiresAt) < time.Minute {
+	if !stored.Tokens.ExpiresAt.IsZero() && time.Until(stored.Tokens.ExpiresAt) < time.Minute {
 		return "", nil
 	}
-	return tokens.AccessToken, nil
+	return stored.Tokens.AccessToken, nil
 }
 
-// EnsureAPIBase probes serverURL + "/api/db/connections" and, if that path
-// returns JSON, appends "/api" to the stored server URL and saves the config.
-// Returns true when the context was upgraded. Used to self-heal after the SDK
-// reports ErrHTMLResponse.
-func EnsureAPIBase(ctx *MCContext) (bool, error) {
-	if ctx == nil || ctx.Server == "" {
-		return false, nil
+func oidcLoginServerCandidates(serverURL string) []string {
+	serverURL = strings.TrimRight(serverURL, "/")
+	if strings.HasSuffix(serverURL, "/api") {
+		return uniqueStrings([]string{strings.TrimSuffix(serverURL, "/api"), serverURL})
 	}
-	if strings.HasSuffix(strings.TrimRight(ctx.Server, "/"), "/api") {
-		return false, nil
+	return uniqueStrings([]string{serverURL})
+}
+
+// ResolveAPIBase probes both the frontend proxy API path and the direct backend
+// path, returning the base URL that serves Mission Control's unauthenticated
+// /health endpoint.
+func ResolveAPIBase(serverURL string) (string, error) {
+	serverURL = strings.TrimRight(serverURL, "/")
+	if serverURL == "" {
+		return "", fmt.Errorf("server URL is required")
 	}
 
-	ok, err := NewAPIClientForServer(ctx.Server, ctx.Token).ProbeAPIBase(gocontext.Background())
+	var failures []string
+	for _, candidate := range apiBaseCandidates(serverURL) {
+		ok, err := probeAPIHealth(gocontext.Background(), candidate)
+		if err == nil && ok {
+			return candidate, nil
+		}
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", candidate, err))
+		} else {
+			failures = append(failures, fmt.Sprintf("%s: /health did not return OK", candidate))
+		}
+	}
+	return "", fmt.Errorf("could not find Mission Control API for %s (%s)", serverURL, strings.Join(failures, "; "))
+}
+
+func apiBaseCandidates(serverURL string) []string {
+	serverURL = strings.TrimRight(serverURL, "/")
+	if strings.HasSuffix(serverURL, "/api") {
+		return uniqueStrings([]string{serverURL, strings.TrimSuffix(serverURL, "/api")})
+	}
+	return uniqueStrings([]string{serverURL + "/api", serverURL})
+}
+
+func probeAPIHealth(ctx gocontext.Context, baseURL string) (bool, error) {
+	healthURL, err := url.JoinPath(baseURL, "health")
 	if err != nil {
 		return false, err
 	}
-	if !ok {
-		return false, nil
-	}
-
-	cfg, err := LoadConfig()
+	ctx, cancel := gocontext.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 	if err != nil {
 		return false, err
 	}
-	stored := cfg.GetContext(ctx.Name)
-	if stored == nil {
-		return false, nil
-	}
-	stored.Server = strings.TrimRight(stored.Server, "/") + "/api"
-	ctx.Server = stored.Server
-	if err := SaveConfig(cfg); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(body)) == "OK", nil
 }
 
 func init() {

--- a/clientcmd/context_test.go
+++ b/clientcmd/context_test.go
@@ -124,4 +124,118 @@ var _ = ginkgo.Describe("context token resolution", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(reloaded.GetContext("local").Token).To(Equal("new-token"))
 	})
+
+	ginkgo.It("reuses frontend OIDC tokens for resolved /api contexts", func() {
+		server := "http://mission-control.local"
+		_, err := storeTokens(server, &oidcclient.Tokens{
+			AccessToken: "stored-token",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		oidcLogin = func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error) {
+			return nil, "", fmt.Errorf("unexpected login")
+		}
+
+		ctx := &MCContext{Name: "local", Server: server + "/api"}
+		Expect(EnsureContextToken(&cobra.Command{}, ctx, io.Discard)).To(Succeed())
+		Expect(ctx.Token).To(Equal("stored-token"))
+	})
+
+	ginkgo.It("starts OIDC login against the frontend URL for resolved /api contexts", func() {
+		var loginServer string
+		oidcLogin = func(_ *cobra.Command, server string, status io.Writer) (*oidcclient.Tokens, string, error) {
+			loginServer = server
+			return &oidcclient.Tokens{AccessToken: "oauth-token"}, "", nil
+		}
+
+		ctx := &MCContext{Name: "local", Server: "http://mission-control.local/api"}
+		Expect(EnsureContextToken(&cobra.Command{}, ctx, io.Discard)).To(Succeed())
+		Expect(ctx.Token).To(Equal("oauth-token"))
+		Expect(loginServer).To(Equal("http://mission-control.local"))
+	})
+})
+
+var _ = ginkgo.Describe("API base resolution", func() {
+	ginkgo.BeforeEach(func() {
+		configDir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", configDir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", configDir)
+	})
+
+	ginkgo.AfterEach(func() {
+		contextAddName = ""
+		contextAddServer = ""
+		contextAddDB = ""
+		contextAddToken = ""
+		contextAddUse = false
+	})
+
+	ginkgo.It("prefers the frontend /api health endpoint", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/health":
+				_, _ = w.Write([]byte("OK"))
+			case "/health":
+				_, _ = w.Write([]byte("frontend OK"))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		resolved, err := ResolveAPIBase(server.URL)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(server.URL + "/api"))
+	})
+
+	ginkgo.It("falls back to direct backend health", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/health":
+				_, _ = w.Write([]byte("OK"))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		resolved, err := ResolveAPIBase(server.URL)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(server.URL))
+	})
+
+	ginkgo.It("stores the resolved API base for context add", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/health" {
+				_, _ = w.Write([]byte("OK"))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		contextAddName = "beta"
+		contextAddServer = server.URL
+		contextAddToken = "token"
+		contextAddUse = true
+
+		cmd := &cobra.Command{}
+		cmd.SetOut(io.Discard)
+		cmd.Flags().String("server", "", "")
+		cmd.Flags().String("token", "", "")
+		cmd.Flags().String("db-url", "", "")
+		Expect(cmd.Flags().Set("server", server.URL)).To(Succeed())
+		Expect(cmd.Flags().Set("token", "token")).To(Succeed())
+
+		Expect(contextAddCmd.RunE(cmd, nil)).To(Succeed())
+
+		cfg, err := LoadConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.CurrentContext).To(Equal("beta"))
+		ctx := cfg.GetContext("beta")
+		Expect(ctx.Server).To(Equal(server.URL + "/api"))
+	})
 })

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -1,7 +1,6 @@
 package clientcmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -115,20 +114,6 @@ func currentAPIContext(cmd *cobra.Command) (*MCContext, error) {
 	return mcCtx, nil
 }
 
-func retryAfterAPIBaseUpgrade(mcCtx *MCContext, err error) (bool, error) {
-	if !errors.Is(err, sdk.ErrHTMLResponse) {
-		return false, err
-	}
-	upgraded, upErr := EnsureAPIBase(mcCtx)
-	if upErr != nil {
-		return false, fmt.Errorf("%w (probe failed: %v)", err, upErr)
-	}
-	if !upgraded {
-		return false, err
-	}
-	return true, nil
-}
-
 func playbookAPIClient(cmd *cobra.Command) (*MCContext, *sdk.Client, error) {
 	mcCtx, err := currentAPIContext(cmd)
 	if err != nil {
@@ -138,17 +123,11 @@ func playbookAPIClient(cmd *cobra.Command) (*MCContext, *sdk.Client, error) {
 }
 
 func listRemotePlaybooks(cmd *cobra.Command, opts sdk.PlaybookListOptions) ([]api.PlaybookListItem, error) {
-	mcCtx, client, err := playbookAPIClient(cmd)
+	_, client, err := playbookAPIClient(cmd)
 	if err != nil {
 		return nil, err
 	}
-	items, err := client.ListPlaybooks(opts)
-	if upgraded, upgradeErr := retryAfterAPIBaseUpgrade(mcCtx, err); upgradeErr != nil {
-		return nil, upgradeErr
-	} else if upgraded {
-		items, err = NewAPIClient(mcCtx).ListPlaybooks(opts)
-	}
-	return items, err
+	return client.ListPlaybooks(opts)
 }
 
 func runRemotePlaybook(cmd *cobra.Command, args []string) error {
@@ -156,18 +135,12 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("provide at most one of --config-id, --component-id, or --check-id")
 	}
 
-	mcCtx, client, err := playbookAPIClient(cmd)
+	_, client, err := playbookAPIClient(cmd)
 	if err != nil {
 		return err
 	}
 
 	playbooks, err := client.ListPlaybooks(sdk.PlaybookListOptions{})
-	if upgraded, upgradeErr := retryAfterAPIBaseUpgrade(mcCtx, err); upgradeErr != nil {
-		return upgradeErr
-	} else if upgraded {
-		client = NewAPIClient(mcCtx)
-		playbooks, err = client.ListPlaybooks(sdk.PlaybookListOptions{})
-	}
 	if err != nil {
 		return err
 	}
@@ -183,12 +156,6 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 	}
 
 	response, err := client.RunPlaybook(params)
-	if upgraded, upgradeErr := retryAfterAPIBaseUpgrade(mcCtx, err); upgradeErr != nil {
-		return upgradeErr
-	} else if upgraded {
-		client = NewAPIClient(mcCtx)
-		response, err = client.RunPlaybook(params)
-	}
 	if err != nil {
 		return err
 	}

--- a/faro/catalog_test.go
+++ b/faro/catalog_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/query"
+	"github.com/flanksource/incident-commander/clientcmd"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("faro catalog API paths", func() {
+	ginkgo.BeforeEach(func() {
+		dir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", dir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", dir)
+	})
+
+	ginkgo.It("uses direct backend paths when the context server is a backend URL", func() {
+		server := catalogSearchServer("/resources/search")
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteList(catalogListOpts{Limit: 5})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(*items[0].Name).To(Equal("api"))
+	})
+
+	ginkgo.It("uses /api paths when the context server is a resolved frontend API URL", func() {
+		server := catalogSearchServer("/api/resources/search")
+		defer server.Close()
+		storeRemoteContext(server.URL + "/api")
+
+		items, err := remoteList(catalogListOpts{Limit: 5})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(*items[0].Name).To(Equal("api"))
+	})
+})
+
+func catalogSearchServer(expectedPath string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Expect(r.Method).To(Equal(http.MethodPost))
+		Expect(r.URL.Path).To(Equal(expectedPath))
+		var got query.SearchResourcesRequest
+		Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+		Expect(got.Limit).To(Equal(5))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
+	}))
+}
+
+func storeRemoteContext(serverURL string) {
+	Expect(clientcmd.SaveConfig(&clientcmd.MCConfig{
+		CurrentContext: "test",
+		Contexts: []clientcmd.MCContext{{
+			Name:   "test",
+			Server: serverURL,
+			Token:  "token",
+		}},
+	})).To(Succeed())
+}

--- a/faro/main.go
+++ b/faro/main.go
@@ -20,6 +20,13 @@ var (
 // faro is a slimmed-down Mission Control client. It exposes only the surfaces
 // that operate against a remote Mission Control server using the credentials
 // obtained through the OIDC login flow.
+func silenceUsage(cmd *cobra.Command) {
+	cmd.SilenceUsage = true
+	for _, child := range cmd.Commands() {
+		silenceUsage(child)
+	}
+}
+
 func main() {
 	if len(commit) > 8 {
 		version = fmt.Sprintf("%v, commit %v, built at %v", version, commit[0:8], date)
@@ -29,8 +36,9 @@ func main() {
 	api.BuildCommit = commit
 
 	root := &cobra.Command{
-		Use:   "faro",
-		Short: "Slim Mission Control client",
+		Use:          "faro",
+		Short:        "Slim Mission Control client",
+		SilenceUsage: true,
 	}
 
 	root.AddCommand(&cobra.Command{
@@ -52,6 +60,7 @@ func main() {
 	if c, _, err := root.Find([]string{"catalog"}); err == nil && c != nil {
 		clicky.BindAllFlags(c.PersistentFlags(), "format")
 	}
+	silenceUsage(root)
 
 	harFlush := func() error { return nil }
 	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {

--- a/faro/suite_test.go
+++ b/faro/suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFaro(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Faro")
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -250,30 +250,6 @@ func (c *Client) Whoami(ctx context.Context) (*WhoamiResponse, int, error) {
 	return &result, r.StatusCode, nil
 }
 
-func (c *Client) ProbeAPIBase(ctx context.Context) (bool, error) {
-	r, err := c.R(ctx).
-		QueryParam("limit", "0").
-		Get(c.apiPath("/api/db/connections"))
-	if err != nil {
-		return false, err
-	}
-	body, err := r.AsString()
-	if err != nil {
-		return false, err
-	}
-	switch r.StatusCode {
-	case 200, 401, 403:
-	default:
-		return false, nil
-	}
-	if looksLikeHTML(r.Header.Get("Content-Type"), body) {
-		return false, nil
-	}
-	contentType := strings.ToLower(r.Header.Get("Content-Type"))
-	trimmed := strings.TrimLeft(body, " \t\r\n")
-	return strings.Contains(contentType, "json") || strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{"), nil
-}
-
 func (c *Client) GetConnection(name, namespace string) (*models.Connection, error) {
 	var connections []models.Connection
 	r, err := c.R(context.Background()).


### PR DESCRIPTION
faro can be configured with either a shared frontend URL or a direct SaaS backend URL.

Resolve the API base when contexts are created by probing `/api/health` first and `/health` second. Frontend deployments store `<frontend>/api`, while direct backend deployments keep the backend URL.

`auth login` now saves a context with the resolved API base, while OIDC token lookup still works for frontend issuer URLs. Runtime commands no longer attempt API-base self-healing or retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced login flow with improved token storage and context management
  * Added API base resolution for better server compatibility detection

* **Bug Fixes**
  * Simplified error handling in connection testing and playbook operations
  * Improved token reuse and OIDC login recovery

* **Tests**
  * Expanded test coverage for authentication, token resolution, and API discovery
  * Added test suite infrastructure improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->