### PR TITLE
fix: add missing platform-specific release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,10 @@ darwin:
 
 .PHONY: windows
 windows:
-	GOOS=windows GOARCH=amd64 go build -o ./.bin/$(NAME).exe -ldflags "-X \"main.version=$(VERSION_TAG)\""  main.go
+	GOOS=windows GOARCH=amd64 go build -o ./.bin/$(NAME)_windows_amd64.exe -ldflags "-X \"main.version=$(VERSION_TAG)\""  main.go
 
 # faro is a slim Mission Control client (remote-only surfaces). Built for the
-# requested matrix: linux amd64/arm64, darwin arm64, windows amd64.
+# requested matrix: linux amd64/arm64, darwin amd64/arm64, windows amd64/arm64.
 .PHONY: faro-linux
 faro-linux: $(TAILWIND_JS)
 	GOOS=linux GOARCH=amd64 go build -o ./.bin/faro_linux_amd64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
@@ -142,11 +142,13 @@ faro-linux: $(TAILWIND_JS)
 
 .PHONY: faro-darwin
 faro-darwin: $(TAILWIND_JS)
+	GOOS=darwin GOARCH=amd64 go build -o ./.bin/faro_darwin_amd64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
 	GOOS=darwin GOARCH=arm64 go build -o ./.bin/faro_darwin_arm64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro-windows
 faro-windows: $(TAILWIND_JS)
-	GOOS=windows GOARCH=amd64 go build -o ./.bin/faro.exe -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=amd64 go build -o ./.bin/faro_windows_amd64.exe -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=arm64 go build -o ./.bin/faro_windows_arm64.exe -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro
 faro: faro-linux faro-darwin faro-windows


### PR DESCRIPTION
Release assets were missing some platform-specific Faro builds and Windows binaries used inconsistent names.\n\nUpdate the release build matrix to include Faro Darwin AMD64 and Windows ARM64. Rename Windows outputs to follow the existing {name}_{os}_{arch} convention for release assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build outputs to use architecture-specific filenames for Windows and macOS releases.
  * macOS now produces both amd64 and arm64 executables with arch-suffixed names.
  * Windows now produces both amd64 and arm64 executables (instead of a single binary) with arch-suffixed names.
  * Refreshed cross-platform build matrix documentation to reflect Windows amd64/arm64 and Darwin amd64/arm64 targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->