### PR TITLE
chore(ui): add playbook dropdown option

### DIFF
--- a/ui/frontend/src/config-detail/ConfigItemDetail.tsx
+++ b/ui/frontend/src/config-detail/ConfigItemDetail.tsx
@@ -59,7 +59,7 @@ import { TagList } from "./TagList";
 import { CatalogReportDialog } from "./CatalogReportDialog";
 import ConfigChangesSection from "./config-changes/ConfigChangesSection";
 import { defaultConfigChangesExtensions } from "./config-changes/config-changes-builtin-extensions";
-import { ConfigPlaybooksTab } from "../playbooks/PlaybookBrowser";
+import { ConfigPlaybooksDropdown, ConfigPlaybooksTab } from "../playbooks/PlaybookBrowser";
 import { DetailPageLayout, EntityHeader, PageBreadcrumbs } from "../layout/DetailPageLayout";
 import type {
   ConfigChange as UIConfigChange,
@@ -305,6 +305,7 @@ function ConfigHeaderActions({ config, onReport }: { config: ConfigItem; onRepor
           <Badge variant="metric" label="Scraped" value={timeAgo(config.last_scraped_time)} size="xs" icon="lucide:refresh-cw" />
         </AccessMatrixTooltip>
       )}
+      <ConfigPlaybooksDropdown config={config} />
       <button
         type="button"
         onClick={onReport}

--- a/ui/frontend/src/playbooks/PlaybookBrowser.tsx
+++ b/ui/frontend/src/playbooks/PlaybookBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
@@ -115,6 +115,80 @@ export function PlaybookBrowser({ mode, runId }: PlaybookBrowserProps) {
 
 export function stepOutputMaxHeight(stepCount: number): CSSProperties {
   return { maxHeight: `min(20vh, calc((100vh - 200px) / ${Math.max(1, stepCount)}))` };
+}
+
+export function ConfigPlaybooksDropdown({ config }: { config: ConfigItem }) {
+  const runnableQuery = useRunnablePlaybooksForConfig(config.id);
+  const runnable = (runnableQuery.data ?? []).map(runnableListItemToPlaybook);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<RunDialogSelection | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", closeOnOutsideClick);
+    return () => document.removeEventListener("mousedown", closeOnOutsideClick);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm font-medium shadow-sm hover:bg-accent/50 disabled:cursor-not-allowed disabled:opacity-60"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={runnableQuery.isLoading}
+      >
+        <Icon name={runnableQuery.isLoading ? "lucide:loader-2" : "lucide:play-square"} className={runnableQuery.isLoading ? "animate-spin" : undefined} />
+        <span>Playbooks</span>
+        {runnable.length > 0 && <Badge size="xxs">{runnable.length}</Badge>}
+        <Icon name="lucide:chevron-down" className="text-xs text-muted-foreground" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-10 z-30 w-64 overflow-hidden rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-lg"
+        >
+          {runnableQuery.error ? (
+            <div className="px-3 py-2 text-sm text-destructive">Failed to load playbooks</div>
+          ) : runnable.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-muted-foreground">No runnable playbooks</div>
+          ) : (
+            runnable.map((playbook) => (
+              <button
+                key={playbook.id}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  setSelected({ playbook, target: { config_id: config.id }, resourceLabel: config.name || config.id });
+                }}
+                className="flex h-9 w-full min-w-0 items-center gap-2 px-3 text-left text-sm hover:bg-accent/50"
+              >
+                <PlaybookIcon playbook={playbook} className="h-4 max-w-4 shrink-0" />
+                <span className="truncate">{displayPlaybookName(playbook)}</span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+      {selected && (
+        <SubmitPlaybookRunDialog
+          open
+          playbook={selected.playbook}
+          target={selected.target}
+          resourceLabel={selected.resourceLabel}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
 }
 
 export function ConfigPlaybooksTab({ config }: { config: ConfigItem }) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a playbooks dropdown menu in the config detail header. Users can now easily view all available playbooks for the current configuration, see the count of runnable options, and submit playbook runs directly from the configuration detail view. The dropdown provides clear loading, error, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->