### PR TITLE
fix(playbooks): require target flags for cached playbook commands

### DIFF
--- a/clientcmd/playbook_cache.go
+++ b/clientcmd/playbook_cache.go
@@ -123,6 +123,7 @@ func cachedPlaybookCommandName(runRoot *cobra.Command, item api.PlaybookListItem
 
 func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Command {
 	params := playbookParametersFromItem(item)
+	targetReq := playbookTargetRequirementFromItem(item)
 	values := map[string]*string{}
 	var wait = true
 	var pollInterval = 2 * time.Second
@@ -144,18 +145,12 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 			if targetCount(configID, componentID, checkID) > 1 {
 				return fmt.Errorf("provide at most one of --config-id, --component-id, or --check-id")
 			}
-			args := make([]string, 0, len(values))
-			for _, p := range params {
-				value := ""
-				if values[p.Name] != nil {
-					value = *values[p.Name]
-				}
-				if p.Required && strings.TrimSpace(value) == "" {
-					return fmt.Errorf("missing required parameter: --%s", p.Name)
-				}
-				if strings.TrimSpace(value) != "" {
-					args = append(args, p.Name+"="+value)
-				}
+			if err := validatePlaybookTargetFlags(item, targetReq, configID, componentID, checkID); err != nil {
+				return err
+			}
+			args, err := cachedPlaybookParamArgs(cmd, params, values)
+			if err != nil {
+				return err
 			}
 			req, err := buildRemoteRunParamsWithOptions(item.ID, args, paramFile, configID, componentID, checkID)
 			if err != nil {
@@ -202,6 +197,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	cmd.Flags().StringVar(&configID, "config-id", "", "Config ID to run the playbook against")
 	cmd.Flags().StringVar(&componentID, "component-id", "", "Component ID to run the playbook against")
 	cmd.Flags().StringVar(&checkID, "check-id", "", "Check ID to run the playbook against")
+	markRequiredPlaybookTargetFlags(cmd, targetReq)
 	cmd.Flags().StringVarP(&paramFile, "params", "p", "", "YAML/JSON file containing parameters")
 	for _, p := range params {
 		if p.Name == "" || cmd.Flags().Lookup(p.Name) != nil {
@@ -210,8 +206,32 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 		value := fmt.Sprint(p.Default)
 		values[p.Name] = &value
 		cmd.Flags().StringVar(values[p.Name], p.Name, value, p.Description)
+		if p.Required && !playbookParameterHasDefault(p) {
+			_ = cmd.MarkFlagRequired(p.Name)
+		}
 	}
 	return cmd
+}
+
+func cachedPlaybookParamArgs(cmd *cobra.Command, params []v1.PlaybookParameter, values map[string]*string) ([]string, error) {
+	args := make([]string, 0, len(values))
+	for _, p := range params {
+		value := ""
+		if values[p.Name] != nil {
+			value = *values[p.Name]
+		}
+		if p.Required && !playbookParameterHasDefault(p) && strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("missing required parameter: --%s", p.Name)
+		}
+		if cmd.Flags().Changed(p.Name) && strings.TrimSpace(value) != "" {
+			args = append(args, p.Name+"="+value)
+		}
+	}
+	return args, nil
+}
+
+func playbookParameterHasDefault(p v1.PlaybookParameter) bool {
+	return strings.TrimSpace(string(p.Default)) != ""
 }
 
 func playbookParametersFromItem(item api.PlaybookListItem) []v1.PlaybookParameter {
@@ -221,6 +241,98 @@ func playbookParametersFromItem(item api.PlaybookListItem) []v1.PlaybookParamete
 	var params []v1.PlaybookParameter
 	_ = json.Unmarshal(item.Parameters, &params)
 	return params
+}
+
+type playbookTargetRequirement struct {
+	Config    bool
+	Component bool
+	Check     bool
+}
+
+func playbookTargetRequirementFromItem(item api.PlaybookListItem) playbookTargetRequirement {
+	if len(item.Spec) == 0 {
+		return playbookTargetRequirement{}
+	}
+	var spec v1.PlaybookSpec
+	if err := json.Unmarshal(item.Spec, &spec); err != nil {
+		return playbookTargetRequirement{}
+	}
+	return playbookTargetRequirement{
+		Config:    len(spec.Configs) > 0,
+		Component: len(spec.Components) > 0,
+		Check:     len(spec.Checks) > 0,
+	}
+}
+
+func (r playbookTargetRequirement) any() bool {
+	return r.Config || r.Component || r.Check
+}
+
+func (r playbookTargetRequirement) count() int {
+	count := 0
+	if r.Config {
+		count++
+	}
+	if r.Component {
+		count++
+	}
+	if r.Check {
+		count++
+	}
+	return count
+}
+
+func (r playbookTargetRequirement) flagNames() []string {
+	var flags []string
+	if r.Config {
+		flags = append(flags, "--config-id")
+	}
+	if r.Component {
+		flags = append(flags, "--component-id")
+	}
+	if r.Check {
+		flags = append(flags, "--check-id")
+	}
+	return flags
+}
+
+func markRequiredPlaybookTargetFlags(cmd *cobra.Command, req playbookTargetRequirement) {
+	if req.count() != 1 {
+		return
+	}
+	if req.Config {
+		_ = cmd.MarkFlagRequired("config-id")
+	}
+	if req.Component {
+		_ = cmd.MarkFlagRequired("component-id")
+	}
+	if req.Check {
+		_ = cmd.MarkFlagRequired("check-id")
+	}
+}
+
+func validatePlaybookTargetFlags(item api.PlaybookListItem, req playbookTargetRequirement, configID, componentID, checkID string) error {
+	if !req.any() {
+		return nil
+	}
+	ref := playbookRef(item)
+	if configID == "" && componentID == "" && checkID == "" {
+		flags := req.flagNames()
+		if len(flags) == 1 {
+			return fmt.Errorf("%s is required for playbook %q", flags[0], ref)
+		}
+		return fmt.Errorf("one of %s is required for playbook %q", strings.Join(flags, ", "), ref)
+	}
+	if configID != "" && !req.Config {
+		return fmt.Errorf("--config-id is not valid for playbook %q; use %s", ref, strings.Join(req.flagNames(), ", "))
+	}
+	if componentID != "" && !req.Component {
+		return fmt.Errorf("--component-id is not valid for playbook %q; use %s", ref, strings.Join(req.flagNames(), ", "))
+	}
+	if checkID != "" && !req.Check {
+		return fmt.Errorf("--check-id is not valid for playbook %q; use %s", ref, strings.Join(req.flagNames(), ", "))
+	}
+	return nil
 }
 
 func formatCachedPlaybookLong(item api.PlaybookListItem, params []v1.PlaybookParameter) string {

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 
 	"github.com/flanksource/incident-commander/api"
+	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/sdk"
 )
 
@@ -191,5 +193,42 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout.String()).To(ContainSubstring(`"id": "` + id.String() + `"`))
 		Expect(stdout.String()).To(ContainSubstring(`"description": "Restarts a pod"`))
+	})
+
+	ginkgo.It("requires config id for cached playbooks with config selectors", func() {
+		id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+		spec := []byte(`{"configs":[{"types":["Kubernetes::Deployment"]}],"actions":[{"exec":{"script":"echo ok"}}]}`)
+		cmd := newCachedPlaybookCommand(api.PlaybookListItem{
+			ID:        id,
+			Namespace: "mission-control",
+			Name:      "kubernetes-update-image",
+			Spec:      spec,
+		}, "kubernetes-update-image")
+
+		_, errOut, err := executeCommand(cmd)
+
+		Expect(err).To(MatchError(ContainSubstring(`required flag(s) "config-id" not set`)))
+		Expect(errOut).NotTo(ContainSubstring("Usage:"))
+	})
+
+	ginkgo.It("does not send templated defaults unless the cached playbook flag is changed", func() {
+		param := v1.PlaybookParameter{
+			Name:    "container",
+			Type:    v1.PlaybookParameterTypeText,
+			Default: `$( .config.config | jq ".spec.template.spec.containers[0].name" )`,
+		}
+		cmd := &cobra.Command{Use: "kubernetes-update-image"}
+		value := string(param.Default)
+		values := map[string]*string{"container": &value}
+		cmd.Flags().StringVar(values["container"], "container", value, "")
+
+		args, err := cachedPlaybookParamArgs(cmd, []v1.PlaybookParameter{param}, values)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(args).To(BeEmpty())
+
+		Expect(cmd.Flags().Set("container", "api")).To(Succeed())
+		args, err = cachedPlaybookParamArgs(cmd, []v1.PlaybookParameter{param}, values)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(args).To(Equal([]string{"container=api"}))
 	})
 })


### PR DESCRIPTION
Cached playbook commands could run without a target resource even when the playbook declared `configs`, `components`, or `checks` selectors.

This allowed runs to start with an empty resource ID and fail later during action execution.

Mark the matching target flag as required for cached playbook commands and validate selector-compatible target flags before dispatch. Also avoid sending templated default parameter values unless the user explicitly overrides them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added stricter runtime validation for playbook target selection flags to prevent incompatible options.
  * Refined required-parameter handling so parameters with defaults are not incorrectly treated as required.
  * Improved CLI argument building for cached playbook parameters, emitting only explicitly provided non-empty values.
* **Tests**
  * Added coverage ensuring cached playbook execution fails with a clear missing `config-id` error when selectors are present, without showing usage.
  * Added coverage confirming templated default parameters are suppressed until the user explicitly updates the related flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->