### PR TITLE
feat(faro): add context remove command

### DIFF
--- a/clientcmd/context.go
+++ b/clientcmd/context.go
@@ -99,6 +99,9 @@ func (c *MCConfig) RemoveContext(name string) bool {
 			c.Contexts = append(c.Contexts[:i], c.Contexts[i+1:]...)
 			if c.CurrentContext == name {
 				c.CurrentContext = ""
+				if len(c.Contexts) == 1 {
+					c.CurrentContext = c.Contexts[0].Name
+				}
 			}
 			return true
 		}
@@ -253,6 +256,7 @@ var contextRemoveCmd = &cobra.Command{
 			}
 		}
 
+		previousCurrent := cfg.CurrentContext
 		if !cfg.RemoveContext(name) {
 			return fmt.Errorf("context %q not found", name)
 		}
@@ -260,6 +264,9 @@ var contextRemoveCmd = &cobra.Command{
 			return err
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Removed context %q\n", name)
+		if previousCurrent == name && cfg.CurrentContext != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Switched to context %q\n", cfg.CurrentContext)
+		}
 		return nil
 	},
 }

--- a/clientcmd/context.go
+++ b/clientcmd/context.go
@@ -93,6 +93,19 @@ func (c *MCConfig) SetContext(ctx MCContext) {
 	c.Contexts = append(c.Contexts, ctx)
 }
 
+func (c *MCConfig) RemoveContext(name string) bool {
+	for i := range c.Contexts {
+		if c.Contexts[i].Name == name {
+			c.Contexts = append(c.Contexts[:i], c.Contexts[i+1:]...)
+			if c.CurrentContext == name {
+				c.CurrentContext = ""
+			}
+			return true
+		}
+	}
+	return false
+}
+
 func (c *MCConfig) CurrentMCContext() *MCContext {
 	if contextFlag != "" {
 		return c.GetContext(contextFlag)
@@ -198,6 +211,55 @@ var contextListCmd = &cobra.Command{
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "%s%s\t%s\n", marker, c.Name, info)
 		}
+		return nil
+	},
+}
+
+var contextRemoveCmd = &cobra.Command{
+	Use:     "remove [name]",
+	Aliases: []string{"rm", "delete"},
+	Short:   "Remove a Mission Control context",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := LoadConfig()
+		if err != nil {
+			return err
+		}
+
+		var name string
+		if len(args) > 0 {
+			name = args[0]
+		} else {
+			if len(cfg.Contexts) == 0 {
+				return fmt.Errorf("no contexts configured")
+			}
+			options := make([]huh.Option[string], len(cfg.Contexts))
+			for i, c := range cfg.Contexts {
+				label := c.Name
+				if c.Name == cfg.CurrentContext {
+					label += " (current)"
+				}
+				if c.Server != "" {
+					label += "  " + c.Server
+				}
+				options[i] = huh.NewOption(label, c.Name)
+			}
+			if err := huh.NewSelect[string]().
+				Title("Remove context").
+				Options(options...).
+				Value(&name).
+				Run(); err != nil {
+				return err
+			}
+		}
+
+		if !cfg.RemoveContext(name) {
+			return fmt.Errorf("context %q not found", name)
+		}
+		if err := SaveConfig(cfg); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed context %q\n", name)
 		return nil
 	},
 }
@@ -408,5 +470,5 @@ func init() {
 	contextAddCmd.Flags().StringVar(&contextAddToken, "token", "", "API token for the server")
 	contextAddCmd.Flags().BoolVar(&contextAddUse, "use", false, "Switch to this context after adding")
 
-	ContextCmd.AddCommand(contextUseCmd, contextListCmd, contextCurrentCmd, contextAddCmd)
+	ContextCmd.AddCommand(contextUseCmd, contextListCmd, contextCurrentCmd, contextAddCmd, contextRemoveCmd)
 }

--- a/clientcmd/context_test.go
+++ b/clientcmd/context_test.go
@@ -156,6 +156,63 @@ var _ = ginkgo.Describe("context token resolution", func() {
 	})
 })
 
+var _ = ginkgo.Describe("context remove", func() {
+	ginkgo.BeforeEach(func() {
+		configDir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", configDir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", configDir)
+	})
+
+	ginkgo.It("removes the named context", func() {
+		Expect(SaveConfig(&MCConfig{
+			CurrentContext: "local",
+			Contexts: []MCContext{
+				{Name: "local", Server: "http://local"},
+				{Name: "beta", Server: "http://beta"},
+			},
+		})).To(Succeed())
+
+		var stdout bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&stdout)
+
+		Expect(contextRemoveCmd.RunE(cmd, []string{"beta"})).To(Succeed())
+
+		cfg, err := LoadConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.GetContext("beta")).To(BeNil())
+		Expect(cfg.GetContext("local")).ToNot(BeNil())
+		Expect(cfg.CurrentContext).To(Equal("local"))
+		Expect(stdout.String()).To(ContainSubstring(`Removed context "beta"`))
+	})
+
+	ginkgo.It("clears the current context when removing it", func() {
+		Expect(SaveConfig(&MCConfig{
+			CurrentContext: "local",
+			Contexts:       []MCContext{{Name: "local", Server: "http://local"}},
+		})).To(Succeed())
+
+		cmd := &cobra.Command{}
+		cmd.SetOut(io.Discard)
+		Expect(contextRemoveCmd.RunE(cmd, []string{"local"})).To(Succeed())
+
+		cfg, err := LoadConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Contexts).To(BeEmpty())
+		Expect(cfg.CurrentContext).To(BeEmpty())
+	})
+
+	ginkgo.It("returns an error for missing contexts", func() {
+		Expect(SaveConfig(&MCConfig{
+			Contexts: []MCContext{{Name: "local", Server: "http://local"}},
+		})).To(Succeed())
+
+		err := contextRemoveCmd.RunE(&cobra.Command{}, []string{"missing"})
+
+		Expect(err).To(MatchError(`context "missing" not found`))
+	})
+})
+
 var _ = ginkgo.Describe("API base resolution", func() {
 	ginkgo.BeforeEach(func() {
 		configDir := ginkgo.GinkgoT().TempDir()

--- a/clientcmd/context_test.go
+++ b/clientcmd/context_test.go
@@ -186,7 +186,29 @@ var _ = ginkgo.Describe("context remove", func() {
 		Expect(stdout.String()).To(ContainSubstring(`Removed context "beta"`))
 	})
 
-	ginkgo.It("clears the current context when removing it", func() {
+	ginkgo.It("switches to the only remaining context when removing the current context", func() {
+		Expect(SaveConfig(&MCConfig{
+			CurrentContext: "local",
+			Contexts: []MCContext{
+				{Name: "local", Server: "http://local"},
+				{Name: "beta", Server: "http://beta"},
+			},
+		})).To(Succeed())
+
+		var stdout bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&stdout)
+		Expect(contextRemoveCmd.RunE(cmd, []string{"local"})).To(Succeed())
+
+		cfg, err := LoadConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Contexts).To(HaveLen(1))
+		Expect(cfg.GetContext("beta")).ToNot(BeNil())
+		Expect(cfg.CurrentContext).To(Equal("beta"))
+		Expect(stdout.String()).To(ContainSubstring(`Switched to context "beta"`))
+	})
+
+	ginkgo.It("clears the current context when no contexts remain", func() {
 		Expect(SaveConfig(&MCConfig{
 			CurrentContext: "local",
 			Contexts:       []MCContext{{Name: "local", Server: "http://local"}},


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3232

Add `faro context remove [name]` to delete saved contexts.

Includes `rm` and `delete` aliases, interactive selection when no name is provided, and clears `current_context` when removing the active context.