### PR TITLE
feat(faro): tidy up output and add json-logs support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
           go-version: 1.26.x
           cache: false
       - run: make -B manifests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For deps
       - run: make auth/oidc/static/tailwind.min.js
       - run: make ui
       - name: golangci-lint

--- a/clientcmd/log.go
+++ b/clientcmd/log.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flanksource/clicky"
 	"github.com/flanksource/commons/logger"
+	"sigs.k8s.io/yaml"
 )
 
 func shouldLogJSON() bool {
@@ -25,6 +26,19 @@ func Log(w io.Writer, data map[string]any) error {
 	out = append(out, '\n')
 
 	_, err := w.Write(out)
+	return err
+}
+
+func LogYAML(w io.Writer, data map[string]any) error {
+	if shouldLogJSON() {
+		return Log(w, data)
+	}
+
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
 	return err
 }
 

--- a/clientcmd/log.go
+++ b/clientcmd/log.go
@@ -1,0 +1,54 @@
+package clientcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/commons/logger"
+)
+
+func shouldLogJSON() bool {
+	return clicky.Flags.JsonLogs || logger.IsJsonLogs()
+}
+
+func writeEvent(w io.Writer, data map[string]any) {
+	_ = WriteEventOutput(w, "", data)
+}
+
+func WriteEventOutput(w io.Writer, file string, data map[string]any) error {
+	var out []byte
+	if shouldLogJSON() {
+		out, _ = json.Marshal(data)
+	} else {
+		out = formatKeyValues(data)
+	}
+	out = append(out, '\n')
+
+	if file != "" {
+		return os.WriteFile(file, out, 0600)
+	}
+	_, err := w.Write(out)
+	return err
+}
+
+func formatKeyValues(data map[string]any) []byte {
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var out bytes.Buffer
+	for i, key := range keys {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%s=%v", key, data[key])
+	}
+	return out.Bytes()
+}

--- a/clientcmd/log.go
+++ b/clientcmd/log.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 
 	"github.com/flanksource/clicky"
@@ -16,11 +15,7 @@ func shouldLogJSON() bool {
 	return clicky.Flags.JsonLogs || logger.IsJsonLogs()
 }
 
-func writeEvent(w io.Writer, data map[string]any) {
-	_ = WriteEventOutput(w, "", data)
-}
-
-func WriteEventOutput(w io.Writer, file string, data map[string]any) error {
+func Log(w io.Writer, data map[string]any) error {
 	var out []byte
 	if shouldLogJSON() {
 		out, _ = json.Marshal(data)
@@ -29,9 +24,6 @@ func WriteEventOutput(w io.Writer, file string, data map[string]any) error {
 	}
 	out = append(out, '\n')
 
-	if file != "" {
-		return os.WriteFile(file, out, 0600)
-	}
 	_, err := w.Write(out)
 	return err
 }

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -27,7 +27,6 @@ var LocalRunHandler func(cmd *cobra.Command, args []string) error
 var (
 	ParamFile string
 	OutFile   string
-	OutFormat string
 )
 
 var (
@@ -41,7 +40,6 @@ var (
 	playbookListComponentID string
 	playbookListCheckID     string
 	playbookListJSON        bool
-	playbookListOutFormat   string
 )
 
 var Run = &cobra.Command{
@@ -81,7 +79,7 @@ var ListPlaybooks = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return savePlaybookList(cmd.OutOrStdout(), items, OutFile, playbookListJSON || playbookListOutFormat == "json")
+		return savePlaybookList(cmd.OutOrStdout(), items, OutFile, playbookListJSON)
 	},
 }
 
@@ -160,16 +158,27 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	playbookRef := item.Namespace + "/" + item.Name
 	if !playbookWait {
-		return SaveOutputToWriter(cmd.OutOrStdout(), response, OutFile, OutFormat)
+		return WriteEventOutput(cmd.OutOrStdout(), OutFile, map[string]any{
+			"type":      "playbook_run_scheduled",
+			"playbook":  playbookRef,
+			"run_id":    response.RunID,
+			"starts_at": response.StartsAt,
+		})
 	}
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "playbook %s/%s run %s scheduled for %s\n", item.Namespace, item.Name, response.RunID, response.StartsAt)
+	writeEvent(cmd.ErrOrStderr(), map[string]any{
+		"type":      "playbook_run_scheduled",
+		"playbook":  playbookRef,
+		"run_id":    response.RunID,
+		"starts_at": response.StartsAt,
+	})
 	summary, err := waitForRemotePlaybookRun(cmd.ErrOrStderr(), client, response.RunID)
 	if err != nil {
 		return err
 	}
-	if err := SaveOutputToWriter(cmd.OutOrStdout(), summary, OutFile, OutFormat); err != nil {
+	if err := WriteEventOutput(cmd.OutOrStdout(), OutFile, PlaybookActionResults(summary)); err != nil {
 		return err
 	}
 	if summary.Run.Status != models.PlaybookRunStatusCompleted {
@@ -187,14 +196,31 @@ func init() {
 	Run.Flags().StringVar(&playbookComponentID, "component-id", "", "Component ID to run the playbook against")
 	Run.Flags().StringVar(&playbookCheckID, "check-id", "", "Check ID to run the playbook against")
 	Run.Flags().StringVarP(&OutFile, "out-file", "o", "", "Write playbook summary to file instead of stdout")
-	Run.Flags().StringVarP(&OutFormat, "out-format", "f", "yaml", "Format of output file or stdout (yaml or json)")
 
 	ListPlaybooks.Flags().StringVar(&playbookListConfigID, "config-id", "", "Only list playbooks runnable for this config ID")
 	ListPlaybooks.Flags().StringVar(&playbookListComponentID, "component-id", "", "Only list playbooks runnable for this component ID")
 	ListPlaybooks.Flags().StringVar(&playbookListCheckID, "check-id", "", "Only list playbooks runnable for this check ID")
 	ListPlaybooks.Flags().StringVarP(&OutFile, "out-file", "o", "", "Write playbook list to file instead of stdout")
 	ListPlaybooks.Flags().BoolVar(&playbookListJSON, "json", false, "Print the full playbook list as JSON")
-	ListPlaybooks.Flags().StringVarP(&playbookListOutFormat, "out-format", "f", "table", "Format of output file or stdout (table or json)")
 
 	Playbook.AddCommand(ListPlaybooks, Run)
+}
+
+func PlaybookActionResults(summary *sdk.PlaybookSummary) map[string]any {
+	if summary == nil || len(summary.Actions) == 0 {
+		return map[string]any{"result": map[string]any{}}
+	}
+
+	if len(summary.Actions) == 1 {
+		return map[string]any{"result": summary.Actions[0].Result}
+	}
+
+	results := make([]map[string]any, 0, len(summary.Actions))
+	for _, action := range summary.Actions {
+		results = append(results, map[string]any{
+			"name":   action.Name,
+			"result": action.Result,
+		})
+	}
+	return map[string]any{"results": results}
 }

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -23,11 +23,8 @@ var Playbook = &cobra.Command{
 // only supports running playbooks by id/name against a remote server.
 var LocalRunHandler func(cmd *cobra.Command, args []string) error
 
-// Shared output flags (read by both the remote client and local execution).
-var (
-	ParamFile string
-	OutFile   string
-)
+// Shared parameter flag (read by both the remote client and local execution).
+var ParamFile string
 
 var (
 	playbookNamespace       string
@@ -79,7 +76,7 @@ var ListPlaybooks = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return savePlaybookList(cmd.OutOrStdout(), items, OutFile, playbookListJSON)
+		return savePlaybookList(cmd.OutOrStdout(), items, playbookListJSON)
 	},
 }
 
@@ -160,7 +157,7 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 
 	playbookRef := item.Namespace + "/" + item.Name
 	if !playbookWait {
-		return WriteEventOutput(cmd.OutOrStdout(), OutFile, map[string]any{
+		return Log(cmd.OutOrStdout(), map[string]any{
 			"type":      "playbook_run_scheduled",
 			"playbook":  playbookRef,
 			"run_id":    response.RunID,
@@ -168,7 +165,7 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	writeEvent(cmd.ErrOrStderr(), map[string]any{
+	Log(cmd.ErrOrStderr(), map[string]any{
 		"type":      "playbook_run_scheduled",
 		"playbook":  playbookRef,
 		"run_id":    response.RunID,
@@ -178,7 +175,7 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := WriteEventOutput(cmd.OutOrStdout(), OutFile, PlaybookActionResults(summary)); err != nil {
+	if err := Log(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
 		return err
 	}
 	if summary.Run.Status != models.PlaybookRunStatusCompleted {
@@ -195,12 +192,10 @@ func init() {
 	Run.Flags().StringVar(&playbookConfigID, "config-id", "", "Config ID to run the playbook against")
 	Run.Flags().StringVar(&playbookComponentID, "component-id", "", "Component ID to run the playbook against")
 	Run.Flags().StringVar(&playbookCheckID, "check-id", "", "Check ID to run the playbook against")
-	Run.Flags().StringVarP(&OutFile, "out-file", "o", "", "Write playbook summary to file instead of stdout")
 
 	ListPlaybooks.Flags().StringVar(&playbookListConfigID, "config-id", "", "Only list playbooks runnable for this config ID")
 	ListPlaybooks.Flags().StringVar(&playbookListComponentID, "component-id", "", "Only list playbooks runnable for this component ID")
 	ListPlaybooks.Flags().StringVar(&playbookListCheckID, "check-id", "", "Only list playbooks runnable for this check ID")
-	ListPlaybooks.Flags().StringVarP(&OutFile, "out-file", "o", "", "Write playbook list to file instead of stdout")
 	ListPlaybooks.Flags().BoolVar(&playbookListJSON, "json", false, "Print the full playbook list as JSON")
 
 	Playbook.AddCommand(ListPlaybooks, Run)

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -165,7 +165,7 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	Log(cmd.ErrOrStderr(), map[string]any{
+	_ = Log(cmd.ErrOrStderr(), map[string]any{
 		"type":      "playbook_run_scheduled",
 		"playbook":  playbookRef,
 		"run_id":    response.RunID,
@@ -175,7 +175,7 @@ func runRemotePlaybook(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := Log(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
+	if err := LogYAML(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
 		return err
 	}
 	if summary.Run.Status != models.PlaybookRunStatusCompleted {

--- a/clientcmd/playbook_cache.go
+++ b/clientcmd/playbook_cache.go
@@ -178,7 +178,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 					"starts_at": response.StartsAt,
 				})
 			}
-			Log(cmd.ErrOrStderr(), map[string]any{
+			_ = Log(cmd.ErrOrStderr(), map[string]any{
 				"type":      "playbook_run_scheduled",
 				"playbook":  ref,
 				"run_id":    response.RunID,
@@ -188,7 +188,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 			if err != nil {
 				return err
 			}
-			if err := Log(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
+			if err := LogYAML(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
 				return err
 			}
 			if summary.Run.Status != "completed" {

--- a/clientcmd/playbook_cache.go
+++ b/clientcmd/playbook_cache.go
@@ -126,7 +126,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	values := map[string]*string{}
 	var wait = true
 	var pollInterval = 2 * time.Second
-	var configID, componentID, checkID, paramFile, outFile string
+	var configID, componentID, checkID, paramFile string
 	short := item.Description
 	if short == "" {
 		short = item.Title
@@ -171,14 +171,14 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 			}
 			ref := playbookRef(item)
 			if !wait {
-				return WriteEventOutput(cmd.OutOrStdout(), outFile, map[string]any{
+				return Log(cmd.OutOrStdout(), map[string]any{
 					"type":      "playbook_run_scheduled",
 					"playbook":  ref,
 					"run_id":    response.RunID,
 					"starts_at": response.StartsAt,
 				})
 			}
-			writeEvent(cmd.ErrOrStderr(), map[string]any{
+			Log(cmd.ErrOrStderr(), map[string]any{
 				"type":      "playbook_run_scheduled",
 				"playbook":  ref,
 				"run_id":    response.RunID,
@@ -188,7 +188,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 			if err != nil {
 				return err
 			}
-			if err := WriteEventOutput(cmd.OutOrStdout(), outFile, PlaybookActionResults(summary)); err != nil {
+			if err := Log(cmd.OutOrStdout(), PlaybookActionResults(summary)); err != nil {
 				return err
 			}
 			if summary.Run.Status != "completed" {
@@ -203,7 +203,6 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	cmd.Flags().StringVar(&componentID, "component-id", "", "Component ID to run the playbook against")
 	cmd.Flags().StringVar(&checkID, "check-id", "", "Check ID to run the playbook against")
 	cmd.Flags().StringVarP(&paramFile, "params", "p", "", "YAML/JSON file containing parameters")
-	cmd.Flags().StringVarP(&outFile, "out-file", "o", "", "Write playbook summary to file instead of stdout")
 	for _, p := range params {
 		if p.Name == "" || cmd.Flags().Lookup(p.Name) != nil {
 			continue

--- a/clientcmd/playbook_cache.go
+++ b/clientcmd/playbook_cache.go
@@ -126,7 +126,7 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	values := map[string]*string{}
 	var wait = true
 	var pollInterval = 2 * time.Second
-	var configID, componentID, checkID, paramFile, outFile, outFormat string
+	var configID, componentID, checkID, paramFile, outFile string
 	short := item.Description
 	if short == "" {
 		short = item.Title
@@ -169,15 +169,26 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 			if err != nil {
 				return err
 			}
+			ref := playbookRef(item)
 			if !wait {
-				return SaveOutputToWriter(cmd.OutOrStdout(), response, outFile, outFormat)
+				return WriteEventOutput(cmd.OutOrStdout(), outFile, map[string]any{
+					"type":      "playbook_run_scheduled",
+					"playbook":  ref,
+					"run_id":    response.RunID,
+					"starts_at": response.StartsAt,
+				})
 			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "playbook %s run %s scheduled for %s\n", playbookRef(item), response.RunID, response.StartsAt)
+			writeEvent(cmd.ErrOrStderr(), map[string]any{
+				"type":      "playbook_run_scheduled",
+				"playbook":  ref,
+				"run_id":    response.RunID,
+				"starts_at": response.StartsAt,
+			})
 			summary, err := waitForRemotePlaybookRunWithInterval(cmd.ErrOrStderr(), client, response.RunID, pollInterval)
 			if err != nil {
 				return err
 			}
-			if err := SaveOutputToWriter(cmd.OutOrStdout(), summary, outFile, outFormat); err != nil {
+			if err := WriteEventOutput(cmd.OutOrStdout(), outFile, PlaybookActionResults(summary)); err != nil {
 				return err
 			}
 			if summary.Run.Status != "completed" {
@@ -193,7 +204,6 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	cmd.Flags().StringVar(&checkID, "check-id", "", "Check ID to run the playbook against")
 	cmd.Flags().StringVarP(&paramFile, "params", "p", "", "YAML/JSON file containing parameters")
 	cmd.Flags().StringVarP(&outFile, "out-file", "o", "", "Write playbook summary to file instead of stdout")
-	cmd.Flags().StringVarP(&outFormat, "out-format", "f", "yaml", "Format of output file or stdout (yaml or json)")
 	for _, p := range params {
 		if p.Name == "" || cmd.Flags().Lookup(p.Name) != nil {
 			continue

--- a/clientcmd/playbook_params.go
+++ b/clientcmd/playbook_params.go
@@ -187,7 +187,7 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 		runStatus := string(summary.Run.Status)
 		isFinal := lo.Contains(models.PlaybookRunStatusFinalStates, summary.Run.Status)
 		if runStatus != lastRunStatus && !isFinal {
-			writeEvent(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
+			Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
 			lastRunStatus = runStatus
 		}
 		for _, action := range summary.Actions {
@@ -200,11 +200,11 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 			if action.Error != nil && *action.Error != "" {
 				event["error"] = *action.Error
 			}
-			writeEvent(stderr, event)
+			Log(stderr, event)
 			lastActions[key] = status
 		}
 		if runStatus != lastRunStatus && isFinal {
-			writeEvent(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
+			Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
 			lastRunStatus = runStatus
 		}
 
@@ -233,7 +233,7 @@ func SaveOutputToWriter(w io.Writer, object any, file string, format string) err
 	return err
 }
 
-func savePlaybookList(w io.Writer, items []api.PlaybookListItem, file string, asJSON bool) error {
+func savePlaybookList(w io.Writer, items []api.PlaybookListItem, asJSON bool) error {
 	var out bytes.Buffer
 	if asJSON {
 		b, _ := json.MarshalIndent(items, "", "  ")
@@ -250,9 +250,6 @@ func savePlaybookList(w io.Writer, items []api.PlaybookListItem, file string, as
 		}
 	}
 
-	if file != "" {
-		return os.WriteFile(file, out.Bytes(), 0600)
-	}
 	_, err := w.Write(out.Bytes())
 	return err
 }

--- a/clientcmd/playbook_params.go
+++ b/clientcmd/playbook_params.go
@@ -185,8 +185,9 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 		}
 
 		runStatus := string(summary.Run.Status)
-		if runStatus != lastRunStatus {
-			fmt.Fprintf(stderr, "run %s status=%s\n", runID, runStatus)
+		isFinal := lo.Contains(models.PlaybookRunStatusFinalStates, summary.Run.Status)
+		if runStatus != lastRunStatus && !isFinal {
+			writeEvent(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
 			lastRunStatus = runStatus
 		}
 		for _, action := range summary.Actions {
@@ -195,15 +196,19 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 			if lastActions[key] == status {
 				continue
 			}
+			event := map[string]any{"type": "playbook_action_status", "action": action.Name, "status": status}
 			if action.Error != nil && *action.Error != "" {
-				fmt.Fprintf(stderr, "action %s status=%s error=%s\n", action.Name, status, *action.Error)
-			} else {
-				fmt.Fprintf(stderr, "action %s status=%s\n", action.Name, status)
+				event["error"] = *action.Error
 			}
+			writeEvent(stderr, event)
 			lastActions[key] = status
 		}
+		if runStatus != lastRunStatus && isFinal {
+			writeEvent(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
+			lastRunStatus = runStatus
+		}
 
-		if lo.Contains(models.PlaybookRunStatusFinalStates, summary.Run.Status) {
+		if isFinal {
 			return summary, nil
 		}
 		time.Sleep(pollInterval)

--- a/clientcmd/playbook_params.go
+++ b/clientcmd/playbook_params.go
@@ -187,7 +187,7 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 		runStatus := string(summary.Run.Status)
 		isFinal := lo.Contains(models.PlaybookRunStatusFinalStates, summary.Run.Status)
 		if runStatus != lastRunStatus && !isFinal {
-			Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
+			_ = Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
 			lastRunStatus = runStatus
 		}
 		for _, action := range summary.Actions {
@@ -200,11 +200,11 @@ func waitForRemotePlaybookRunWithInterval(stderr io.Writer, client *sdk.Client, 
 			if action.Error != nil && *action.Error != "" {
 				event["error"] = *action.Error
 			}
-			Log(stderr, event)
+			_ = Log(stderr, event)
 			lastActions[key] = status
 		}
 		if runStatus != lastRunStatus && isFinal {
-			Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
+			_ = Log(stderr, map[string]any{"type": "playbook_run_status", "run_id": runID, "status": runStatus})
 			lastRunStatus = runStatus
 		}
 

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		actionID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 		var stdout bytes.Buffer
 
-		err := Log(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
+		err := LogYAML(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
 			Playbook: models.Playbook{Namespace: "ops", Name: "diagnose"},
 			Run:      models.PlaybookRun{ID: uuid.New(), Status: models.PlaybookRunStatusCompleted},
 			Actions: []models.PlaybookRunAction{{
@@ -129,9 +129,9 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		}))
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout.String()).To(ContainSubstring("result=map"))
-		Expect(stdout.String()).To(ContainSubstring("code:200"))
-		Expect(stdout.String()).To(ContainSubstring("content:37.59.119.142"))
+		Expect(stdout.String()).To(ContainSubstring("result:"))
+		Expect(stdout.String()).To(ContainSubstring("code: 200"))
+		Expect(stdout.String()).To(ContainSubstring("content: 37.59.119.142"))
 		Expect(stdout.String()).ToNot(ContainSubstring("playbook"))
 		Expect(stdout.String()).ToNot(ContainSubstring("actions"))
 		Expect(stdout.String()).ToNot(ContainSubstring(actionID.String()))
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		clicky.Flags.JsonLogs = true
 		var stdout bytes.Buffer
 
-		err := Log(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
+		err := LogYAML(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
 			Actions: []models.PlaybookRunAction{{
 				Name:   "HTTP Request",
 				Status: models.PlaybookActionStatusCompleted,

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		actionID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 		var stdout bytes.Buffer
 
-		err := WriteEventOutput(&stdout, "", PlaybookActionResults(&sdk.PlaybookSummary{
+		err := Log(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
 			Playbook: models.Playbook{Namespace: "ops", Name: "diagnose"},
 			Run:      models.PlaybookRun{ID: uuid.New(), Status: models.PlaybookRunStatusCompleted},
 			Actions: []models.PlaybookRunAction{{
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		clicky.Flags.JsonLogs = true
 		var stdout bytes.Buffer
 
-		err := WriteEventOutput(&stdout, "", PlaybookActionResults(&sdk.PlaybookSummary{
+		err := Log(&stdout, PlaybookActionResults(&sdk.PlaybookSummary{
 			Actions: []models.PlaybookRunAction{{
 				Name:   "HTTP Request",
 				Status: models.PlaybookActionStatusCompleted,
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 			Category:  "Kubernetes",
 			Namespace: "monitoring",
 			Name:      "restart-pod",
-		}}, "", false)
+		}}, false)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout.String()).To(ContainSubstring("CATEGORY"))
@@ -186,7 +186,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 			Namespace:   "monitoring",
 			Name:        "restart-pod",
 			Description: "Restarts a pod",
-		}}, "", true)
+		}}, true)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout.String()).To(ContainSubstring(`"id": "` + id.String() + `"`))

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/flanksource/clicky"
 	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -23,6 +24,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 	var savedComponentID string
 	var savedCheckID string
 	var savedPollInterval time.Duration
+	var savedJSONLogs bool
 
 	ginkgo.BeforeEach(func() {
 		savedParamFile = ParamFile
@@ -30,6 +32,8 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		savedComponentID = playbookComponentID
 		savedCheckID = playbookCheckID
 		savedPollInterval = playbookPollInterval
+		savedJSONLogs = clicky.Flags.JsonLogs
+		clicky.Flags.JsonLogs = false
 	})
 
 	ginkgo.AfterEach(func() {
@@ -38,6 +42,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		playbookComponentID = savedComponentID
 		playbookCheckID = savedCheckID
 		playbookPollInterval = savedPollInterval
+		clicky.Flags.JsonLogs = savedJSONLogs
 	})
 
 	ginkgo.It("resolves playbook refs by id, namespace/name, and unambiguous name", func() {
@@ -101,8 +106,51 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		summary, err := waitForRemotePlaybookRun(&stderr, sdk.New(server.URL, "fake-token"), runID.String())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(summary.Run.Status).To(Equal(models.PlaybookRunStatusCompleted))
-		Expect(stderr.String()).To(ContainSubstring("run " + runID.String() + " status=completed"))
-		Expect(stderr.String()).To(ContainSubstring("action echo status=completed"))
+		Expect(stderr.String()).To(ContainSubstring("run_id=" + runID.String()))
+		Expect(stderr.String()).To(ContainSubstring("status=completed"))
+		Expect(stderr.String()).To(ContainSubstring("type=playbook_run_status"))
+		Expect(stderr.String()).To(ContainSubstring("action=echo"))
+		Expect(stderr.String()).To(ContainSubstring("type=playbook_action_status"))
+	})
+
+	ginkgo.It("prints only the action result for playbook run summaries", func() {
+		actionID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+		var stdout bytes.Buffer
+
+		err := WriteEventOutput(&stdout, "", PlaybookActionResults(&sdk.PlaybookSummary{
+			Playbook: models.Playbook{Namespace: "ops", Name: "diagnose"},
+			Run:      models.PlaybookRun{ID: uuid.New(), Status: models.PlaybookRunStatusCompleted},
+			Actions: []models.PlaybookRunAction{{
+				ID:     actionID,
+				Name:   "HTTP Request",
+				Status: models.PlaybookActionStatusCompleted,
+				Result: map[string]any{"code": 200, "content": "37.59.119.142"},
+			}},
+		}))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout.String()).To(ContainSubstring("result=map"))
+		Expect(stdout.String()).To(ContainSubstring("code:200"))
+		Expect(stdout.String()).To(ContainSubstring("content:37.59.119.142"))
+		Expect(stdout.String()).ToNot(ContainSubstring("playbook"))
+		Expect(stdout.String()).ToNot(ContainSubstring("actions"))
+		Expect(stdout.String()).ToNot(ContainSubstring(actionID.String()))
+	})
+
+	ginkgo.It("prints action results as JSON when json logs are enabled", func() {
+		clicky.Flags.JsonLogs = true
+		var stdout bytes.Buffer
+
+		err := WriteEventOutput(&stdout, "", PlaybookActionResults(&sdk.PlaybookSummary{
+			Actions: []models.PlaybookRunAction{{
+				Name:   "HTTP Request",
+				Status: models.PlaybookActionStatusCompleted,
+				Result: map[string]any{"code": 200},
+			}},
+		}))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout.String()).To(ContainSubstring(`"result":{"code":200}`))
 	})
 
 	ginkgo.It("prints playbook lists as a compact table by default", func() {

--- a/cmd/playbook.go
+++ b/cmd/playbook.go
@@ -202,7 +202,7 @@ func runLocalPlaybook(cmd *cobra.Command, args []string) error {
 		shutdown.ShutdownAndExit(1, err.Error())
 	}
 
-	if err := clientcmd.Log(cmd.OutOrStdout(), clientcmd.PlaybookActionResults(&sdk.PlaybookSummary{
+	if err := clientcmd.LogYAML(cmd.OutOrStdout(), clientcmd.PlaybookActionResults(&sdk.PlaybookSummary{
 		Playbook: summary.Playbook,
 		Run:      summary.Run,
 		Actions:  summary.Actions,

--- a/cmd/playbook.go
+++ b/cmd/playbook.go
@@ -202,7 +202,7 @@ func runLocalPlaybook(cmd *cobra.Command, args []string) error {
 		shutdown.ShutdownAndExit(1, err.Error())
 	}
 
-	if err := clientcmd.WriteEventOutput(cmd.OutOrStdout(), clientcmd.OutFile, clientcmd.PlaybookActionResults(&sdk.PlaybookSummary{
+	if err := clientcmd.Log(cmd.OutOrStdout(), clientcmd.PlaybookActionResults(&sdk.PlaybookSummary{
 		Playbook: summary.Playbook,
 		Run:      summary.Run,
 		Actions:  summary.Actions,

--- a/cmd/playbook.go
+++ b/cmd/playbook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flanksource/incident-commander/echo"
 	"github.com/flanksource/incident-commander/playbook"
 	"github.com/flanksource/incident-commander/playbook/runner"
+	"github.com/flanksource/incident-commander/sdk"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -201,7 +202,11 @@ func runLocalPlaybook(cmd *cobra.Command, args []string) error {
 		shutdown.ShutdownAndExit(1, err.Error())
 	}
 
-	if err := clientcmd.SaveOutputToWriter(cmd.OutOrStdout(), summary, clientcmd.OutFile, clientcmd.OutFormat); err != nil {
+	if err := clientcmd.WriteEventOutput(cmd.OutOrStdout(), clientcmd.OutFile, clientcmd.PlaybookActionResults(&sdk.PlaybookSummary{
+		Playbook: summary.Playbook,
+		Run:      summary.Run,
+		Actions:  summary.Actions,
+	})); err != nil {
 		shutdown.ShutdownAndExit(1, err.Error())
 	}
 


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playbook command output to consistently follow the `--json` flag, with deterministic non-JSON formatting and structured YAML for results.
* **New Features**
  * Improved playbook run/status logging for both scheduled and completed states (earlier visibility when not waiting).
* **Chores**
  * Removed `--out-file` and `--out-format` from playbook commands; output control is now via `--json`.
  * Standardized progress and action status messages to match the active logging format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->