### PR TITLE
feat(faro): Allow multiple access tokens for the same server

### DIFF
--- a/clientcmd/api_client.go
+++ b/clientcmd/api_client.go
@@ -3,10 +3,10 @@ package clientcmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/flanksource/commons/logger"
+	"github.com/flanksource/incident-commander/auth/oidcclient"
 	"github.com/flanksource/incident-commander/sdk"
 )
 
@@ -15,7 +15,7 @@ func NewAPIClient(mcCtx *MCContext, opts ...sdk.ClientOption) *sdk.Client {
 		return nil
 	}
 	opts = append([]sdk.ClientOption{sdk.WithTokenProvider(contextTokenProvider(mcCtx))}, opts...)
-	return NewAPIClientForServer(mcCtx.Server, mcCtx.Token, opts...)
+	return NewAPIClientForServer(mcCtx.Server, mcCtx.AccessToken(), opts...)
 }
 
 func NewAPIClientForServer(server, token string, opts ...sdk.ClientOption) *sdk.Client {
@@ -27,61 +27,42 @@ func contextTokenProvider(mcCtx *MCContext) sdk.TokenProvider {
 	return func(context.Context) (string, error) {
 		mu.Lock()
 		defer mu.Unlock()
-		return ResolveContextToken(mcCtx)
+		return resolveContextToken(mcCtx)
 	}
 }
 
-func ResolveContextToken(mcCtx *MCContext) (string, error) {
+func resolveContextToken(mcCtx *MCContext) (string, error) {
 	if mcCtx == nil {
 		return "", nil
 	}
-	token := mcCtx.Token
-	if mcCtx.Server == "" {
-		return token, nil
+	if mcCtx.Server == "" || mcCtx.OIDC == nil {
+		return mcCtx.AccessToken(), nil
+	}
+	if !shouldRefreshOIDCToken(mcCtx.OIDC) {
+		return mcCtx.AccessToken(), nil
 	}
 
-	stored, err := loadStoredOIDCTokens(mcCtx.Server)
+	previousAccessToken := mcCtx.OIDC.AccessToken
+	logger.Debugf("refreshing OIDC token for context %q server %s", mcCtx.Name, mcCtx.Server)
+	refreshed, err := refreshOIDCTokens(mcCtx.Server, mcCtx.OIDC)
 	if err != nil {
-		if token != "" || os.IsNotExist(err) {
-			return token, nil
+		logger.Debugf("failed to refresh OIDC token for context %q server %s: %v", mcCtx.Name, mcCtx.Server, err)
+		if mcCtx.Token != "" && mcCtx.Token != previousAccessToken {
+			return mcCtx.Token, nil
 		}
-		return "", fmt.Errorf("failed to load stored tokens for %s: %w", mcCtx.Server, err)
-	}
-	if stored == nil || stored.Tokens == nil {
-		return token, nil
+		return "", fmt.Errorf("refresh OIDC token for %s: %w", mcCtx.Server, err)
 	}
 
-	previousStoredToken := stored.Tokens.AccessToken
-	if shouldRefreshStoredToken(token, previousStoredToken, stored) {
-		logger.Debugf("refreshing OIDC token for context %q server %s", mcCtx.Name, mcCtx.Server)
-		refreshed, err := refreshOIDCTokens(mcCtx.Server, stored)
-		if err != nil {
-			logger.Debugf("failed to refresh OIDC token for context %q server %s: %v", mcCtx.Name, mcCtx.Server, err)
-			if token != "" && token != previousStoredToken {
-				return token, nil
-			}
-			return "", fmt.Errorf("refresh OIDC token for %s: %w", mcCtx.Server, err)
-		}
-		logger.Debugf("refreshed OIDC token for context %q server %s", mcCtx.Name, mcCtx.Server)
-		stored = refreshed
+	logger.Debugf("refreshed OIDC token for context %q server %s", mcCtx.Name, mcCtx.Server)
+	mcCtx.SetOIDCTokens(refreshed)
+	if cfg, err := LoadConfig(); err == nil {
+		updateContextOIDCTokens(cfg, mcCtx.Name, refreshed)
+	} else {
+		return "", fmt.Errorf("failed to update context OIDC tokens: %w", err)
 	}
-
-	if shouldUseStoredOIDCToken(token, previousStoredToken, stored.Tokens) {
-		token = stored.Tokens.AccessToken
-		mcCtx.Token = token
-		if cfg, err := LoadConfig(); err == nil {
-			updateContextToken(cfg, mcCtx.Name, token)
-		} else {
-			return "", fmt.Errorf("failed to update context token: %w", err)
-		}
-	}
-
-	return token, nil
+	return mcCtx.AccessToken(), nil
 }
 
-func shouldRefreshStoredToken(contextToken, previousStoredToken string, stored *storedOIDCToken) bool {
-	if stored == nil || stored.Tokens == nil || !oidcTokenExpiring(stored.Tokens) || stored.Tokens.RefreshToken == "" {
-		return false
-	}
-	return contextToken == "" || contextToken == previousStoredToken || !isMissionControlAccessTokenFormat(contextToken)
+func shouldRefreshOIDCToken(tokens *oidcclient.Tokens) bool {
+	return tokens != nil && oidcTokenExpiring(tokens) && tokens.RefreshToken != ""
 }

--- a/clientcmd/auth_login.go
+++ b/clientcmd/auth_login.go
@@ -2,15 +2,12 @@ package clientcmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -42,65 +39,71 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	loginServerURL := oidcLoginServerCandidates(apiServer)[0]
-
 	if loginToken != "" {
-		path, err := storeTokens(loginServerURL, &oidcclient.Tokens{AccessToken: loginToken})
-		if err != nil {
-			return fmt.Errorf("failed to save token: %w", err)
-		}
-		contextName, err := saveLoginContext(apiServer, loginToken)
+		contextName, err := saveTokenContext(apiServer, loginToken)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Token stored for %s\n", loginServerURL)
-		fmt.Fprintf(cmd.OutOrStdout(), "Tokens saved to: %s\n", path)
+		fmt.Fprintf(cmd.OutOrStdout(), "Token stored for %s\n", apiServer)
 		fmt.Fprintf(cmd.OutOrStdout(), "Context %q saved for %s\n", contextName, apiServer)
 		fmt.Fprintf(cmd.OutOrStdout(), "Run `whoami` to verify connectivity.\n")
 		return nil
 	}
 
-	tokens, tokenPath, err := performOIDCLoginForAPIBase(cmd, apiServer, cmd.OutOrStdout())
+	tokens, err := performOIDCLoginForAPIBase(cmd, apiServer, cmd.OutOrStdout())
 	if err != nil {
 		return err
 	}
-	contextName, err := saveLoginContext(apiServer, tokens.AccessToken)
+	contextName, err := saveLoginContext(apiServer, tokens)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "\nLogin successful!\n\n")
-	fmt.Fprintf(cmd.OutOrStdout(), "Tokens saved to: %s\n", tokenPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "OIDC tokens saved to: %s\n", configPath())
 	fmt.Fprintf(cmd.OutOrStdout(), "Context %q saved for %s\n", contextName, apiServer)
 	fmt.Fprintf(cmd.OutOrStdout(), "Access token expires: %s\n", tokens.ExpiresAt.Format(time.RFC3339))
 
 	return nil
 }
 
-func performOIDCLoginForAPIBase(cmd *cobra.Command, apiServer string, status io.Writer) (*oidcclient.Tokens, string, error) {
+func performOIDCLoginForAPIBase(cmd *cobra.Command, apiServer string, status io.Writer) (*oidcclient.Tokens, error) {
 	var lastErr error
 	for _, loginServer := range oidcLoginServerCandidates(apiServer) {
-		tokens, tokenPath, err := oidcLogin(cmd, loginServer, status)
+		tokens, err := oidcLogin(cmd, loginServer, status)
 		if err == nil {
-			return tokens, tokenPath, nil
+			return tokens, nil
 		}
 		lastErr = err
 	}
-	return nil, "", fmt.Errorf("OIDC login failed for %s: %w", apiServer, lastErr)
+	return nil, fmt.Errorf("OIDC login failed for %s: %w", apiServer, lastErr)
 }
 
-func saveLoginContext(serverURL, token string) (string, error) {
+func saveLoginContext(serverURL string, tokens *oidcclient.Tokens) (string, error) {
+	return saveAuthContext(serverURL, func(ctx *MCContext) {
+		ctx.SetOIDCTokens(tokens)
+	})
+}
+
+func saveTokenContext(serverURL, token string) (string, error) {
+	return saveAuthContext(serverURL, func(ctx *MCContext) {
+		ctx.Token = token
+		ctx.OIDC = nil
+	})
+}
+
+func saveAuthContext(serverURL string, apply func(*MCContext)) (string, error) {
 	cfg, err := LoadConfig()
 	if err != nil {
 		return "", err
 	}
 	name := ServerToContextName(serverURL)
-	ctx := MCContext{Name: name, Server: serverURL, Token: token}
+	ctx := MCContext{Name: name, Server: serverURL}
 	if existing := cfg.GetContext(name); existing != nil {
 		ctx = *existing
 		ctx.Server = serverURL
-		ctx.Token = token
 	}
+	apply(&ctx)
 	cfg.SetContext(ctx)
 	cfg.CurrentContext = name
 	return name, SaveConfig(cfg)
@@ -108,25 +111,25 @@ func saveLoginContext(serverURL, token string) (string, error) {
 
 var oidcLogin = PerformOIDCLogin
 
-func PerformOIDCLogin(cmd *cobra.Command, serverURL string, status io.Writer) (*oidcclient.Tokens, string, error) {
+func PerformOIDCLogin(cmd *cobra.Command, serverURL string, status io.Writer) (*oidcclient.Tokens, error) {
 	if status == nil {
 		status = io.Discard
 	}
 	endpoints, err := oidcclient.Discover(serverURL + "/.well-known/openid-configuration")
 	if err != nil {
-		return nil, "", fmt.Errorf("OIDC discovery failed: %w", err)
+		return nil, fmt.Errorf("OIDC discovery failed: %w", err)
 	}
 
 	verifier, challenge, err := oidcclient.GeneratePKCE()
 	if err != nil {
-		return nil, "", fmt.Errorf("PKCE generation failed: %w", err)
+		return nil, fmt.Errorf("PKCE generation failed: %w", err)
 	}
 	state := oidcclient.RandomBase64(16)
 	nonce := oidcclient.RandomBase64(16)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to start local server: %w", err)
+		return nil, fmt.Errorf("failed to start local server: %w", err)
 	}
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", listener.Addr().(*net.TCPAddr).Port)
 
@@ -189,65 +192,20 @@ func PerformOIDCLogin(cmd *cobra.Command, serverURL string, status io.Writer) (*
 	select {
 	case code = <-codeCh:
 	case err = <-errCh:
-		return nil, "", err
+		return nil, err
 	case <-time.After(5 * time.Minute):
-		return nil, "", fmt.Errorf("login timed out")
+		return nil, fmt.Errorf("login timed out")
 	}
 
 	tokens, err := oidcclient.ExchangeCode(endpoints.TokenEndpoint, code, redirectURI, verifier)
 	if err != nil {
-		return nil, "", fmt.Errorf("token exchange failed: %w", err)
+		return nil, fmt.Errorf("token exchange failed: %w", err)
 	}
 
 	if err := oidcclient.ValidateNonce(tokens.IDToken, nonce); err != nil {
-		return nil, "", fmt.Errorf("nonce validation failed: %w", err)
+		return nil, fmt.Errorf("nonce validation failed: %w", err)
 	}
-
-	tokenPath, err := storeTokens(serverURL, tokens)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to save tokens: %w", err)
-	}
-	return tokens, tokenPath, nil
-}
-
-func storeTokens(serverURL string, tokens *oidcclient.Tokens) (string, error) {
-	path, err := tokenPath(serverURL)
-	if err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return "", err
-	}
-	data, err := json.MarshalIndent(tokens, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return path, os.WriteFile(path, data, 0600)
-}
-
-func tokenPath(serverURL string) (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-	host := strings.NewReplacer("://", "_", "/", "_", ":", "_").Replace(serverURL)
-	return filepath.Join(dir, "mission-control", fmt.Sprintf("tokens_%s.json", host)), nil
-}
-
-func LoadStoredTokens(serverURL string) (*oidcclient.Tokens, error) {
-	path, err := tokenPath(serverURL)
-	if err != nil {
-		return nil, err
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var tokens oidcclient.Tokens
-	if err := json.Unmarshal(data, &tokens); err != nil {
-		return nil, err
-	}
-	return &tokens, nil
+	return tokens, nil
 }
 
 func openBrowser(url string) error {

--- a/clientcmd/auth_login_test.go
+++ b/clientcmd/auth_login_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = ginkgo.Describe("auth login", func() {
-	var oldOIDCLogin func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error)
+	var oldOIDCLogin func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, error)
 
 	ginkgo.BeforeEach(func() {
 		oldOIDCLogin = oidcLogin
@@ -38,10 +38,7 @@ var _ = ginkgo.Describe("auth login", func() {
 		cmd.SetOut(io.Discard)
 		Expect(runAuthLogin(cmd, nil)).To(Succeed())
 
-		stored, err := LoadStoredTokens(server.URL)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stored.AccessToken).To(Equal("my-access-token"))
-		expectLoginContext(server.URL+"/api", "my-access-token")
+		expectTokenContext(server.URL+"/api", "my-access-token")
 	})
 
 	ginkgo.It("stores token contexts with the direct backend base", func() {
@@ -54,10 +51,7 @@ var _ = ginkgo.Describe("auth login", func() {
 		cmd.SetOut(io.Discard)
 		Expect(runAuthLogin(cmd, nil)).To(Succeed())
 
-		stored, err := LoadStoredTokens(server.URL)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stored.AccessToken).To(Equal("tok2"))
-		expectLoginContext(server.URL, "tok2")
+		expectTokenContext(server.URL, "tok2")
 	})
 
 	ginkgo.It("runs OIDC login against the frontend URL for resolved /api contexts", func() {
@@ -66,9 +60,9 @@ var _ = ginkgo.Describe("auth login", func() {
 		loginServer = server.URL
 
 		var gotLoginServer string
-		oidcLogin = func(_ *cobra.Command, server string, _ io.Writer) (*oidcclient.Tokens, string, error) {
+		oidcLogin = func(_ *cobra.Command, server string, _ io.Writer) (*oidcclient.Tokens, error) {
 			gotLoginServer = server
-			return &oidcclient.Tokens{AccessToken: "oauth-token", ExpiresAt: time.Now().Add(time.Hour)}, "tokens.json", nil
+			return &oidcclient.Tokens{AccessToken: "oauth-token", ExpiresAt: time.Now().Add(time.Hour)}, nil
 		}
 
 		cmd := &cobra.Command{}
@@ -76,7 +70,7 @@ var _ = ginkgo.Describe("auth login", func() {
 		Expect(runAuthLogin(cmd, nil)).To(Succeed())
 
 		Expect(gotLoginServer).To(Equal(server.URL))
-		expectLoginContext(server.URL+"/api", "oauth-token")
+		expectOIDCContext(server.URL+"/api", "oauth-token")
 	})
 })
 
@@ -97,7 +91,20 @@ func authHealthServer(frontend bool) *httptest.Server {
 	}))
 }
 
-func expectLoginContext(serverURL, token string) {
+func expectTokenContext(serverURL, token string) {
+	ctx := expectContext(serverURL)
+	Expect(ctx.Token).To(Equal(token))
+	Expect(ctx.OIDC).To(BeNil())
+}
+
+func expectOIDCContext(serverURL, token string) {
+	ctx := expectContext(serverURL)
+	Expect(ctx.Token).To(BeEmpty())
+	Expect(ctx.OIDC).ToNot(BeNil())
+	Expect(ctx.OIDC.AccessToken).To(Equal(token))
+}
+
+func expectContext(serverURL string) *MCContext {
 	cfg, err := LoadConfig()
 	Expect(err).ToNot(HaveOccurred())
 	name := ServerToContextName(serverURL)
@@ -105,5 +112,5 @@ func expectLoginContext(serverURL, token string) {
 	ctx := cfg.GetContext(name)
 	Expect(ctx).ToNot(BeNil())
 	Expect(ctx.Server).To(Equal(serverURL))
-	Expect(ctx.Token).To(Equal(token))
+	return ctx
 }

--- a/clientcmd/cache.go
+++ b/clientcmd/cache.go
@@ -191,7 +191,7 @@ func refreshCurrentContextCache(ctx gocontext.Context, force bool) (*ContextCach
 		return result, nil
 	}
 
-	token, err := ResolveContextToken(mc)
+	token, err := resolveContextToken(mc)
 	if err != nil {
 		return result, err
 	}

--- a/clientcmd/context.go
+++ b/clientcmd/context.go
@@ -13,15 +13,17 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/flanksource/incident-commander/auth/oidcclient"
 	"github.com/spf13/cobra"
 )
 
 type MCContext struct {
-	Name       string            `json:"name"`
-	Server     string            `json:"server,omitempty"`
-	DB         string            `json:"db,omitempty"`
-	Token      string            `json:"token,omitempty"`
-	Properties map[string]string `json:"properties,omitempty"`
+	Name       string             `json:"name"`
+	Server     string             `json:"server,omitempty"`
+	DB         string             `json:"db,omitempty"`
+	Token      string             `json:"token,omitempty"`
+	OIDC       *oidcclient.Tokens `json:"oidc,omitempty"`
+	Properties map[string]string  `json:"properties,omitempty"`
 }
 
 type MCConfig struct {
@@ -133,7 +135,39 @@ func ContextHasAPI() (*MCContext, bool) {
 		return nil, false
 	}
 	ctx := cfg.CurrentMCContext()
-	return ctx, ctx != nil && ctx.Server != "" && ctx.Token != ""
+	return ctx, ctx != nil && ctx.Server != "" && ctx.HasAuth()
+}
+
+func (c *MCContext) HasAuth() bool {
+	return c != nil && (c.AccessToken() != "" || (c.OIDC != nil && c.OIDC.RefreshToken != ""))
+}
+
+func (c *MCContext) AccessToken() string {
+	if c == nil {
+		return ""
+	}
+	if c.OIDC != nil && c.OIDC.AccessToken != "" {
+		return c.OIDC.AccessToken
+	}
+	return c.Token
+}
+
+func (c *MCContext) SetOIDCTokens(tokens *oidcclient.Tokens) {
+	if c == nil {
+		return
+	}
+	c.OIDC = cloneOIDCTokens(tokens)
+	if tokens != nil && tokens.AccessToken != "" {
+		c.Token = ""
+	}
+}
+
+func cloneOIDCTokens(tokens *oidcclient.Tokens) *oidcclient.Tokens {
+	if tokens == nil {
+		return nil
+	}
+	clone := *tokens
+	return &clone
 }
 
 var ContextCmd = &cobra.Command{
@@ -332,14 +366,19 @@ Examples:
 				return err
 			}
 			ctx.Server = server
+			if !cmd.Flags().Changed("token") {
+				ctx.Token = ""
+				ctx.OIDC = nil
+			}
 		}
 		if cmd.Flags().Changed("db-url") {
 			ctx.DB = contextAddDB
 		}
 		if cmd.Flags().Changed("token") {
 			ctx.Token = contextAddToken
+			ctx.OIDC = nil
 		}
-		if ctx.Server != "" && !cmd.Flags().Changed("token") && (ctx.Token == "" || cmd.Flags().Changed("server")) {
+		if ctx.Server != "" && !cmd.Flags().Changed("token") && !ctx.HasAuth() {
 			if err := EnsureContextToken(cmd, &ctx, cmd.ErrOrStderr()); err != nil {
 				return err
 			}
@@ -367,41 +406,26 @@ Examples:
 }
 
 func EnsureContextToken(cmd *cobra.Command, ctx *MCContext, status io.Writer) error {
-	if ctx == nil || ctx.Server == "" || ctx.Token != "" {
+	if ctx == nil || ctx.Server == "" || ctx.AccessToken() != "" {
 		return nil
 	}
-	if token, err := storedAccessToken(ctx.Server); err == nil && token != "" {
-		ctx.Token = token
-		return nil
-	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to load stored tokens for %s: %w", ctx.Server, err)
+	if ctx.OIDC != nil && ctx.OIDC.RefreshToken != "" {
+		if token, err := resolveContextToken(ctx); err == nil && token != "" {
+			return nil
+		}
 	}
 
 	var lastErr error
 	for _, loginServer := range oidcLoginServerCandidates(ctx.Server) {
 		fmt.Fprintf(status, "No token configured for context %q; starting OIDC login for %s\n", ctx.Name, loginServer)
-		tokens, _, err := oidcLogin(cmd, loginServer, status)
+		tokens, err := oidcLogin(cmd, loginServer, status)
 		if err == nil {
-			ctx.Token = tokens.AccessToken
+			ctx.SetOIDCTokens(tokens)
 			return nil
 		}
 		lastErr = err
 	}
 	return fmt.Errorf("OAuth login failed for %s: %w", ctx.Server, lastErr)
-}
-
-func storedAccessToken(serverURL string) (string, error) {
-	stored, err := loadStoredOIDCTokens(serverURL)
-	if err != nil {
-		return "", err
-	}
-	if stored == nil || stored.Tokens == nil || stored.Tokens.AccessToken == "" {
-		return "", nil
-	}
-	if !stored.Tokens.ExpiresAt.IsZero() && time.Until(stored.Tokens.ExpiresAt) < time.Minute {
-		return "", nil
-	}
-	return stored.Tokens.AccessToken, nil
 }
 
 func oidcLoginServerCandidates(serverURL string) []string {

--- a/clientcmd/context_test.go
+++ b/clientcmd/context_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = ginkgo.Describe("context token resolution", func() {
-	var oldOIDCLogin func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error)
+	var oldOIDCLogin func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, error)
 
 	ginkgo.BeforeEach(func() {
 		oldOIDCLogin = oidcLogin
@@ -28,41 +28,41 @@ var _ = ginkgo.Describe("context token resolution", func() {
 
 	ginkgo.AfterEach(func() {
 		oidcLogin = oldOIDCLogin
+		contextAddName = ""
+		contextAddServer = ""
+		contextAddDB = ""
+		contextAddToken = ""
+		contextAddUse = false
 	})
 
-	ginkgo.It("reuses a stored access token before starting OIDC login", func() {
+	ginkgo.It("uses embedded OIDC tokens before starting OIDC login", func() {
 		server := "http://mission-control.local"
-		_, err := storeTokens(server, &oidcclient.Tokens{
-			AccessToken: "stored-token",
-			ExpiresAt:   time.Now().Add(time.Hour),
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		oidcLogin = func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error) {
-			return nil, "", fmt.Errorf("unexpected login")
+		oidcLogin = func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, error) {
+			return nil, fmt.Errorf("unexpected login")
 		}
 
-		ctx := &MCContext{Name: "local", Server: server}
+		ctx := &MCContext{Name: "local", Server: server, OIDC: &oidcclient.Tokens{AccessToken: "stored-token"}}
 		Expect(EnsureContextToken(&cobra.Command{}, ctx, io.Discard)).To(Succeed())
-		Expect(ctx.Token).To(Equal("stored-token"))
+		Expect(ctx.AccessToken()).To(Equal("stored-token"))
 	})
 
 	ginkgo.It("starts OIDC login when no usable token is available", func() {
 		var stderr bytes.Buffer
-		oidcLogin = func(_ *cobra.Command, server string, status io.Writer) (*oidcclient.Tokens, string, error) {
+		oidcLogin = func(_ *cobra.Command, server string, status io.Writer) (*oidcclient.Tokens, error) {
 			Expect(server).To(Equal("http://mission-control.local"))
 			fmt.Fprint(status, "login started")
-			return &oidcclient.Tokens{AccessToken: "oauth-token"}, "", nil
+			return &oidcclient.Tokens{AccessToken: "oauth-token"}, nil
 		}
 
 		ctx := &MCContext{Name: "local", Server: "http://mission-control.local"}
 		Expect(EnsureContextToken(&cobra.Command{}, ctx, &stderr)).To(Succeed())
-		Expect(ctx.Token).To(Equal("oauth-token"))
+		Expect(ctx.Token).To(BeEmpty())
+		Expect(ctx.OIDC.AccessToken).To(Equal("oauth-token"))
 		Expect(stderr.String()).To(ContainSubstring("starting OIDC login"))
 		Expect(stderr.String()).To(ContainSubstring("login started"))
 	})
 
-	ginkgo.It("refreshes expiring stored OIDC tokens for API clients", func() {
+	ginkgo.It("refreshes expiring embedded OIDC tokens for API clients", func() {
 		var tokenRequests int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
@@ -96,63 +96,123 @@ var _ = ginkgo.Describe("context token resolution", func() {
 			Contexts: []MCContext{{
 				Name:   "local",
 				Server: server.URL,
-				Token:  "old-token",
+				OIDC: &oidcclient.Tokens{
+					AccessToken:  "old-token",
+					RefreshToken: "refresh-token",
+					ExpiresAt:    time.Now().Add(-time.Minute),
+				},
 			}},
 		}
 		Expect(SaveConfig(cfg)).To(Succeed())
-		_, err := storeTokens(server.URL, &oidcclient.Tokens{
-			AccessToken:  "old-token",
-			RefreshToken: "refresh-token",
-			ExpiresAt:    time.Now().Add(-time.Minute),
-		})
-		Expect(err).ToNot(HaveOccurred())
 
 		mcCtx := cfg.GetContext("local")
 		token, err := contextTokenProvider(mcCtx)(context.Background())
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(token).To(Equal("new-token"))
-		Expect(mcCtx.Token).To(Equal("new-token"))
+		Expect(mcCtx.Token).To(BeEmpty())
+		Expect(mcCtx.OIDC.AccessToken).To(Equal("new-token"))
+		Expect(mcCtx.OIDC.RefreshToken).To(Equal("next-refresh-token"))
 		Expect(tokenRequests).To(Equal(1))
-
-		stored, err := LoadStoredTokens(server.URL)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stored.AccessToken).To(Equal("new-token"))
-		Expect(stored.RefreshToken).To(Equal("next-refresh-token"))
 
 		reloaded, err := LoadConfig()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(reloaded.GetContext("local").Token).To(Equal("new-token"))
-	})
-
-	ginkgo.It("reuses frontend OIDC tokens for resolved /api contexts", func() {
-		server := "http://mission-control.local"
-		_, err := storeTokens(server, &oidcclient.Tokens{
-			AccessToken: "stored-token",
-			ExpiresAt:   time.Now().Add(time.Hour),
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		oidcLogin = func(*cobra.Command, string, io.Writer) (*oidcclient.Tokens, string, error) {
-			return nil, "", fmt.Errorf("unexpected login")
-		}
-
-		ctx := &MCContext{Name: "local", Server: server + "/api"}
-		Expect(EnsureContextToken(&cobra.Command{}, ctx, io.Discard)).To(Succeed())
-		Expect(ctx.Token).To(Equal("stored-token"))
+		Expect(reloaded.GetContext("local").Token).To(BeEmpty())
+		Expect(reloaded.GetContext("local").OIDC.AccessToken).To(Equal("new-token"))
 	})
 
 	ginkgo.It("starts OIDC login against the frontend URL for resolved /api contexts", func() {
 		var loginServer string
-		oidcLogin = func(_ *cobra.Command, server string, status io.Writer) (*oidcclient.Tokens, string, error) {
+		oidcLogin = func(_ *cobra.Command, server string, status io.Writer) (*oidcclient.Tokens, error) {
 			loginServer = server
-			return &oidcclient.Tokens{AccessToken: "oauth-token"}, "", nil
+			return &oidcclient.Tokens{AccessToken: "oauth-token"}, nil
 		}
 
 		ctx := &MCContext{Name: "local", Server: "http://mission-control.local/api"}
 		Expect(EnsureContextToken(&cobra.Command{}, ctx, io.Discard)).To(Succeed())
-		Expect(ctx.Token).To(Equal("oauth-token"))
+		Expect(ctx.OIDC.AccessToken).To(Equal("oauth-token"))
 		Expect(loginServer).To(Equal("http://mission-control.local"))
+	})
+
+	ginkgo.It("uses a manual context token when no OIDC tokens are configured", func() {
+		ctx := &MCContext{Name: "user-b", Server: "http://mission-control.local", Token: "user-b.jwt.token"}
+		token, err := resolveContextToken(ctx)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token).To(Equal("user-b.jwt.token"))
+		Expect(ctx.Token).To(Equal("user-b.jwt.token"))
+	})
+
+	ginkgo.It("uses embedded OIDC tokens for same-server contexts", func() {
+		server := "http://mission-control.local"
+		cfg := &MCConfig{Contexts: []MCContext{
+			{Name: "user-a", Server: server, OIDC: &oidcclient.Tokens{AccessToken: "user-a.jwt.token", ExpiresAt: time.Now().Add(time.Hour)}},
+			{Name: "user-b", Server: server, OIDC: &oidcclient.Tokens{AccessToken: "user-b.jwt.token", ExpiresAt: time.Now().Add(time.Hour)}},
+		}}
+
+		ctx := cfg.GetContext("user-a")
+		token, err := resolveContextToken(ctx)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token).To(Equal("user-a.jwt.token"))
+		Expect(ctx.OIDC.AccessToken).To(Equal("user-a.jwt.token"))
+	})
+
+	ginkgo.It("starts a fresh OIDC login when adding another context for the same server", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/health" {
+				_, _ = w.Write([]byte("OK"))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		Expect(SaveConfig(&MCConfig{
+			CurrentContext: "admin",
+			Contexts: []MCContext{{
+				Name:   "admin",
+				Server: server.URL + "/api",
+				OIDC: &oidcclient.Tokens{
+					AccessToken:  "admin.jwt.token",
+					RefreshToken: "admin-refresh-token",
+					ExpiresAt:    time.Now().Add(time.Hour),
+				},
+			}},
+		})).To(Succeed())
+
+		var loginCount int
+		oidcLogin = func(_ *cobra.Command, loginServer string, _ io.Writer) (*oidcclient.Tokens, error) {
+			loginCount++
+			Expect(loginServer).To(Equal(server.URL))
+			return &oidcclient.Tokens{
+				AccessToken:  "viewer.jwt.token",
+				RefreshToken: "viewer-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}, nil
+		}
+
+		contextAddName = "viewer"
+		contextAddServer = server.URL
+		contextAddUse = true
+
+		cmd := &cobra.Command{}
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.Flags().String("server", "", "")
+		cmd.Flags().String("token", "", "")
+		cmd.Flags().String("db-url", "", "")
+		Expect(cmd.Flags().Set("server", server.URL)).To(Succeed())
+
+		Expect(contextAddCmd.RunE(cmd, nil)).To(Succeed())
+
+		Expect(loginCount).To(Equal(1))
+		cfg, err := LoadConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.CurrentContext).To(Equal("viewer"))
+		Expect(cfg.GetContext("admin").OIDC.AccessToken).To(Equal("admin.jwt.token"))
+		Expect(cfg.GetContext("viewer").Token).To(BeEmpty())
+		Expect(cfg.GetContext("viewer").OIDC.AccessToken).To(Equal("viewer.jwt.token"))
 	})
 })
 

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -97,7 +97,7 @@ func currentAPIContext(cmd *cobra.Command) (*MCContext, error) {
 	if mcCtx.Server == "" {
 		return nil, fmt.Errorf("current context %q must define a server for API playbook commands", mcCtx.Name)
 	}
-	if mcCtx.Token == "" {
+	if !mcCtx.HasAuth() {
 		if err := EnsureContextToken(cmd, mcCtx, cmd.ErrOrStderr()); err != nil {
 			return nil, err
 		}

--- a/clientcmd/whoami.go
+++ b/clientcmd/whoami.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/flanksource/duty"
 	dutyAPI "github.com/flanksource/duty/api"
-	"github.com/flanksource/incident-commander/auth/oidcclient"
 	"github.com/flanksource/incident-commander/sdk"
 	"github.com/spf13/cobra"
 )
@@ -79,12 +77,6 @@ type accessTokenStatus struct {
 	Status      string `json:"status"`
 	Error       string `json:"error,omitempty"`
 	expiresTime *time.Time
-}
-
-type storedOIDCToken struct {
-	Tokens *oidcclient.Tokens
-	Server string
-	Path   string
 }
 
 func runWhoami(cmd *cobra.Command, _ []string) error {
@@ -202,41 +194,32 @@ func probeAuth(parent gocontext.Context, cfg *MCConfig, mcCtx *MCContext, dbConn
 
 	out.Configured = true
 	out.Server = mcCtx.Server
-	token := mcCtx.Token
-	if token != "" {
-		out.TokenSource = "context"
-	}
-
-	stored, storedErr := loadStoredOIDCTokens(mcCtx.Server)
-	if storedErr != nil && !os.IsNotExist(storedErr) {
-		out.RefreshStatus = "stored OIDC token unavailable: " + storedErr.Error()
-	}
-	if stored != nil && stored.Tokens != nil {
-		oldAccessToken := stored.Tokens.AccessToken
-		out.TokenExpires = formatTime(stored.Tokens.ExpiresAt)
-		out.TokenTTL = formatTTL(stored.Tokens.ExpiresAt)
-		if refresh && oidcTokenExpiring(stored.Tokens) && stored.Tokens.RefreshToken != "" {
-			refreshed, err := refreshOIDCTokens(mcCtx.Server, stored)
+	token := mcCtx.AccessToken()
+	if mcCtx.OIDC != nil {
+		out.TokenSource = "oidc"
+		out.TokenExpires = formatTime(mcCtx.OIDC.ExpiresAt)
+		out.TokenTTL = formatTTL(mcCtx.OIDC.ExpiresAt)
+		if refresh && oidcTokenExpiring(mcCtx.OIDC) && mcCtx.OIDC.RefreshToken != "" {
+			refreshed, err := refreshOIDCTokens(mcCtx.Server, mcCtx.OIDC)
 			if err != nil {
 				out.RefreshStatus = "failed: " + err.Error()
 			} else {
-				stored = refreshed
+				mcCtx.SetOIDCTokens(refreshed)
+				token = mcCtx.AccessToken()
 				out.RefreshStatus = "refreshed"
-				out.TokenExpires = formatTime(stored.Tokens.ExpiresAt)
-				out.TokenTTL = formatTTL(stored.Tokens.ExpiresAt)
+				out.TokenExpires = formatTime(mcCtx.OIDC.ExpiresAt)
+				out.TokenTTL = formatTTL(mcCtx.OIDC.ExpiresAt)
+				updateContextOIDCTokens(cfg, mcCtx.Name, refreshed)
 			}
-		} else if oidcTokenExpiring(stored.Tokens) && stored.Tokens.RefreshToken == "" {
+		} else if oidcTokenExpiring(mcCtx.OIDC) && mcCtx.OIDC.RefreshToken == "" {
 			out.RefreshStatus = "unavailable: no refresh token"
-		} else if oidcTokenExpiring(stored.Tokens) {
+		} else if oidcTokenExpiring(mcCtx.OIDC) {
 			out.RefreshStatus = "needed"
 		} else {
 			out.RefreshStatus = "not needed"
 		}
-		if shouldUseStoredOIDCToken(token, oldAccessToken, stored.Tokens) {
-			token = stored.Tokens.AccessToken
-			out.TokenSource = "stored_oidc"
-			updateContextToken(cfg, mcCtx.Name, token)
-		}
+	} else if token != "" {
+		out.TokenSource = "context"
 	}
 
 	if token == "" {
@@ -331,5 +314,5 @@ func whoamiEndpointCandidates(server string) []string {
 
 func init() {
 	WhoamiCmd.Flags().BoolVar(&whoamiJSON, "json", false, "Print status as JSON")
-	WhoamiCmd.Flags().BoolVar(&whoamiRefresh, "refresh", true, "Refresh stored OIDC tokens before validating")
+	WhoamiCmd.Flags().BoolVar(&whoamiRefresh, "refresh", true, "Refresh OIDC tokens before validating")
 }

--- a/clientcmd/whoami_test.go
+++ b/clientcmd/whoami_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"time"
 
-	"github.com/flanksource/incident-commander/auth/oidcclient"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -64,27 +62,5 @@ var _ = ginkgo.Describe("whoami command", func() {
 			Auth:     whoamiAuth{Status: "invalid"},
 		})
 		Expect(err).To(MatchError("whoami status failed: database=ok auth=invalid"))
-	})
-
-	ginkgo.It("prefers a valid stored OIDC token over a stale context JWT", func() {
-		Expect(shouldUseStoredOIDCToken(
-			"old.jwt.token",
-			"previous.jwt.token",
-			&oidcclient.Tokens{
-				AccessToken: "fresh.jwt.token",
-				ExpiresAt:   time.Now().Add(time.Hour),
-			},
-		)).To(BeTrue())
-	})
-
-	ginkgo.It("does not replace Mission Control access tokens with stored OIDC tokens", func() {
-		Expect(shouldUseStoredOIDCToken(
-			"password.salt.1.8192.1",
-			"previous.jwt.token",
-			&oidcclient.Tokens{
-				AccessToken: "fresh.jwt.token",
-				ExpiresAt:   time.Now().Add(time.Hour),
-			},
-		)).To(BeFalse())
 	})
 })

--- a/clientcmd/whoami_text.go
+++ b/clientcmd/whoami_text.go
@@ -205,12 +205,3 @@ func uniqueStrings(values []string) []string {
 	}
 	return out
 }
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
-}

--- a/clientcmd/whoami_token.go
+++ b/clientcmd/whoami_token.go
@@ -15,24 +15,6 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-func loadStoredOIDCTokens(server string) (*storedOIDCToken, error) {
-	var firstErr error
-	for _, candidate := range oidcServerCandidates(server) {
-		tokens, err := LoadStoredTokens(candidate)
-		if err == nil {
-			path, _ := tokenPath(candidate)
-			return &storedOIDCToken{Tokens: tokens, Server: candidate, Path: path}, nil
-		}
-		if firstErr == nil {
-			firstErr = err
-		}
-	}
-	if firstErr == nil {
-		firstErr = os.ErrNotExist
-	}
-	return nil, firstErr
-}
-
 func oidcServerCandidates(server string) []string {
 	server = strings.TrimRight(server, "/")
 	candidates := []string{server}
@@ -49,62 +31,48 @@ func oidcTokenExpiring(tokens *oidcclient.Tokens) bool {
 	return tokens.AccessToken == "" || (!tokens.ExpiresAt.IsZero() && time.Until(tokens.ExpiresAt) < time.Minute)
 }
 
-func shouldUseStoredOIDCToken(contextToken, previousStoredToken string, tokens *oidcclient.Tokens) bool {
-	if tokens == nil || tokens.AccessToken == "" || oidcTokenExpiring(tokens) {
-		return false
+func refreshOIDCTokens(server string, tokens *oidcclient.Tokens) (*oidcclient.Tokens, error) {
+	if tokens == nil {
+		return nil, fmt.Errorf("no OIDC tokens")
 	}
-	if contextToken == "" || contextToken == previousStoredToken {
-		return true
-	}
-	return !isMissionControlAccessTokenFormat(contextToken)
-}
-
-func refreshOIDCTokens(server string, stored *storedOIDCToken) (*storedOIDCToken, error) {
-	if stored == nil || stored.Tokens == nil {
-		return nil, fmt.Errorf("no stored OIDC tokens")
-	}
-	if stored.Tokens.RefreshToken == "" {
+	if tokens.RefreshToken == "" {
 		return nil, fmt.Errorf("no refresh token")
 	}
 
 	var lastErr error
-	for _, candidate := range oidcServerCandidates(firstNonEmpty(stored.Server, server)) {
+	for _, candidate := range oidcServerCandidates(server) {
 		endpoints, err := oidcclient.Discover(strings.TrimRight(candidate, "/") + "/.well-known/openid-configuration")
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		refreshed, err := oidcclient.RefreshToken(endpoints.TokenEndpoint, stored.Tokens.RefreshToken)
+		refreshed, err := oidcclient.RefreshToken(endpoints.TokenEndpoint, tokens.RefreshToken)
 		if err != nil {
 			lastErr = err
 			continue
 		}
 		if refreshed.RefreshToken == "" {
-			refreshed.RefreshToken = stored.Tokens.RefreshToken
+			refreshed.RefreshToken = tokens.RefreshToken
 		}
 		if refreshed.IDToken == "" {
-			refreshed.IDToken = stored.Tokens.IDToken
+			refreshed.IDToken = tokens.IDToken
 		}
-		path, err := storeTokens(candidate, refreshed)
-		if err != nil {
-			return nil, err
-		}
-		return &storedOIDCToken{Tokens: refreshed, Server: candidate, Path: path}, nil
+		return refreshed, nil
 	}
 	return nil, lastErr
 }
 
-func updateContextToken(cfg *MCConfig, name, token string) {
-	if cfg == nil || name == "" || token == "" {
+func updateContextOIDCTokens(cfg *MCConfig, name string, tokens *oidcclient.Tokens) {
+	if cfg == nil || name == "" || tokens == nil {
 		return
 	}
 	ctx := cfg.GetContext(name)
-	if ctx == nil || ctx.Token == token {
+	if ctx == nil {
 		return
 	}
-	ctx.Token = token
+	ctx.SetOIDCTokens(tokens)
 	if err := SaveConfig(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to update context token: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to update context OIDC tokens: %v\n", err)
 	}
 }
 
@@ -183,23 +151,6 @@ func hashMissionControlAccessToken(token string) (string, error) {
 
 	hash := argon2.IDKey([]byte(fields[0]), []byte(fields[1]), timeCost, memoryCost, parallelism, 20)
 	return base64.URLEncoding.EncodeToString(hash), nil
-}
-
-func isMissionControlAccessTokenFormat(token string) bool {
-	fields := strings.Split(token, ".")
-	if len(fields) != 5 {
-		return false
-	}
-	if _, err := parseUint32(fields[2]); err != nil {
-		return false
-	}
-	if _, err := parseUint32(fields[3]); err != nil {
-		return false
-	}
-	if _, err := parseUint8(fields[4]); err != nil {
-		return false
-	}
-	return true
 }
 
 func parseUint32(s string) (uint32, error) {


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3235

Remove the need to store refreshtoken and id_token in a different file. It was adding an overhead to coordinate contexts with files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined authentication token management by consolidating storage within the context configuration system.
  * OIDC tokens are now persisted alongside context data instead of separate files, improving consistency.
  * Enhanced token resolution to automatically refresh credentials when approaching expiration.
  * Unified token access across CLI commands through improved context integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->