### PR TITLE
fix(playbook): do not treat db errors separately in run setup

### DIFF
--- a/playbook/runner/runner.go
+++ b/playbook/runner/runner.go
@@ -454,13 +454,6 @@ func RunAction(ctx context.Context, run *models.PlaybookRun, action *models.Play
 	defer span.End()
 
 	if err := TemplateAndExecuteAction(ctx, spec, playbook, run, action); err != nil {
-		if e, ok := oops.AsOops(err); ok {
-			if lo.Contains(e.Tags(), "db") {
-				// DB errors are retryable
-				return err
-			}
-		}
-
 		if ctx.IsTrace() {
 			ctx.Errorf("action failed: %+v", err)
 		} else if ctx.IsDebug() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated playbook action error handling to treat all error types consistently.
  * Removed the special-case for certain database-tagged “oops” errors.
  * Failures are now always logged according to the configured verbosity and the action is marked as failed before returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->