### PR TITLE
fix(faro): avoid server UI dependency for connection route registration

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/application"
 	"github.com/flanksource/incident-commander/auth"
+	"github.com/flanksource/incident-commander/connection"
 	"github.com/flanksource/incident-commander/db"
 	"github.com/flanksource/incident-commander/echo"
 	"github.com/flanksource/incident-commander/events"
@@ -40,7 +41,6 @@ import (
 	// register event handlers & echo routers
 	_ "github.com/flanksource/incident-commander/artifacts"
 	_ "github.com/flanksource/incident-commander/catalog"
-	_ "github.com/flanksource/incident-commander/connection"
 	_ "github.com/flanksource/incident-commander/playbook"
 	_ "github.com/flanksource/incident-commander/plugin/gateway"
 	_ "github.com/flanksource/incident-commander/shorturl"
@@ -51,6 +51,10 @@ import (
 	"github.com/flanksource/incident-commander/vars"
 	"github.com/flanksource/incident-commander/views"
 )
+
+func init() {
+	echo.RegisterRoutes(connection.RegisterRoutes)
+}
 
 func launchKopper(ctx context.Context) {
 	mgr, err := kopper.Manager(&kopper.ManagerOptions{

--- a/connection/controllers.go
+++ b/connection/controllers.go
@@ -14,13 +14,8 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/flanksource/incident-commander/db"
-	echoSrv "github.com/flanksource/incident-commander/echo"
 	"github.com/flanksource/incident-commander/rbac"
 )
-
-func init() {
-	echoSrv.RegisterRoutes(RegisterRoutes)
-}
 
 func RegisterRoutes(e *echo.Echo) {
 	logger.Infof("Registering /connection routes")


### PR DESCRIPTION
## Summary

The `connection` package was registering its Echo routes via an `init()` function that imported `echoSrv` (the server UI package). This created an implicit dependency on the server UI from the connection package, which caused issues when the connection package was used outside of the full server context (e.g. Faro).

## Changes

- Removed the `init()` function from `connection/controllers.go` that auto-registered routes by side-effect import.
- Explicitly register the connection routes in `cmd/server.go` using `echo.RegisterRoutes(connection.RegisterRoutes)`, alongside other route registrations.
- Removed the blank side-effect import `_ "github.com/flanksource/incident-commander/connection"` from `cmd/server.go` and replaced it with a direct import.

## Why

Keeping route registration inside the `connection` package via `init()` coupled it to the Echo server infrastructure at import time. Moving registration to `cmd/server.go` keeps the connection package free of server UI dependencies and makes route registration explicit and easier to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized route registration initialization flow for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->