### PR TITLE
fix(oidc): include subject claim in ID token

### DIFF
--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -220,7 +220,8 @@ func (s *Storage) AuthorizeClientIDSecret(_ gocontext.Context, _, _ string) erro
 	return nil // public client, no secret
 }
 
-func (s *Storage) SetUserinfoFromScopes(_ gocontext.Context, _ *oidc.UserInfo, _, _ string, _ []string) error {
+func (s *Storage) SetUserinfoFromScopes(_ gocontext.Context, userinfo *oidc.UserInfo, subject, _ string, _ []string) error {
+	userinfo.Subject = subject
 	return nil // deprecated
 }
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -24,6 +24,7 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	oidclib "github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/oidc/v3/pkg/op"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/flanksource/incident-commander/vars"
@@ -187,6 +188,31 @@ var _ = ginkgo.Describe("OIDC", func() {
 			rt, err := provider.Storage.TokenRequestByRefreshToken(gocontext.TODO(), refreshToken)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rt.GetSubject()).To(Equal(person.ID.String()))
+		})
+
+		ginkgo.It("includes subject in id tokens", func() {
+			req := &oidclib.AuthRequest{
+				ClientID:     oidc.ClientID,
+				RedirectURI:  "http://localhost:9999/callback",
+				Scopes:       []string{"openid", "profile", "email"},
+				ResponseType: "code",
+			}
+			ar, err := provider.Storage.CreateAuthRequest(gocontext.TODO(), req, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(provider.Storage.SetAuthRequestSubject(ar.GetID(), person.ID.String())).To(Succeed())
+
+			fetched, err := provider.Storage.AuthRequestByID(gocontext.TODO(), ar.GetID())
+			Expect(err).ToNot(HaveOccurred())
+			client, err := provider.Storage.GetClientByClientID(gocontext.TODO(), oidc.ClientID)
+			Expect(err).ToNot(HaveOccurred())
+
+			idToken, err := op.CreateIDToken(gocontext.TODO(), "http://localhost:8080", fetched, time.Hour, "access-token", "auth-code", provider.Storage, client)
+			Expect(err).ToNot(HaveOccurred())
+
+			claims := jwt.MapClaims{}
+			_, _, err = new(jwt.Parser).ParseUnverified(idToken, claims)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims["sub"]).To(Equal(person.ID.String()))
 		})
 
 		ginkgo.It("revokes refresh tokens", func() {


### PR DESCRIPTION
## Summary

The OIDC `sub` (subject) claim was missing from issued ID tokens. This broke clients that rely on the subject to identify the authenticated user.

## Root Cause

`SetUserinfoFromScopes` in `auth/oidc/storage.go` ignored the `subject` parameter and never set `userinfo.Subject`. The method had a `// deprecated` comment and returned immediately, so the subject was never propagated into the token claims.

## Changes

- **`auth/oidc/storage.go`**: Set `userinfo.Subject = subject` inside `SetUserinfoFromScopes` so the subject is included in the ID token.
- **`auth/oidc_test.go`**: Added a test that creates a full auth request, mints an ID token via `op.CreateIDToken`, parses the resulting JWT, and asserts that the `sub` claim equals the expected user ID.

## Testing

The new test `includes subject in id tokens` covers the fix end-to-end by verifying the `sub` claim in the raw JWT produced by the OIDC provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenID Connect (OIDC) so stored user subject information is correctly reflected in `UserInfo`, ensuring subject claims are properly populated.

* **Tests**
  * Added coverage to validate that generated OIDC ID tokens include the expected `sub` claim matching the stored subject.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->