### PR TITLE
feat: add AWS Bedrock LLM backend support for playbook AI actions

### DIFF
--- a/api/global.go
+++ b/api/global.go
@@ -37,6 +37,7 @@ type LLMBackend string
 
 const (
 	LLMBackendAnthropic LLMBackend = "anthropic"
+	LLMBackendBedrock   LLMBackend = "bedrock"
 	LLMBackendOpenAI    LLMBackend = "openai"
 	LLMBackendOllama    LLMBackend = "ollama"
 	LLMBackendGemini    LLMBackend = "gemini"

--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -284,7 +284,7 @@ type AIActionClient struct {
 	APIKey types.EnvVar `json:"apiKey,omitempty"`
 
 	// Optionally specify the LLM backend.
-	// Supported: anthropic (default), ollama, openai.
+	// Supported: anthropic (default), ollama, openai, bedrock, gemini.
 	Backend api.LLMBackend `json:"backend,omitempty"`
 
 	// Model name based on the backend chosen.
@@ -294,6 +294,14 @@ type AIActionClient struct {
 	// BaseURL or API url.
 	// Example: server URL for ollama or custom url for Anthropic if using a proxy
 	APIURL string `json:"apiURL,omitempty"`
+
+	// Region for AWS Bedrock backend.
+	Region string `json:"region,omitempty"`
+
+	// AWS credentials for Bedrock, populated from an aws connection in Populate().
+	AWSAccessKey    string `json:"-"`
+	AWSSecretKey    string `json:"-"`
+	AWSSessionToken string `json:"-"`
 }
 
 func (t *AIActionClient) Populate(ctx context.Context) error {
@@ -305,30 +313,43 @@ func (t *AIActionClient) Populate(ctx context.Context) error {
 			return fmt.Errorf("connection(%s) was not found: %w", *t.Connection, err)
 		}
 
-		if err := t.APIKey.Scan(conn.Password); err != nil {
-			return err
+		// AWS connections provide bedrock credentials, not an API key
+		if conn.Type == models.ConnectionTypeAWS {
+			return t.populateFromAWSConnection(ctx, conn)
 		}
 
-		t.APIURL = conn.URL
-
-		if m, ok := conn.Properties["model"]; ok {
-			t.Model = m
+		if t.APIKey.IsEmpty() {
+			if err := t.APIKey.Scan(conn.Password); err != nil {
+				return err
+			}
 		}
 
-		switch conn.Type {
-		case models.ConnectionTypeOllama:
-			t.Backend = api.LLMBackendOllama
-		case models.ConnectionTypeAnthropic:
-			t.Backend = api.LLMBackendAnthropic
-		case models.ConnectionTypeOpenAI:
-			t.Backend = api.LLMBackendOpenAI
-		case models.ConnectionTypeGemini:
-			t.Backend = api.LLMBackendGemini
-		default:
-			return fmt.Errorf("connection of type %q is not supported. Supported types: [%s]",
-				conn.Type,
-				strings.Join([]string{models.ConnectionTypeOllama, models.ConnectionTypeAnthropic, models.ConnectionTypeOpenAI, models.ConnectionTypeGemini}, ", "),
-			)
+		if t.APIURL == "" {
+			t.APIURL = conn.URL
+		}
+
+		if t.Model == "" {
+			if m, ok := conn.Properties["model"]; ok {
+				t.Model = m
+			}
+		}
+
+		if t.Backend == "" {
+			switch conn.Type {
+			case models.ConnectionTypeOllama:
+				t.Backend = api.LLMBackendOllama
+			case models.ConnectionTypeAnthropic:
+				t.Backend = api.LLMBackendAnthropic
+			case models.ConnectionTypeOpenAI:
+				t.Backend = api.LLMBackendOpenAI
+			case models.ConnectionTypeGemini:
+				t.Backend = api.LLMBackendGemini
+			default:
+				return fmt.Errorf("connection of type %q is not supported. Supported types: [%s]",
+					conn.Type,
+					strings.Join([]string{models.ConnectionTypeOllama, models.ConnectionTypeAnthropic, models.ConnectionTypeOpenAI, models.ConnectionTypeGemini, models.ConnectionTypeAWS}, ", "),
+				)
+			}
 		}
 	}
 
@@ -345,6 +366,40 @@ func (t *AIActionClient) Populate(ctx context.Context) error {
 		} else {
 			t.APIKey.ValueStatic = v
 		}
+	}
+
+	return nil
+}
+
+func (t *AIActionClient) populateFromAWSConnection(ctx context.Context, conn *models.Connection) error {
+	if t.Backend != "" && t.Backend != api.LLMBackendBedrock {
+		return fmt.Errorf("aws connection %q cannot be used with backend %q; only bedrock is supported", conn.Name, t.Backend)
+	}
+
+	if t.Region == "" {
+		if r, ok := conn.Properties["region"]; ok {
+			t.Region = r
+		}
+	}
+	if t.Model == "" {
+		if m, ok := conn.Properties["model"]; ok {
+			t.Model = m
+		}
+	}
+	if t.AWSAccessKey == "" {
+		t.AWSAccessKey = conn.Username
+	}
+	if t.AWSSecretKey == "" {
+		t.AWSSecretKey = conn.Password
+	}
+	if t.AWSSessionToken == "" {
+		if st, ok := conn.Properties["sessionToken"]; ok {
+			t.AWSSessionToken = st
+		}
+	}
+
+	if t.Backend == "" {
+		t.Backend = api.LLMBackendBedrock
 	}
 
 	return nil

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -108,7 +108,7 @@ spec:
                         backend:
                           description: |-
                             Optionally specify the LLM backend.
-                            Supported: anthropic (default), ollama, openai.
+                            Supported: anthropic (default), ollama, openai, bedrock, gemini.
                           type: string
                         changes:
                           description: Select changes for the config to provide as
@@ -305,6 +305,9 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        region:
+                          description: Region for AWS Bedrock backend.
+                          type: string
                         relationships:
                           description: Select related configs to provide as an additional
                             context to the AI model.

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -15,7 +15,7 @@
         },
         "backend": {
           "type": "string",
-          "description": "Optionally specify the LLM backend.\nSupported: anthropic (default), ollama, openai."
+          "description": "Optionally specify the LLM backend.\nSupported: anthropic (default), ollama, openai, bedrock, gemini."
         },
         "model": {
           "type": "string",
@@ -24,6 +24,10 @@
         "apiURL": {
           "type": "string",
           "description": "BaseURL or API url.\nExample: server URL for ollama or custom url for Anthropic if using a proxy"
+        },
+        "region": {
+          "type": "string",
+          "description": "Region for AWS Bedrock backend."
         },
         "config": {
           "type": "string"

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -15,7 +15,7 @@
         },
         "backend": {
           "type": "string",
-          "description": "Optionally specify the LLM backend.\nSupported: anthropic (default), ollama, openai."
+          "description": "Optionally specify the LLM backend.\nSupported: anthropic (default), ollama, openai, bedrock, gemini."
         },
         "model": {
           "type": "string",
@@ -24,6 +24,10 @@
         "apiURL": {
           "type": "string",
           "description": "BaseURL or API url.\nExample: server URL for ollama or custom url for Anthropic if using a proxy"
+        },
+        "region": {
+          "type": "string",
+          "description": "Region for AWS Bedrock backend."
         },
         "config": {
           "type": "string"

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.24.3
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.75.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2Egsw
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34/go.mod h1:Etz2dj6UHYuw+Xw830KfzCfWGMzqvUTCjUj5b76GVDc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaYzsyaPkCHGRRMAOhU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.24.3 h1:GXQrb3kyg4EU94onCRH/oG2IsVjHMNE+IPE4RGkgSa4=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.24.3/go.mod h1:PKGlRhLmSZuA6iCbRD1oZKrTJHdm6NWwWBvHxfDNHTA=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.75.2 h1:qXso3xK+5GmfBq8n/ymjJB12kHkO3Yhy9+8cIHlw6J4=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.75.2/go.mod h1:N336OxQ6TvRbb6V1esVE8PtQFU86YvYaS+lVjsJTmP0=
 github.com/aws/aws-sdk-go-v2/service/eks v1.84.6 h1:RSCziGPe92ZoBreWKOJsLhK45Nx7+2b2y8hNbOUvHLQ=

--- a/llm/bedrock_converse.go
+++ b/llm/bedrock_converse.go
@@ -1,0 +1,231 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/samber/lo"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// _converseModel implements llms.Model using the Bedrock Converse API,
+// which is provider-agnostic and works with any model ID on Bedrock.
+type _converseModel struct {
+	client  *bedrockruntime.Client
+	modelID string
+}
+
+var _ llms.Model = (*_converseModel)(nil)
+
+func newConverseModel(client *bedrockruntime.Client, modelID string) *_converseModel {
+	return &_converseModel{client: client, modelID: modelID}
+}
+
+func (m *_converseModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return llms.GenerateFromSinglePrompt(ctx, m, prompt, options...)
+}
+
+func (m *_converseModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	opts := &llms.CallOptions{}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	var systemPrompts []types.SystemContentBlock
+	var bedrockMessages []types.Message
+	var lastRole types.ConversationRole
+
+	for _, msg := range messages {
+		if msg.Role == llms.ChatMessageTypeSystem {
+			for _, part := range msg.Parts {
+				if text, ok := part.(llms.TextContent); ok {
+					systemPrompts = append(systemPrompts, &types.SystemContentBlockMemberText{Value: text.Text})
+				}
+			}
+			continue
+		}
+
+		role := langchainRoleToConverse(msg.Role)
+		contentBlocks := langchainPartsToContentBlocks(msg.Parts)
+
+		// Merge consecutive messages with the same role (Converse requires alternating roles)
+		if len(bedrockMessages) > 0 && bedrockMessages[len(bedrockMessages)-1].Role == role {
+			bedrockMessages[len(bedrockMessages)-1].Content = append(
+				bedrockMessages[len(bedrockMessages)-1].Content, contentBlocks...,
+			)
+		} else {
+			bedrockMessages = append(bedrockMessages, types.Message{
+				Role:    role,
+				Content: contentBlocks,
+			})
+		}
+		lastRole = role
+	}
+
+	// Converse requires first message to be user
+	if len(bedrockMessages) > 0 && bedrockMessages[0].Role != types.ConversationRoleUser {
+		bedrockMessages[0].Role = types.ConversationRoleUser
+	}
+
+	// If last message is assistant (e.g. from conversation history), add an empty user turn
+	if lastRole == types.ConversationRoleAssistant {
+		bedrockMessages = append(bedrockMessages, types.Message{
+			Role:    types.ConversationRoleUser,
+			Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: ""}},
+		})
+	}
+
+	input := &bedrockruntime.ConverseInput{
+		ModelId:  aws.String(m.modelID),
+		Messages: bedrockMessages,
+		System:   systemPrompts,
+	}
+
+	if opts.MaxTokens > 0 {
+		m := int32(opts.MaxTokens)
+		input.InferenceConfig = &types.InferenceConfiguration{MaxTokens: &m}
+	}
+	if opts.Temperature > 0 {
+		t := float32(opts.Temperature)
+		if input.InferenceConfig == nil {
+			input.InferenceConfig = &types.InferenceConfiguration{}
+		}
+		input.InferenceConfig.Temperature = &t
+	}
+	if len(opts.Tools) > 0 {
+		input.ToolConfig = convertToolsToConverse(opts.Tools)
+	}
+
+	output, err := m.client.Converse(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock Converse: %w", err)
+	}
+
+	return convertConverseOutput(output)
+}
+
+func langchainRoleToConverse(role llms.ChatMessageType) types.ConversationRole {
+	switch role {
+	case llms.ChatMessageTypeAI:
+		return types.ConversationRoleAssistant
+	default:
+		return types.ConversationRoleUser
+	}
+}
+
+func langchainPartsToContentBlocks(parts []llms.ContentPart) []types.ContentBlock {
+	var blocks []types.ContentBlock
+	for _, part := range parts {
+		switch p := part.(type) {
+		case llms.TextContent:
+			blocks = append(blocks, &types.ContentBlockMemberText{Value: p.Text})
+		case llms.ToolCall:
+			inputDoc, _ := marshalToDocument(p.FunctionCall.Arguments)
+			blocks = append(blocks, &types.ContentBlockMemberToolUse{
+				Value: types.ToolUseBlock{
+					ToolUseId: aws.String(p.ID),
+					Name:      aws.String(p.FunctionCall.Name),
+					Input:     inputDoc,
+				},
+			})
+		case llms.ToolCallResponse:
+			blocks = append(blocks, &types.ContentBlockMemberToolResult{
+				Value: types.ToolResultBlock{
+					ToolUseId: aws.String(p.ToolCallID),
+					Content:   []types.ToolResultContentBlock{&types.ToolResultContentBlockMemberText{Value: p.Content}},
+				},
+			})
+		}
+	}
+	return blocks
+}
+
+func convertToolsToConverse(tools []llms.Tool) *types.ToolConfiguration {
+	bedrockTools := make([]types.Tool, len(tools))
+	for i, t := range tools {
+		schema, _ := marshalToDocument(t.Function.Parameters)
+		bedrockTools[i] = &types.ToolMemberToolSpec{
+			Value: types.ToolSpecification{
+				Name:        aws.String(t.Function.Name),
+				Description: aws.String(t.Function.Description),
+				InputSchema: &types.ToolInputSchemaMemberJson{Value: schema},
+			},
+		}
+	}
+	return &types.ToolConfiguration{Tools: bedrockTools}
+}
+
+func convertConverseOutput(output *bedrockruntime.ConverseOutput) (*llms.ContentResponse, error) {
+	msg, ok := output.Output.(*types.ConverseOutputMemberMessage)
+	if !ok {
+		return nil, errors.New("bedrock Converse: unexpected output type")
+	}
+
+	choice := &llms.ContentChoice{
+		StopReason: string(output.StopReason),
+		GenerationInfo: map[string]any{
+			"InputTokens":  int(lo.FromPtr(output.Usage.InputTokens)),
+			"OutputTokens": int(lo.FromPtr(output.Usage.OutputTokens)),
+		},
+	}
+
+	for _, block := range msg.Value.Content {
+		switch b := block.(type) {
+		case *types.ContentBlockMemberText:
+			choice.Content += b.Value
+		case *types.ContentBlockMemberToolUse:
+			choice.ToolCalls = append(choice.ToolCalls, llms.ToolCall{
+				ID:   lo.FromPtr(b.Value.ToolUseId),
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      lo.FromPtr(b.Value.Name),
+					Arguments: unmarshalDocument(b.Value.Input),
+				},
+			})
+		}
+	}
+
+	if len(choice.ToolCalls) > 0 {
+		choice.FuncCall = choice.ToolCalls[0].FunctionCall
+	}
+
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}, nil
+}
+
+type _smithyMarshaler interface {
+	MarshalSmithyDocument() ([]byte, error)
+}
+
+func unmarshalDocument(doc document.Interface) string {
+	if doc == nil {
+		return ""
+	}
+	if m, ok := doc.(_smithyMarshaler); ok {
+		b, err := m.MarshalSmithyDocument()
+		if err == nil {
+			return string(b)
+		}
+	}
+	return ""
+}
+
+func marshalToDocument(v any) (document.Interface, error) {
+	if v == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	return document.NewLazyDocument(doc), nil
+}

--- a/llm/bedrock_converse.go
+++ b/llm/bedrock_converse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -17,18 +18,54 @@ import (
 // _converseModel implements llms.Model using the Bedrock Converse API,
 // which is provider-agnostic and works with any model ID on Bedrock.
 type _converseModel struct {
-	client  *bedrockruntime.Client
-	modelID string
+	client         *bedrockruntime.Client
+	modelID        string
+	responseFormat ResponseFormat
+	customSchema   string
 }
 
 var _ llms.Model = (*_converseModel)(nil)
 
-func newConverseModel(client *bedrockruntime.Client, modelID string) *_converseModel {
-	return &_converseModel{client: client, modelID: modelID}
+func newConverseModel(client *bedrockruntime.Client, modelID string, responseFormat ResponseFormat, customSchema string) *_converseModel {
+	return &_converseModel{
+		client:         client,
+		modelID:        modelID,
+		responseFormat: responseFormat,
+		customSchema:   customSchema,
+	}
 }
 
 func (m *_converseModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	return llms.GenerateFromSinglePrompt(ctx, m, prompt, options...)
+}
+
+func (m *_converseModel) formatInstruction() string {
+	switch m.responseFormat {
+	case ResponseFormatDiagnosis:
+		return `Respond with a JSON object containing these fields:
+- "headline": A short headline with emojis that clearly mentions the affected resource & the issue.
+- "summary": Brief slack flavored markdown summary (≤50 words) of the issue and impact.
+- "recommended_fix": Slack flavored markdown bullet array of 1-5 concise fixes (≤10 words each).
+
+Respond with ONLY the JSON object. No markdown code blocks, no explanatory text.`
+
+	case ResponseFormatPlaybookRecommendations:
+		return `Respond with a JSON object containing:
+- "playbooks": A list of recommended playbook objects sorted by relevance. Each with:
+  - "id": The UUID of the playbook
+  - "emoji": An emoji to represent it
+  - "title": The title of the playbook
+  - "parameters": A list of {key, value} parameter pairs
+  - "resource_id": The UUID of the resource to operate on
+
+Respond with ONLY the JSON object. No markdown code blocks, no explanatory text.`
+
+	case ResponseFormatCustomSchema:
+		return fmt.Sprintf("Respond with a JSON object matching this schema:\n%s\n\nRespond with ONLY the JSON object. No markdown code blocks, no explanatory text.", m.customSchema)
+
+	default:
+		return ""
+	}
 }
 
 func (m *_converseModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
@@ -40,6 +77,11 @@ func (m *_converseModel) GenerateContent(ctx context.Context, messages []llms.Me
 	var systemPrompts []types.SystemContentBlock
 	var bedrockMessages []types.Message
 	var lastRole types.ConversationRole
+
+	// Append JSON output instruction when a response format is set
+	if formatInstruction := m.formatInstruction(); formatInstruction != "" {
+		systemPrompts = append(systemPrompts, &types.SystemContentBlockMemberText{Value: formatInstruction})
+	}
 
 	for _, msg := range messages {
 		if msg.Role == llms.ChatMessageTypeSystem {
@@ -193,6 +235,8 @@ func convertConverseOutput(output *bedrockruntime.ConverseOutput) (*llms.Content
 
 	if len(choice.ToolCalls) > 0 {
 		choice.FuncCall = choice.ToolCalls[0].FunctionCall
+	} else {
+		choice.Content = cleanJSONResponse(choice.Content)
 	}
 
 	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}, nil
@@ -213,6 +257,27 @@ func unmarshalDocument(doc document.Interface) string {
 		}
 	}
 	return ""
+}
+
+func cleanJSONResponse(raw string) string {
+	raw = strings.TrimSpace(raw)
+
+	// Strip markdown code fences: ```json ... ``` or ``` ... ```
+	if strings.HasPrefix(raw, "```") {
+		raw = strings.TrimPrefix(raw, "```json")
+		raw = strings.TrimPrefix(raw, "```")
+		if idx := strings.LastIndex(raw, "```"); idx >= 0 {
+			raw = raw[:idx]
+		}
+		raw = strings.TrimSpace(raw)
+	}
+
+	// Strip surrounding single backticks
+	if strings.HasPrefix(raw, "`") && strings.HasSuffix(raw, "`") {
+		raw = strings.Trim(raw, "`")
+	}
+
+	return raw
 }
 
 func marshalToDocument(v any) (document.Interface, error) {

--- a/llm/cost.go
+++ b/llm/cost.go
@@ -41,6 +41,7 @@ var modelRegistry = make(map[api.LLMBackend]map[string]ModelInfo)
 // init populates the modelRegistry with known model data.
 func init() {
 	populateAnthropicModels()
+	populateBedrockModels()
 	populateGeminiDirectModels() // Populating gemini under 'gemini' key
 	populateOpenAIModels()
 	// Add calls to populate other providers as needed
@@ -115,6 +116,94 @@ func populateAnthropicModels() {
 		OutputPrice:         1.25,
 		CacheWritesPrice:    0.3,
 		CacheReadsPrice:     0.03,
+	}
+
+	modelRegistry[provider] = models
+}
+
+func populateBedrockModels() {
+	provider := api.LLMBackendBedrock
+	models := make(map[string]ModelInfo)
+
+	// Claude models on Bedrock (priced same as direct Anthropic)
+	models["anthropic.claude-3-7-sonnet-20250219-v1:0"] = ModelInfo{
+		Provider:            provider,
+		ModelID:             "anthropic.claude-3-7-sonnet-20250219-v1:0",
+		MaxTokens:           8192,
+		ContextWindow:       200_000,
+		SupportsImages:      true,
+		SupportsPromptCache: false,
+		InputPrice:          3.0,
+		OutputPrice:         15.0,
+	}
+	models["anthropic.claude-3-5-sonnet-20241022-v1:0"] = ModelInfo{
+		Provider:            provider,
+		ModelID:             "anthropic.claude-3-5-sonnet-20241022-v1:0",
+		MaxTokens:           8192,
+		ContextWindow:       200_000,
+		SupportsImages:      true,
+		SupportsPromptCache: false,
+		InputPrice:          3.0,
+		OutputPrice:         15.0,
+	}
+	models["anthropic.claude-3-5-haiku-20241022-v1:0"] = ModelInfo{
+		Provider:            provider,
+		ModelID:             "anthropic.claude-3-5-haiku-20241022-v1:0",
+		MaxTokens:           8192,
+		ContextWindow:       200_000,
+		SupportsImages:      true,
+		SupportsPromptCache: false,
+		InputPrice:          0.8,
+		OutputPrice:         4.0,
+	}
+	models["anthropic.claude-3-sonnet-20240229-v1:0"] = ModelInfo{
+		Provider:            provider,
+		ModelID:             "anthropic.claude-3-sonnet-20240229-v1:0",
+		MaxTokens:           4096,
+		ContextWindow:       200_000,
+		SupportsImages:      true,
+		SupportsPromptCache: false,
+		InputPrice:          3.0,
+		OutputPrice:         15.0,
+	}
+	models["anthropic.claude-3-haiku-20240307-v1:0"] = ModelInfo{
+		Provider:            provider,
+		ModelID:             "anthropic.claude-3-haiku-20240307-v1:0",
+		MaxTokens:           4096,
+		ContextWindow:       200_000,
+		SupportsImages:      true,
+		SupportsPromptCache: false,
+		InputPrice:          0.25,
+		OutputPrice:         1.25,
+	}
+
+	// Amazon Nova models
+	models["us.amazon.nova-pro-v1:0"] = ModelInfo{
+		Provider:       provider,
+		ModelID:        "us.amazon.nova-pro-v1:0",
+		MaxTokens:      5120,
+		ContextWindow:  300_000,
+		SupportsImages: true,
+		InputPrice:     0.8,
+		OutputPrice:    3.2,
+	}
+	models["us.amazon.nova-lite-v1:0"] = ModelInfo{
+		Provider:       provider,
+		ModelID:        "us.amazon.nova-lite-v1:0",
+		MaxTokens:      5120,
+		ContextWindow:  300_000,
+		SupportsImages: true,
+		InputPrice:     0.06,
+		OutputPrice:    0.24,
+	}
+	models["us.amazon.nova-micro-v1:0"] = ModelInfo{
+		Provider:       provider,
+		ModelID:        "us.amazon.nova-micro-v1:0",
+		MaxTokens:      5120,
+		ContextWindow:  128_000,
+		SupportsImages: false,
+		InputPrice:     0.035,
+		OutputPrice:    0.14,
 	}
 
 	modelRegistry[provider] = models

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -12,7 +12,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
-	"github.com/tmc/langchaingo/llms/bedrock"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/llms/openai"
 	"google.golang.org/genai"
@@ -178,10 +177,10 @@ func calculateGenerationInfo(llmBackend api.LLMBackend, model string, resp *llms
 				}
 
 			case api.LLMBackendBedrock:
-				if inputTokens, ok := choice.GenerationInfo["input_tokens"]; ok {
+				if inputTokens, ok := choice.GenerationInfo["InputTokens"]; ok {
 					genInfo.InputTokens += inputTokens.(int)
 				}
-				if outputTokens, ok := choice.GenerationInfo["output_tokens"]; ok {
+				if outputTokens, ok := choice.GenerationInfo["OutputTokens"]; ok {
 					genInfo.OutputTokens += outputTokens.(int)
 				}
 			}
@@ -316,11 +315,6 @@ func getLLMModel(ctx dutyctx.Context, config Config) (llms.Model, error) {
 		return wrapper, nil
 
 	case api.LLMBackendBedrock:
-		var opts []bedrock.Option
-		if config.Model != "" {
-			opts = append(opts, bedrock.WithModel(config.Model))
-		}
-
 		var cfgOpts []func(*awsconfig.LoadOptions) error
 		if config.Region != "" {
 			cfgOpts = append(cfgOpts, awsconfig.WithRegion(config.Region))
@@ -331,19 +325,13 @@ func getLLMModel(ctx dutyctx.Context, config Config) (llms.Model, error) {
 			))
 		}
 
-		if len(cfgOpts) > 0 {
-			cfg, err := awsconfig.LoadDefaultConfig(ctx, cfgOpts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load AWS config: %w", err)
-			}
-			opts = append(opts, bedrock.WithClient(bedrockruntime.NewFromConfig(cfg)))
+		cfg, err := awsconfig.LoadDefaultConfig(ctx, cfgOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load AWS config: %w", err)
 		}
 
-		bedrockLLM, err := bedrock.New(opts...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Bedrock llm: %w", err)
-		}
-		return bedrockLLM, nil
+		client := bedrockruntime.NewFromConfig(cfg)
+		return newConverseModel(client, config.Model), nil
 
 	default:
 		return nil, errors.New("unknown config.Backend")

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -82,7 +82,7 @@ func PromptWithHistory(ctx dutyctx.Context, config Config, history []llms.Messag
 		// OpenAI does support function calling, but I don't think we can force the model to use that tool
 		// like we can with Anthropic.
 
-	case api.LLMBackendGemini:
+	case api.LLMBackendGemini, api.LLMBackendBedrock:
 		// Do nothing
 		// NOTE: Handled by the wrapper
 
@@ -331,7 +331,7 @@ func getLLMModel(ctx dutyctx.Context, config Config) (llms.Model, error) {
 		}
 
 		client := bedrockruntime.NewFromConfig(cfg)
-		return newConverseModel(client, config.Model), nil
+		return newConverseModel(client, config.Model, config.ResponseFormat, config.CustomSchema), nil
 
 	default:
 		return nil, errors.New("unknown config.Backend")

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"fmt"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	dutyctx "github.com/flanksource/duty/context"
 	"github.com/samber/lo"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
+	"github.com/tmc/langchaingo/llms/bedrock"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/llms/openai"
 	"google.golang.org/genai"
@@ -172,6 +176,14 @@ func calculateGenerationInfo(llmBackend api.LLMBackend, model string, resp *llms
 				if outputTokens, ok := choice.GenerationInfo["OutputTokens"]; ok {
 					genInfo.OutputTokens += int(outputTokens.(int32))
 				}
+
+			case api.LLMBackendBedrock:
+				if inputTokens, ok := choice.GenerationInfo["input_tokens"]; ok {
+					genInfo.InputTokens += inputTokens.(int)
+				}
+				if outputTokens, ok := choice.GenerationInfo["output_tokens"]; ok {
+					genInfo.OutputTokens += outputTokens.(int)
+				}
 			}
 
 			cost, err := CalculateCost(llmBackend, model, genInfo)
@@ -302,6 +314,36 @@ func getLLMModel(ctx dutyctx.Context, config Config) (llms.Model, error) {
 		}
 
 		return wrapper, nil
+
+	case api.LLMBackendBedrock:
+		var opts []bedrock.Option
+		if config.Model != "" {
+			opts = append(opts, bedrock.WithModel(config.Model))
+		}
+
+		var cfgOpts []func(*awsconfig.LoadOptions) error
+		if config.Region != "" {
+			cfgOpts = append(cfgOpts, awsconfig.WithRegion(config.Region))
+		}
+		if config.AWSAccessKey != "" && config.AWSSecretKey != "" {
+			cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider(config.AWSAccessKey, config.AWSSecretKey, config.AWSSessionToken),
+			))
+		}
+
+		if len(cfgOpts) > 0 {
+			cfg, err := awsconfig.LoadDefaultConfig(ctx, cfgOpts...)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load AWS config: %w", err)
+			}
+			opts = append(opts, bedrock.WithClient(bedrockruntime.NewFromConfig(cfg)))
+		}
+
+		bedrockLLM, err := bedrock.New(opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Bedrock llm: %w", err)
+		}
+		return bedrockLLM, nil
 
 	default:
 		return nil, errors.New("unknown config.Backend")


### PR DESCRIPTION
## Summary

Adds  as a new LLM backend for playbook AI actions, using the existing `aws` connection type for credentials.

### What changed

- **`api/global.go`**: Added `LLMBackendBedrock = "bedrock"`
- **`api/v1/playbook_actions.go`**: 
  - Added `Region`, `AWSAccessKey`, `AWSSecretKey`, `AWSSessionToken` fields to `AIActionClient`
  - AWS connections now extract credentials for bedrock: access key, secret key, region, session token
  - Fixed `Populate()`: connection values now only fill gaps — user-set fields on the action always win (previously they were unconditionally overwritten)
- **`llm/llm.go`**: Bedrock model creation via langchaingo's `bedrock` package; falls back to AWS default credential chain when no explicit keys
- **`llm/cost.go`**: Pricing for Bedrock-hosted Claude models and Amazon Nova (Pro, Lite, Micro)
- **`go.mod`**: Added `github.com/aws/aws-sdk-go-v2/service/bedrockruntime`

### Usage

```yaml
actions:
  - name: analyze
    ai:
      backend: bedrock
      connection: connection://aws/my-aws    # reuses existing AWS creds
      region: us-east-1
      model: anthropic.claude-3-5-sonnet-20241022-v1:0
      prompt: "Analyze this issue..."
```

Or without a connection (uses default AWS credential chain):

```yaml
actions:
  - name: analyze  
    ai:
      backend: bedrock
      region: us-east-1
      model: us.amazon.nova-pro-v1:0
      prompt: "Analyze this issue..."
```

### Supported models (cost tracked)
- Anthropic Claude 3.7/3.5 Sonnet, 3.5 Haiku, 3 Sonnet, 3 Haiku
- Amazon Nova Pro, Lite, Micro