### PR TITLE
llm: add genkit Skills middleware support

### DIFF
--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -413,19 +413,17 @@ type AIOutputSchemaGit struct {
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
 }
 
-// AISkill references a skill file in a git repository.
-// The repo is cloned at execution time and the skill file content is
-// prepended to the system prompt.
+// AISkill references a skill file, either from a git repository (when Connection
+// is set) or from the local filesystem (when Connection is empty). Skill content
+// is exposed to the model as a loadable skill via the use_skill tool.
 type AISkill struct {
-	// Git connection reference (e.g., "connection://github/my-org")
-	Connection string `json:"connection" yaml:"connection"`
-	// Path to the skill file within the repo (e.g., "skills/access-auditor.md")
+	// Git connection reference (e.g., "connection://github/my-org").
+	// When empty, Path is read from the local filesystem.
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	// Path to the skill file within the repo or local filesystem (e.g., "skills/access-auditor.md")
 	Path string `json:"path" yaml:"path"`
 	// Branch or tag to checkout (optional, defaults to the repo's default branch)
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
-	// JsonSchemaPath is the path to a JSON schema file in the repo.
-	// If set, the AI response must conform to this schema (takes precedence over inline OutputSchema).
-	JsonSchemaPath string `json:"jsonSchemaPath,omitempty" yaml:"jsonSchemaPath,omitempty"`
 }
 
 type AIAction struct {

--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -420,10 +420,14 @@ type AISkill struct {
 	// Git connection reference (e.g., "connection://github/my-org").
 	// When empty, Path is read from the local filesystem.
 	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
-	// Path to the skill library directory within the repo or local filesystem (e.g., "skills")
-	Path string `json:"path" yaml:"path"`
+
 	// Branch or tag to checkout (optional, defaults to the repo's default branch)
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+
+	// Path to a directory that contains skill subdirectories, each with a SKILL.md file.
+	// Must be the *parent* directory of the skill directories, not a skill directory itself.
+	// Example: if skills live at /home/user/my-skills/foo/SKILL.md, pass "/home/aditya/my-skills" — not "/home/aditya/my-skills/foo".
+	Path string `json:"path" yaml:"path"`
 }
 
 type AIAction struct {

--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -426,7 +426,7 @@ type AISkill struct {
 
 	// Path to a directory that contains skill subdirectories, each with a SKILL.md file.
 	// Must be the *parent* directory of the skill directories, not a skill directory itself.
-	// Example: if skills live at /home/user/my-skills/foo/SKILL.md, pass "/home/aditya/my-skills" — not "/home/aditya/my-skills/foo".
+	// Example: if skills live at /data/skills/foo/SKILL.md, pass "/data/skills" — not "/data/skills/foo".
 	Path string `json:"path" yaml:"path"`
 }
 

--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -413,14 +413,14 @@ type AIOutputSchemaGit struct {
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
 }
 
-// AISkill references a skill file, either from a git repository (when Connection
-// is set) or from the local filesystem (when Connection is empty). Skill content
-// is exposed to the model as a loadable skill via the use_skill tool.
+// AISkill references a Genkit skill library directory, either from a git repository
+// (when Connection is set) or from the local filesystem (when Connection is empty).
+// Skills are exposed to the model as loadable skills via the use_skill tool.
 type AISkill struct {
 	// Git connection reference (e.g., "connection://github/my-org").
 	// When empty, Path is read from the local filesystem.
 	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
-	// Path to the skill file within the repo or local filesystem (e.g., "skills/access-auditor.md")
+	// Path to the skill library directory within the repo or local filesystem (e.g., "skills")
 	Path string `json:"path" yaml:"path"`
 	// Branch or tag to checkout (optional, defaults to the repo's default branch)
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
@@ -450,9 +450,7 @@ type AIAction struct {
 	// Supported: markdown (default), slack, recommendPlaybook
 	Formats []AIActionFormat `json:"formats,omitempty"`
 
-	// Skills references reusable skill files from git repositories.
-	// Each skill file's content is prepended to the system prompt.
-	// If any skill has JsonSchemaPath set, that schema is used for output validation.
+	// Skills references reusable Genkit skill libraries.
 	Skills []AISkill `json:"skills,omitempty" yaml:"skills,omitempty"`
 
 	// OutputSchema is a JSON schema that the AI response must conform to.

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -438,28 +438,24 @@ spec:
                             If any skill has JsonSchemaPath set, that schema is used for output validation.
                           items:
                             description: |-
-                              AISkill references a skill file in a git repository.
-                              The repo is cloned at execution time and the skill file content is
-                              prepended to the system prompt.
+                              AISkill references a skill file, either from a git repository (when Connection
+                              is set) or from the local filesystem (when Connection is empty). Skill content
+                              is exposed to the model as a loadable skill via the use_skill tool.
                             properties:
                               branch:
                                 description: Branch or tag to checkout (optional,
                                   defaults to the repo's default branch)
                                 type: string
                               connection:
-                                description: Git connection reference (e.g., "connection://github/my-org")
-                                type: string
-                              jsonSchemaPath:
                                 description: |-
-                                  JsonSchemaPath is the path to a JSON schema file in the repo.
-                                  If set, the AI response must conform to this schema (takes precedence over inline OutputSchema).
+                                  Git connection reference (e.g., "connection://github/my-org").
+                                  When empty, Path is read from the local filesystem.
                                 type: string
                               path:
                                 description: Path to the skill file within the repo
-                                  (e.g., "skills/access-auditor.md")
+                                  or local filesystem (e.g., "skills/access-auditor.md")
                                 type: string
                             required:
-                            - connection
                             - path
                             type: object
                           type: array

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -452,7 +452,7 @@ spec:
                                 description: |-
                                   Path to a directory that contains skill subdirectories, each with a SKILL.md file.
                                   Must be the *parent* directory of the skill directories, not a skill directory itself.
-                                  Example: if skills live at /home/user/my-skills/foo/SKILL.md, pass "/home/aditya/my-skills" — not "/home/aditya/my-skills/foo".
+                                  Example: if skills live at /data/skills/foo/SKILL.md, pass "/data/skills" — not "/data/skills/foo".
                                 type: string
                             required:
                             - path

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -432,15 +432,12 @@ spec:
                             type: object
                           type: array
                         skills:
-                          description: |-
-                            Skills references reusable skill files from git repositories.
-                            Each skill file's content is prepended to the system prompt.
-                            If any skill has JsonSchemaPath set, that schema is used for output validation.
+                          description: Skills references reusable Genkit skill libraries.
                           items:
                             description: |-
-                              AISkill references a skill file, either from a git repository (when Connection
-                              is set) or from the local filesystem (when Connection is empty). Skill content
-                              is exposed to the model as a loadable skill via the use_skill tool.
+                              AISkill references a Genkit skill library directory, either from a git repository
+                              (when Connection is set) or from the local filesystem (when Connection is empty).
+                              Skills are exposed to the model as loadable skills via the use_skill tool.
                             properties:
                               branch:
                                 description: Branch or tag to checkout (optional,
@@ -452,8 +449,8 @@ spec:
                                   When empty, Path is read from the local filesystem.
                                 type: string
                               path:
-                                description: Path to the skill file within the repo
-                                  or local filesystem (e.g., "skills/access-auditor.md")
+                                description: Path to the skill library directory within
+                                  the repo or local filesystem (e.g., "skills")
                                 type: string
                             required:
                             - path

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -449,8 +449,10 @@ spec:
                                   When empty, Path is read from the local filesystem.
                                 type: string
                               path:
-                                description: Path to the skill library directory within
-                                  the repo or local filesystem (e.g., "skills")
+                                description: |-
+                                  Path to a directory that contains skill subdirectories, each with a SKILL.md file.
+                                  Must be the *parent* directory of the skill directories, not a skill directory itself.
+                                  Example: if skills live at /home/user/my-skills/foo/SKILL.md, pass "/home/aditya/my-skills" — not "/home/aditya/my-skills/foo".
                                 type: string
                             required:
                             - path

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -152,13 +152,13 @@
           "type": "string",
           "description": "Git connection reference (e.g., \"connection://github/my-org\").\nWhen empty, Path is read from the local filesystem."
         },
-        "path": {
-          "type": "string",
-          "description": "Path to the skill library directory within the repo or local filesystem (e.g., \"skills\")"
-        },
         "branch": {
           "type": "string",
           "description": "Branch or tag to checkout (optional, defaults to the repo's default branch)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /home/user/my-skills/foo/SKILL.md, pass \"/home/aditya/my-skills\" — not \"/home/aditya/my-skills/foo\"."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -158,7 +158,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /home/user/my-skills/foo/SKILL.md, pass \"/home/aditya/my-skills\" — not \"/home/aditya/my-skills/foo\"."
+          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /data/skills/foo/SKILL.md, pass \"/data/skills\" — not \"/data/skills/foo\"."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -89,7 +89,7 @@
             "$ref": "#/$defs/AISkill"
           },
           "type": "array",
-          "description": "Skills references reusable skill files from git repositories.\nEach skill file's content is prepended to the system prompt.\nIf any skill has JsonSchemaPath set, that schema is used for output validation."
+          "description": "Skills references reusable Genkit skill libraries."
         },
         "outputSchema": {
           "$ref": "#/$defs/AIOutputSchema",
@@ -154,7 +154,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to the skill file within the repo or local filesystem (e.g., \"skills/access-auditor.md\")"
+          "description": "Path to the skill library directory within the repo or local filesystem (e.g., \"skills\")"
         },
         "branch": {
           "type": "string",
@@ -166,7 +166,7 @@
       "required": [
         "path"
       ],
-      "description": "AISkill references a skill file, either from a git repository (when Connection\nis set) or from the local filesystem (when Connection is empty). Skill content\nis exposed to the model as a loadable skill via the use_skill tool."
+      "description": "AISkill references a Genkit skill library directory, either from a git repository\n(when Connection is set) or from the local filesystem (when Connection is empty).\nSkills are exposed to the model as loadable skills via the use_skill tool."
     },
     "AWSConnection": {
       "properties": {

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -150,28 +150,23 @@
       "properties": {
         "connection": {
           "type": "string",
-          "description": "Git connection reference (e.g., \"connection://github/my-org\")"
+          "description": "Git connection reference (e.g., \"connection://github/my-org\").\nWhen empty, Path is read from the local filesystem."
         },
         "path": {
           "type": "string",
-          "description": "Path to the skill file within the repo (e.g., \"skills/access-auditor.md\")"
+          "description": "Path to the skill file within the repo or local filesystem (e.g., \"skills/access-auditor.md\")"
         },
         "branch": {
           "type": "string",
           "description": "Branch or tag to checkout (optional, defaults to the repo's default branch)"
-        },
-        "jsonSchemaPath": {
-          "type": "string",
-          "description": "JsonSchemaPath is the path to a JSON schema file in the repo.\nIf set, the AI response must conform to this schema (takes precedence over inline OutputSchema)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "connection",
         "path"
       ],
-      "description": "AISkill references a skill file in a git repository.\nThe repo is cloned at execution time and the skill file content is\nprepended to the system prompt."
+      "description": "AISkill references a skill file, either from a git repository (when Connection\nis set) or from the local filesystem (when Connection is empty). Skill content\nis exposed to the model as a loadable skill via the use_skill tool."
     },
     "AWSConnection": {
       "properties": {

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -152,13 +152,13 @@
           "type": "string",
           "description": "Git connection reference (e.g., \"connection://github/my-org\").\nWhen empty, Path is read from the local filesystem."
         },
-        "path": {
-          "type": "string",
-          "description": "Path to the skill library directory within the repo or local filesystem (e.g., \"skills\")"
-        },
         "branch": {
           "type": "string",
           "description": "Branch or tag to checkout (optional, defaults to the repo's default branch)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /home/user/my-skills/foo/SKILL.md, pass \"/home/aditya/my-skills\" — not \"/home/aditya/my-skills/foo\"."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -158,7 +158,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /home/user/my-skills/foo/SKILL.md, pass \"/home/aditya/my-skills\" — not \"/home/aditya/my-skills/foo\"."
+          "description": "Path to a directory that contains skill subdirectories, each with a SKILL.md file.\nMust be the *parent* directory of the skill directories, not a skill directory itself.\nExample: if skills live at /data/skills/foo/SKILL.md, pass \"/data/skills\" — not \"/data/skills/foo\"."
         }
       },
       "additionalProperties": false,

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -89,7 +89,7 @@
             "$ref": "#/$defs/AISkill"
           },
           "type": "array",
-          "description": "Skills references reusable skill files from git repositories.\nEach skill file's content is prepended to the system prompt.\nIf any skill has JsonSchemaPath set, that schema is used for output validation."
+          "description": "Skills references reusable Genkit skill libraries."
         },
         "outputSchema": {
           "$ref": "#/$defs/AIOutputSchema",
@@ -154,7 +154,7 @@
         },
         "path": {
           "type": "string",
-          "description": "Path to the skill file within the repo or local filesystem (e.g., \"skills/access-auditor.md\")"
+          "description": "Path to the skill library directory within the repo or local filesystem (e.g., \"skills\")"
         },
         "branch": {
           "type": "string",
@@ -166,7 +166,7 @@
       "required": [
         "path"
       ],
-      "description": "AISkill references a skill file, either from a git repository (when Connection\nis set) or from the local filesystem (when Connection is empty). Skill content\nis exposed to the model as a loadable skill via the use_skill tool."
+      "description": "AISkill references a Genkit skill library directory, either from a git repository\n(when Connection is set) or from the local filesystem (when Connection is empty).\nSkills are exposed to the model as loadable skills via the use_skill tool."
     },
     "AWSConnection": {
       "properties": {

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -150,28 +150,23 @@
       "properties": {
         "connection": {
           "type": "string",
-          "description": "Git connection reference (e.g., \"connection://github/my-org\")"
+          "description": "Git connection reference (e.g., \"connection://github/my-org\").\nWhen empty, Path is read from the local filesystem."
         },
         "path": {
           "type": "string",
-          "description": "Path to the skill file within the repo (e.g., \"skills/access-auditor.md\")"
+          "description": "Path to the skill file within the repo or local filesystem (e.g., \"skills/access-auditor.md\")"
         },
         "branch": {
           "type": "string",
           "description": "Branch or tag to checkout (optional, defaults to the repo's default branch)"
-        },
-        "jsonSchemaPath": {
-          "type": "string",
-          "description": "JsonSchemaPath is the path to a JSON schema file in the repo.\nIf set, the AI response must conform to this schema (takes precedence over inline OutputSchema)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "connection",
         "path"
       ],
-      "description": "AISkill references a skill file in a git repository.\nThe repo is cloned at execution time and the skill file content is\nprepended to the system prompt."
+      "description": "AISkill references a skill file, either from a git repository (when Connection\nis set) or from the local filesystem (when Connection is empty). Skill content\nis exposed to the model as a loadable skill via the use_skill tool."
     },
     "AWSConnection": {
       "properties": {

--- a/fixtures/connections/flanksource-claude-code-plugin-github.yaml
+++ b/fixtures/connections/flanksource-claude-code-plugin-github.yaml
@@ -1,0 +1,13 @@
+apiVersion: mission-control.flanksource.com/v1
+kind: Connection
+metadata:
+  name: flanksource-claude-code-plugin-github
+  namespace: mc
+spec:
+  github:
+    url: https://github.com/flanksource/claude-code-plugin
+    personalAccessToken:
+      valueFrom:
+        secretKeyRef:
+          name: flanksource-github
+          key: token

--- a/fixtures/playbooks/ai-mission-control-skills.yaml
+++ b/fixtures/playbooks/ai-mission-control-skills.yaml
@@ -1,0 +1,30 @@
+# Connection fixture at fixtures/connections/flanksource-claude-code-plugin-github.yaml
+apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  name: prompt-mc-ai-with-skills
+  namespace: mc
+spec:
+  title: Prompt AI With MissionControl Skills
+  category: AI
+  icon: robot
+  configs:
+    - name: "*"
+  parameters:
+    - name: prompt
+      label: Prompt
+      required: true
+      properties:
+        multiline: "true"
+  actions:
+    - name: query
+      ai:
+        backend: anthropic
+        connection: connection://mc/anthropic
+        systemPrompt: |
+          You are a seasoned Kubernetes engineer with extensive expertise in troubleshooting and optimizing Kubernetes resources. 
+          Your primary objective is to assist users in diagnosing issues with Kubernetes pods that are not performing as expected.
+        prompt: "{{.params.prompt}}"
+        skills:
+          - path: skills
+            connection: connection://mc/flanksource-claude-code-plugin-github

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -15,6 +15,7 @@ import (
 	anthropicplugin "github.com/firebase/genkit/go/plugins/anthropic"
 	openaiplugin "github.com/firebase/genkit/go/plugins/compat_oai"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
+	middleware "github.com/firebase/genkit/go/plugins/middleware"
 	ollamaplugin "github.com/firebase/genkit/go/plugins/ollama"
 	dutyctx "github.com/flanksource/duty/context"
 	"github.com/samber/lo"
@@ -39,6 +40,9 @@ type Config struct {
 	ResponseFormat ResponseFormat
 	// CustomSchema is the raw JSON schema string when ResponseFormat == ResponseFormatCustomSchema
 	CustomSchema string
+	// SkillsPath is a temp directory containing skill subdirectories (each with a
+	// SKILL.md). When non-empty, genkit's Skills middleware is activated.
+	SkillsPath string
 }
 
 type GenerationInfo struct {
@@ -89,6 +93,9 @@ func PromptWithHistory(ctx dutyctx.Context, config Config, history []*genkitai.M
 	}
 	if schema != nil {
 		opts = append(opts, genkitai.WithOutputSchema(schema))
+	}
+	if config.SkillsPath != "" {
+		opts = append(opts, genkitai.WithUse(&middleware.Skills{SkillPaths: []string{config.SkillsPath}}))
 	}
 
 	resp, err := genkit.Generate(ctx, g, opts...)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -36,10 +36,11 @@ const (
 
 type Config struct {
 	v1.AIActionClient
-	UseAgent       bool
 	ResponseFormat ResponseFormat
+
 	// CustomSchema is the raw JSON schema string when ResponseFormat == ResponseFormatCustomSchema
 	CustomSchema string
+
 	// SkillPaths are local paths to skill libraries. When non-empty, Genkit's
 	// Skills middleware is activated.
 	SkillPaths []string

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -40,9 +40,9 @@ type Config struct {
 	ResponseFormat ResponseFormat
 	// CustomSchema is the raw JSON schema string when ResponseFormat == ResponseFormatCustomSchema
 	CustomSchema string
-	// SkillsPath is a temp directory containing skill subdirectories (each with a
-	// SKILL.md). When non-empty, genkit's Skills middleware is activated.
-	SkillsPath string
+	// SkillPaths are local paths to skill libraries. When non-empty, Genkit's
+	// Skills middleware is activated.
+	SkillPaths []string
 }
 
 type GenerationInfo struct {
@@ -94,8 +94,8 @@ func PromptWithHistory(ctx dutyctx.Context, config Config, history []*genkitai.M
 	if schema != nil {
 		opts = append(opts, genkitai.WithOutputSchema(schema))
 	}
-	if config.SkillsPath != "" {
-		opts = append(opts, genkitai.WithUse(&middleware.Skills{SkillPaths: []string{config.SkillsPath}}))
+	if len(config.SkillPaths) > 0 {
+		opts = append(opts, genkitai.WithUse(&middleware.Skills{SkillPaths: config.SkillPaths}))
 	}
 
 	resp, err := genkit.Generate(ctx, g, opts...)

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -127,14 +127,16 @@ type childRunResultContext struct {
 func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, error) {
 	var result AIActionResult
 
-	// Load skill files and prepend to system prompt.
-	// If any skill has a JsonSchemaPath, use it as the output schema.
-	for i, skill := range spec.Skills {
-		skillContent, schemaContent, err := loadSkill(ctx, skill)
+	// When skills are specified, clone each skill into a temp directory as a
+	// SKILL.md so genkit's Skills middleware can surface them to the model.
+	var skillsPath string
+	if len(spec.Skills) > 0 {
+		dir, skillDir, schemaContent, err := stageSkills(ctx, spec.Skills)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load skill[%d]: %w", i, err)
+			return nil, fmt.Errorf("failed to stage skills: %w", err)
 		}
-		spec.SystemPrompt = skillContent + "\n\n" + spec.SystemPrompt
+		defer os.RemoveAll(dir)
+		skillsPath = skillDir
 
 		if schemaContent != "" {
 			spec.OutputSchema = &v1.AIOutputSchema{
@@ -204,7 +206,7 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 		}
 	}
 
-	llmConf := llm.Config{AIActionClient: spec.AIActionClient}
+	llmConf := llm.Config{AIActionClient: spec.AIActionClient, SkillsPath: skillsPath}
 
 	// Use diagnosis schema when the requested output format needs it.
 	for _, format := range spec.Formats {
@@ -582,6 +584,54 @@ func loadFileFromGit(ctx context.Context, connectionRef, filePath, branch string
 	}
 
 	return string(content), nil
+}
+
+// stageSkills clones each skill's git repo, writes the skill content as a
+// SKILL.md file into a temp directory, and returns (tempRoot, skillsDir, schemaContent, error).
+// The caller is responsible for cleaning up tempRoot with os.RemoveAll.
+func stageSkills(ctx context.Context, skills []v1.AISkill) (tempRoot, skillsDir string, schemaContent string, err error) {
+	tempRoot, err = os.MkdirTemp("", "mc-skills-*")
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	for i, skill := range skills {
+		root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
+		if err != nil {
+			os.RemoveAll(tempRoot)
+			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
+		}
+
+		content, err := safeReadFile(root, skill.Path)
+		if err != nil {
+			os.RemoveAll(tempRoot)
+			return "", "", "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+		}
+
+		// Each skill becomes a subdirectory named after its path (sanitized)
+		skillName := strings.TrimSuffix(filepath.Base(skill.Path), filepath.Ext(skill.Path))
+		skillDir := filepath.Join(tempRoot, skillName)
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			os.RemoveAll(tempRoot)
+			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
+		}
+
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0644); err != nil {
+			os.RemoveAll(tempRoot)
+			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
+		}
+
+		if skill.JsonSchemaPath != "" && schemaContent == "" {
+			schema, err := safeReadFile(root, skill.JsonSchemaPath)
+			if err != nil {
+				os.RemoveAll(tempRoot)
+				return "", "", "", fmt.Errorf("skill[%d] schema %q: %w", i, skill.JsonSchemaPath, err)
+			}
+			schemaContent = string(schema)
+		}
+	}
+
+	return tempRoot, tempRoot, schemaContent, nil
 }
 
 // loadSkill clones a git repository using the provided connection, reads the skill file,

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -127,16 +127,15 @@ type childRunResultContext struct {
 func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, error) {
 	var result AIActionResult
 
-	// When skills are specified, stage each skill into a temp directory as a
-	// SKILL.md so genkit's Skills middleware can surface them to the model.
-	var skillsPath string
+	// Resolve skill paths for the LLM skills middleware. Local paths are passed
+	// through directly; git paths are resolved inside the cloned repository.
+	var skillPaths []string
 	if len(spec.Skills) > 0 {
-		dir, err := stageSkills(ctx, spec.Skills)
+		paths, err := resolveSkillPaths(ctx, spec.Skills)
 		if err != nil {
-			return nil, fmt.Errorf("failed to stage skills: %w", err)
+			return nil, fmt.Errorf("failed to resolve skills: %w", err)
 		}
-		defer os.RemoveAll(dir)
-		skillsPath = dir
+		skillPaths = paths
 	}
 
 	knowledgebase, prompt, err := buildPrompt(ctx, spec.Prompt, spec.LLMContextRequest)
@@ -200,7 +199,7 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 		}
 	}
 
-	llmConf := llm.Config{AIActionClient: spec.AIActionClient, SkillsPath: skillsPath}
+	llmConf := llm.Config{AIActionClient: spec.AIActionClient, SkillPaths: skillPaths}
 
 	// Use diagnosis schema when the requested output format needs it.
 	for _, format := range spec.Formats {
@@ -543,23 +542,32 @@ func cloneGitRepo(ctx context.Context, connectionRef, branch string) (string, er
 	return workTree.Filesystem.Root(), nil
 }
 
-// safeReadFile validates that filePath does not escape root via traversal,
-// then reads and returns the file content.
-func safeReadFile(root, filePath string) ([]byte, error) {
+// safeResolvePath validates that filePath does not escape root via traversal.
+func safeResolvePath(root, filePath string) (string, error) {
 	if filepath.IsAbs(filePath) {
-		return nil, fmt.Errorf("absolute paths are not allowed: %q", filePath)
+		return "", fmt.Errorf("absolute paths are not allowed: %q", filePath)
 	}
 
 	joined := filepath.Join(root, filepath.Clean(filePath))
-
 	resolved, err := filepath.EvalSymlinks(joined)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve path %q: %w", filePath, err)
+		return "", fmt.Errorf("failed to resolve path %q: %w", filePath, err)
 	}
 
 	rel, err := filepath.Rel(root, resolved)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return nil, fmt.Errorf("path %q resolves outside the repository root", filePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %q resolves outside the repository root", filePath)
+	}
+
+	return resolved, nil
+}
+
+// safeReadFile validates that filePath does not escape root via traversal,
+// then reads and returns the file content.
+func safeReadFile(root, filePath string) ([]byte, error) {
+	resolved, err := safeResolvePath(root, filePath)
+	if err != nil {
+		return nil, err
 	}
 
 	return os.ReadFile(resolved)
@@ -580,76 +588,35 @@ func loadFileFromGit(ctx context.Context, connectionRef, filePath, branch string
 	return string(content), nil
 }
 
-// stageSkills stages each skill into a temp directory containing per-skill
-// subdirectories with SKILL.md files. When a skill has Connection set, the
-// repo is cloned; otherwise Path is read from the local filesystem.
-func stageSkills(ctx context.Context, skills []v1.AISkill) (string, error) {
-	tempRoot, err := os.MkdirTemp("", "mc-skills-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
-	}
+// resolveSkillPaths resolves local and git skill paths for the LLM skills middleware.
+func resolveSkillPaths(ctx context.Context, skills []v1.AISkill) ([]string, error) {
+	paths := make([]string, 0, len(skills))
 
 	for i, skill := range skills {
-		var content []byte
-		var srcDir string
+		if strings.TrimSpace(skill.Path) == "" {
+			return nil, fmt.Errorf("skill[%d]: path is required", i)
+		}
 
 		if skill.Connection != "" {
 			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
 			if err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d]: %w", i, err)
+				return nil, fmt.Errorf("skill[%d]: %w", i, err)
 			}
-			resolved := filepath.Join(root, skill.Path)
-			fi, err := os.Stat(resolved)
+
+			resolved, err := safeResolvePath(root, skill.Path)
 			if err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+				return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
 			}
-			if fi.IsDir() {
-				srcDir = resolved
-			} else {
-				content, err = safeReadFile(root, skill.Path)
-				if err != nil {
-					os.RemoveAll(tempRoot)
-					return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-				}
-			}
-		} else {
-			fi, err := os.Stat(skill.Path)
-			if err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-			}
-			if fi.IsDir() {
-				srcDir = skill.Path
-			} else {
-				content, err = os.ReadFile(skill.Path)
-				if err != nil {
-					os.RemoveAll(tempRoot)
-					return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-				}
-			}
+
+			paths = append(paths, resolved)
+			continue
 		}
 
-		skillName := strings.TrimSuffix(filepath.Base(skill.Path), filepath.Ext(skill.Path))
-		linkPath := filepath.Join(tempRoot, skillName)
-
-		if srcDir != "" {
-			if err := os.Symlink(srcDir, linkPath); err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d]: %w", i, err)
-			}
-		} else {
-			if err := os.MkdirAll(linkPath, 0755); err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d]: %w", i, err)
-			}
-			if err := os.WriteFile(filepath.Join(linkPath, "SKILL.md"), content, 0644); err != nil {
-				os.RemoveAll(tempRoot)
-				return "", fmt.Errorf("skill[%d]: %w", i, err)
-			}
+		if _, err := os.Stat(skill.Path); err != nil {
+			return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
 		}
+		paths = append(paths, skill.Path)
 	}
 
-	return tempRoot, nil
+	return paths, nil
 }

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -591,35 +591,63 @@ func stageSkills(ctx context.Context, skills []v1.AISkill) (string, error) {
 
 	for i, skill := range skills {
 		var content []byte
+		var srcDir string
+
 		if skill.Connection != "" {
 			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
 			if err != nil {
 				os.RemoveAll(tempRoot)
 				return "", fmt.Errorf("skill[%d]: %w", i, err)
 			}
-			content, err = safeReadFile(root, skill.Path)
+			resolved := filepath.Join(root, skill.Path)
+			fi, err := os.Stat(resolved)
 			if err != nil {
 				os.RemoveAll(tempRoot)
 				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
 			}
+			if fi.IsDir() {
+				srcDir = resolved
+			} else {
+				content, err = safeReadFile(root, skill.Path)
+				if err != nil {
+					os.RemoveAll(tempRoot)
+					return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+				}
+			}
 		} else {
-			content, err = os.ReadFile(skill.Path)
+			fi, err := os.Stat(skill.Path)
 			if err != nil {
 				os.RemoveAll(tempRoot)
 				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+			}
+			if fi.IsDir() {
+				srcDir = skill.Path
+			} else {
+				content, err = os.ReadFile(skill.Path)
+				if err != nil {
+					os.RemoveAll(tempRoot)
+					return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+				}
 			}
 		}
 
 		skillName := strings.TrimSuffix(filepath.Base(skill.Path), filepath.Ext(skill.Path))
-		skillDir := filepath.Join(tempRoot, skillName)
-		if err := os.MkdirAll(skillDir, 0755); err != nil {
-			os.RemoveAll(tempRoot)
-			return "", fmt.Errorf("skill[%d]: %w", i, err)
-		}
+		linkPath := filepath.Join(tempRoot, skillName)
 
-		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0644); err != nil {
-			os.RemoveAll(tempRoot)
-			return "", fmt.Errorf("skill[%d]: %w", i, err)
+		if srcDir != "" {
+			if err := os.Symlink(srcDir, linkPath); err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d]: %w", i, err)
+			}
+		} else {
+			if err := os.MkdirAll(linkPath, 0755); err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d]: %w", i, err)
+			}
+			if err := os.WriteFile(filepath.Join(linkPath, "SKILL.md"), content, 0644); err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d]: %w", i, err)
+			}
 		}
 	}
 

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -6,13 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/flanksource/artifacts"
-	pkgConnection "github.com/flanksource/duty/connection"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
@@ -29,8 +26,6 @@ import (
 	"github.com/flanksource/incident-commander/events"
 	"github.com/flanksource/incident-commander/llm"
 	llmContext "github.com/flanksource/incident-commander/llm/context"
-	"github.com/flanksource/incident-commander/pkg/clients/git"
-	"github.com/flanksource/incident-commander/pkg/clients/git/connectors"
 	"github.com/flanksource/incident-commander/utils"
 )
 
@@ -127,17 +122,6 @@ type childRunResultContext struct {
 func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, error) {
 	var result AIActionResult
 
-	// Resolve skill paths for the LLM skills middleware. Local paths are passed
-	// through directly; git paths are resolved inside the cloned repository.
-	var skillPaths []string
-	if len(spec.Skills) > 0 {
-		paths, err := resolveSkillPaths(ctx, spec.Skills)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve skills: %w", err)
-		}
-		skillPaths = paths
-	}
-
 	knowledgebase, prompt, err := buildPrompt(ctx, spec.Prompt, spec.LLMContextRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to form prompt: %w", err)
@@ -199,7 +183,15 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 		}
 	}
 
-	llmConf := llm.Config{AIActionClient: spec.AIActionClient, SkillPaths: skillPaths}
+	skillPaths, err := resolveSkillPaths(ctx, spec.Skills)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve skills: %w", err)
+	}
+
+	llmConf := llm.Config{
+		AIActionClient: spec.AIActionClient,
+		SkillPaths:     skillPaths,
+	}
 
 	// Use diagnosis schema when the requested output format needs it.
 	for _, format := range spec.Formats {
@@ -207,6 +199,7 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 			llmConf.ResponseFormat = llm.ResponseFormatDiagnosis
 			break
 		}
+	}
 	}
 
 	// Resolve custom output schema if provided
@@ -497,126 +490,4 @@ func resolveOutputSchema(ctx context.Context, schema v1.AIOutputSchema) (string,
 	}
 
 	return "", nil
-}
-
-// cloneGitRepo resolves a git connection and clones the repo, returning the worktree root path.
-func cloneGitRepo(ctx context.Context, connectionRef, branch string) (string, error) {
-	conn, err := pkgConnection.Get(ctx, connectionRef)
-	if err != nil {
-		return "", fmt.Errorf("failed to get git connection %q: %w", connectionRef, err)
-	} else if conn == nil {
-		return "", fmt.Errorf("git connection %q not found", connectionRef)
-	}
-
-	spec := &connectors.GitopsAPISpec{
-		Repository: conn.URL,
-		Base:       "main",
-		Branch:     "main",
-	}
-
-	if branch != "" {
-		spec.Base = branch
-		spec.Branch = branch
-	}
-
-	switch conn.Type {
-	case models.ConnectionTypeGithub, models.ConnectionTypeGitlab, models.ConnectionTypeAzureDevops:
-		spec.AccessToken = conn.Password
-	case models.ConnectionTypeHTTP:
-		spec.User = conn.Username
-		spec.Password = conn.Password
-	case models.ConnectionTypeGit:
-		spec.User = conn.Username
-		spec.Password = conn.Password
-		spec.SSHPrivateKey = conn.Certificate
-		spec.SSHPrivateKeyPassword = conn.Password
-	default:
-		return "", fmt.Errorf("unsupported connection type %q", conn.Type)
-	}
-
-	_, workTree, err := git.Clone(ctx, spec)
-	if err != nil {
-		return "", fmt.Errorf("failed to clone repository: %w", err)
-	}
-
-	return workTree.Filesystem.Root(), nil
-}
-
-// safeResolvePath validates that filePath does not escape root via traversal.
-func safeResolvePath(root, filePath string) (string, error) {
-	if filepath.IsAbs(filePath) {
-		return "", fmt.Errorf("absolute paths are not allowed: %q", filePath)
-	}
-
-	joined := filepath.Join(root, filepath.Clean(filePath))
-	resolved, err := filepath.EvalSymlinks(joined)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve path %q: %w", filePath, err)
-	}
-
-	rel, err := filepath.Rel(root, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("path %q resolves outside the repository root", filePath)
-	}
-
-	return resolved, nil
-}
-
-// safeReadFile validates that filePath does not escape root via traversal,
-// then reads and returns the file content.
-func safeReadFile(root, filePath string) ([]byte, error) {
-	resolved, err := safeResolvePath(root, filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return os.ReadFile(resolved)
-}
-
-// loadFileFromGit clones a git repo and reads a file at the given path.
-func loadFileFromGit(ctx context.Context, connectionRef, filePath, branch string) (string, error) {
-	root, err := cloneGitRepo(ctx, connectionRef, branch)
-	if err != nil {
-		return "", err
-	}
-
-	content, err := safeReadFile(root, filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read file %q: %w", filePath, err)
-	}
-
-	return string(content), nil
-}
-
-// resolveSkillPaths resolves local and git skill paths for the LLM skills middleware.
-func resolveSkillPaths(ctx context.Context, skills []v1.AISkill) ([]string, error) {
-	paths := make([]string, 0, len(skills))
-
-	for i, skill := range skills {
-		if strings.TrimSpace(skill.Path) == "" {
-			return nil, fmt.Errorf("skill[%d]: path is required", i)
-		}
-
-		if skill.Connection != "" {
-			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
-			if err != nil {
-				return nil, fmt.Errorf("skill[%d]: %w", i, err)
-			}
-
-			resolved, err := safeResolvePath(root, skill.Path)
-			if err != nil {
-				return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-			}
-
-			paths = append(paths, resolved)
-			continue
-		}
-
-		if _, err := os.Stat(skill.Path); err != nil {
-			return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-		}
-		paths = append(paths, skill.Path)
-	}
-
-	return paths, nil
 }

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -127,22 +127,16 @@ type childRunResultContext struct {
 func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, error) {
 	var result AIActionResult
 
-	// When skills are specified, clone each skill into a temp directory as a
+	// When skills are specified, stage each skill into a temp directory as a
 	// SKILL.md so genkit's Skills middleware can surface them to the model.
 	var skillsPath string
 	if len(spec.Skills) > 0 {
-		dir, skillDir, schemaContent, err := stageSkills(ctx, spec.Skills)
+		dir, err := stageSkills(ctx, spec.Skills)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stage skills: %w", err)
 		}
 		defer os.RemoveAll(dir)
-		skillsPath = skillDir
-
-		if schemaContent != "" {
-			spec.OutputSchema = &v1.AIOutputSchema{
-				EnvVar: types.EnvVar{ValueStatic: schemaContent},
-			}
-		}
+		skillsPath = dir
 	}
 
 	knowledgebase, prompt, err := buildPrompt(ctx, spec.Prompt, spec.LLMContextRequest)
@@ -586,76 +580,48 @@ func loadFileFromGit(ctx context.Context, connectionRef, filePath, branch string
 	return string(content), nil
 }
 
-// stageSkills clones each skill's git repo, writes the skill content as a
-// SKILL.md file into a temp directory, and returns (tempRoot, skillsDir, schemaContent, error).
-// The caller is responsible for cleaning up tempRoot with os.RemoveAll.
-func stageSkills(ctx context.Context, skills []v1.AISkill) (tempRoot, skillsDir string, schemaContent string, err error) {
-	tempRoot, err = os.MkdirTemp("", "mc-skills-*")
+// stageSkills stages each skill into a temp directory containing per-skill
+// subdirectories with SKILL.md files. When a skill has Connection set, the
+// repo is cloned; otherwise Path is read from the local filesystem.
+func stageSkills(ctx context.Context, skills []v1.AISkill) (string, error) {
+	tempRoot, err := os.MkdirTemp("", "mc-skills-*")
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to create temp dir: %w", err)
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
 	for i, skill := range skills {
-		root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
-		if err != nil {
-			os.RemoveAll(tempRoot)
-			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
+		var content []byte
+		if skill.Connection != "" {
+			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
+			if err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d]: %w", i, err)
+			}
+			content, err = safeReadFile(root, skill.Path)
+			if err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+			}
+		} else {
+			content, err = os.ReadFile(skill.Path)
+			if err != nil {
+				os.RemoveAll(tempRoot)
+				return "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+			}
 		}
 
-		content, err := safeReadFile(root, skill.Path)
-		if err != nil {
-			os.RemoveAll(tempRoot)
-			return "", "", "", fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-		}
-
-		// Each skill becomes a subdirectory named after its path (sanitized)
 		skillName := strings.TrimSuffix(filepath.Base(skill.Path), filepath.Ext(skill.Path))
 		skillDir := filepath.Join(tempRoot, skillName)
 		if err := os.MkdirAll(skillDir, 0755); err != nil {
 			os.RemoveAll(tempRoot)
-			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
+			return "", fmt.Errorf("skill[%d]: %w", i, err)
 		}
 
 		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0644); err != nil {
 			os.RemoveAll(tempRoot)
-			return "", "", "", fmt.Errorf("skill[%d]: %w", i, err)
-		}
-
-		if skill.JsonSchemaPath != "" && schemaContent == "" {
-			schema, err := safeReadFile(root, skill.JsonSchemaPath)
-			if err != nil {
-				os.RemoveAll(tempRoot)
-				return "", "", "", fmt.Errorf("skill[%d] schema %q: %w", i, skill.JsonSchemaPath, err)
-			}
-			schemaContent = string(schema)
+			return "", fmt.Errorf("skill[%d]: %w", i, err)
 		}
 	}
 
-	return tempRoot, tempRoot, schemaContent, nil
-}
-
-// loadSkill clones a git repository using the provided connection, reads the skill file,
-// and optionally reads the JSON schema file if JsonSchemaPath is set.
-// Returns (skillContent, schemaContent, error).
-func loadSkill(ctx context.Context, skill v1.AISkill) (string, string, error) {
-	root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to clone skill repository: %w", err)
-	}
-
-	content, err := safeReadFile(root, skill.Path)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to read skill file %q: %w", skill.Path, err)
-	}
-
-	var schemaContent string
-	if skill.JsonSchemaPath != "" {
-		schema, err := safeReadFile(root, skill.JsonSchemaPath)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to read json schema file %q: %w", skill.JsonSchemaPath, err)
-		}
-		schemaContent = string(schema)
-	}
-
-	return string(content), schemaContent, nil
+	return tempRoot, nil
 }

--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -200,7 +200,6 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 			break
 		}
 	}
-	}
 
 	// Resolve custom output schema if provided
 	customSchema := false

--- a/playbook/actions/ai_skills.go
+++ b/playbook/actions/ai_skills.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/flanksource/duty/context"
@@ -33,11 +34,49 @@ func resolveSkillPaths(ctx context.Context, skills []v1.AISkill) ([]string, erro
 			continue
 		}
 
-		if _, err := os.Stat(skill.Path); err != nil {
+		fi, err := os.Stat(skill.Path)
+		if err != nil {
 			return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+		} else if !fi.IsDir() {
+			return nil, fmt.Errorf("skill[%d] %q: path must be a directory containing skill subdirectories", i, skill.Path)
 		}
+
 		paths = append(paths, skill.Path)
 	}
 
+	warnEmptySkillPaths(ctx, paths)
+
 	return paths, nil
+}
+
+// warnEmptySkillPaths logs a warning for any resolved path that does not contain
+// at least one skill subdirectory with a SKILL.md file. The genkit skills
+// middleware silently skips such paths, which would otherwise hide a
+// misconfiguration (e.g. pointing Path at a skill directory instead of its
+// parent).
+func warnEmptySkillPaths(ctx context.Context, paths []string) {
+	for _, p := range paths {
+		if !pathHasSkill(p) {
+			ctx.Logger.Warnf("ai skill path %q contains no skill subdirectories with a SKILL.md file; skills will not be loaded from it", p)
+		}
+	}
+}
+
+// pathHasSkill reports whether the directory p contains at least one
+// subdirectory with a SKILL.md file, matching the layout expected by the
+// genkit skills middleware (p/<skill-name>/SKILL.md).
+func pathHasSkill(p string) bool {
+	entries, err := os.ReadDir(p)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if fi, err := os.Stat(filepath.Join(p, entry.Name(), "SKILL.md")); err == nil && !fi.IsDir() {
+			return true
+		}
+	}
+	return false
 }

--- a/playbook/actions/ai_skills.go
+++ b/playbook/actions/ai_skills.go
@@ -1,0 +1,43 @@
+package actions
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/flanksource/duty/context"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+)
+
+// resolveSkillPaths resolves local and git skill paths for the LLM skills middleware.
+func resolveSkillPaths(ctx context.Context, skills []v1.AISkill) ([]string, error) {
+	paths := make([]string, 0, len(skills))
+
+	for i, skill := range skills {
+		if strings.TrimSpace(skill.Path) == "" {
+			return nil, fmt.Errorf("skill[%d]: path is required", i)
+		}
+
+		if skill.Connection != "" {
+			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
+			if err != nil {
+				return nil, fmt.Errorf("skill[%d]: %w", i, err)
+			}
+
+			resolved, err := safeResolvePath(root, skill.Path)
+			if err != nil {
+				return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+			}
+
+			paths = append(paths, resolved)
+			continue
+		}
+
+		if _, err := os.Stat(skill.Path); err != nil {
+			return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
+		}
+		paths = append(paths, skill.Path)
+	}
+
+	return paths, nil
+}

--- a/playbook/actions/ai_skills.go
+++ b/playbook/actions/ai_skills.go
@@ -19,34 +19,71 @@ func resolveSkillPaths(ctx context.Context, skills []v1.AISkill) ([]string, erro
 			return nil, fmt.Errorf("skill[%d]: path is required", i)
 		}
 
+		var root string
 		if skill.Connection != "" {
-			root, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
+			clonedRoot, err := cloneGitRepo(ctx, skill.Connection, skill.Branch)
 			if err != nil {
 				return nil, fmt.Errorf("skill[%d]: %w", i, err)
 			}
-
-			resolved, err := safeResolvePath(root, skill.Path)
-			if err != nil {
-				return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-			}
-
-			paths = append(paths, resolved)
-			continue
+			root = clonedRoot
 		}
 
-		fi, err := os.Stat(skill.Path)
+		resolved, err := resolveAndValidateSkillPath(root, skill.Path)
 		if err != nil {
 			return nil, fmt.Errorf("skill[%d] %q: %w", i, skill.Path, err)
-		} else if !fi.IsDir() {
-			return nil, fmt.Errorf("skill[%d] %q: path must be a directory containing skill subdirectories", i, skill.Path)
 		}
-
-		paths = append(paths, skill.Path)
+		paths = append(paths, resolved)
 	}
 
 	warnEmptySkillPaths(ctx, paths)
 
 	return paths, nil
+}
+
+// resolveAndValidateSkillPath resolves a skill path to an absolute directory and
+// validates it. The same constraints are applied to both git-backed and
+// local-filesystem skills:
+//
+//   - symlink verification: the path is resolved through filepath.EvalSymlinks
+//     so symlinked skill directories are followed to their real target.
+//   - directory traversal validation: when root is non-empty (git-backed
+//     skills), the path must be repo-relative and the resolved target must not
+//     escape root. When root is empty (local-filesystem skills), absolute paths
+//     are allowed and no traversal boundary is enforced, by design.
+//   - the resolved path must be a directory.
+func resolveAndValidateSkillPath(root, p string) (string, error) {
+	var resolved string
+	if root != "" {
+		if filepath.IsAbs(p) {
+			return "", fmt.Errorf("absolute paths are not allowed: %q", p)
+		}
+		joined := filepath.Join(root, filepath.Clean(p))
+		var err error
+		resolved, err = filepath.EvalSymlinks(joined)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve path %q: %w", p, err)
+		}
+		rel, err := filepath.Rel(root, resolved)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return "", fmt.Errorf("path %q resolves outside the repository root", p)
+		}
+	} else {
+		var err error
+		resolved, err = filepath.EvalSymlinks(p)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve path %q: %w", p, err)
+		}
+	}
+
+	fi, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat path %q: %w", p, err)
+	}
+	if !fi.IsDir() {
+		return "", fmt.Errorf("path %q must be a directory containing skill subdirectories", p)
+	}
+
+	return resolved, nil
 }
 
 // warnEmptySkillPaths logs a warning for any resolved path that does not contain

--- a/playbook/actions/git_utils.go
+++ b/playbook/actions/git_utils.go
@@ -1,0 +1,103 @@
+package actions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	pkgConnection "github.com/flanksource/duty/connection"
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/incident-commander/pkg/clients/git"
+	"github.com/flanksource/incident-commander/pkg/clients/git/connectors"
+)
+
+// cloneGitRepo resolves a git connection and clones the repo, returning the worktree root path.
+func cloneGitRepo(ctx context.Context, connectionRef, branch string) (string, error) {
+	conn, err := pkgConnection.Get(ctx, connectionRef)
+	if err != nil {
+		return "", fmt.Errorf("failed to get git connection %q: %w", connectionRef, err)
+	} else if conn == nil {
+		return "", fmt.Errorf("git connection %q not found", connectionRef)
+	}
+
+	spec := &connectors.GitopsAPISpec{
+		Repository: conn.URL,
+		Base:       "main",
+		Branch:     "main",
+	}
+
+	if branch != "" {
+		spec.Base = branch
+		spec.Branch = branch
+	}
+
+	switch conn.Type {
+	case models.ConnectionTypeGithub, models.ConnectionTypeGitlab, models.ConnectionTypeAzureDevops:
+		spec.AccessToken = conn.Password
+	case models.ConnectionTypeHTTP:
+		spec.User = conn.Username
+		spec.Password = conn.Password
+	case models.ConnectionTypeGit:
+		spec.User = conn.Username
+		spec.Password = conn.Password
+		spec.SSHPrivateKey = conn.Certificate
+		spec.SSHPrivateKeyPassword = conn.Password
+	default:
+		return "", fmt.Errorf("unsupported connection type %q", conn.Type)
+	}
+
+	_, workTree, err := git.Clone(ctx, spec)
+	if err != nil {
+		return "", fmt.Errorf("failed to clone repository: %w", err)
+	}
+
+	return workTree.Filesystem.Root(), nil
+}
+
+// safeResolvePath validates that filePath does not escape root via traversal.
+func safeResolvePath(root, filePath string) (string, error) {
+	if filepath.IsAbs(filePath) {
+		return "", fmt.Errorf("absolute paths are not allowed: %q", filePath)
+	}
+
+	joined := filepath.Join(root, filepath.Clean(filePath))
+	resolved, err := filepath.EvalSymlinks(joined)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", filePath, err)
+	}
+
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %q resolves outside the repository root", filePath)
+	}
+
+	return resolved, nil
+}
+
+// safeReadFile validates that filePath does not escape root via traversal,
+// then reads and returns the file content.
+func safeReadFile(root, filePath string) ([]byte, error) {
+	resolved, err := safeResolvePath(root, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.ReadFile(resolved)
+}
+
+// loadFileFromGit clones a git repo and reads a file at the given path.
+func loadFileFromGit(ctx context.Context, connectionRef, filePath, branch string) (string, error) {
+	root, err := cloneGitRepo(ctx, connectionRef, branch)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := safeReadFile(root, filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %q: %w", filePath, err)
+	}
+
+	return string(content), nil
+}


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3242

Replace the old approach of prepending skill content directly into the system prompt with genkit's `middleware.Skills` plugin, which injects a `use_skill` tool so the model can load skills on demand.

- `llm.Config.SkillsPath` carries a temp directory of `SKILL.md` files
- `stageSkills()` clones `AISkill` git repos into the temp dir structure the middleware expects
- The old prepend loop is removed; the genkit middleware handles injection + the `use_skill` tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reusable Genkit skill libraries in playbooks (directory-based with `SKILL.md` subdirectories).
  * Skills can now load from local filesystem or from git-backed connections.
  * Enabled Genkit Skills middleware via new `SkillPaths` configuration.
* **Documentation**
  * Updated CRD and JSON schemas to reflect the new skill library model and simplified required fields.
* **Tests**
  * Updated playbook/fixture coverage and added a sample git connection manifest for skill loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->