### PR TITLE
fix: allow playbook config to override connection model

### DIFF
--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -316,7 +316,7 @@ func (t *AIActionClient) Populate(ctx context.Context) error {
 
 		t.APIURL = conn.URL
 
-		if m, ok := conn.Properties["model"]; ok {
+		if m, ok := conn.Properties["model"]; ok && t.Model == "" {
 			t.Model = m
 		}
 


### PR DESCRIPTION
When an AI playbook specifies a `model:` in its config, it should take precedence over the model defined in the referenced connection. Previously, `AIActionClient.Populate()` always overwrote the user-specified model with the connection's model.

**Fix**: Only use the connection's model as a fallback when the playbook config doesn't specify one.

Fixes #3252