### PR TITLE
fix: don't hardcode ResponseFormatDiagnosis for AI actions

### DIFF
--- a/playbook/actions/ai.go
+++ b/playbook/actions/ai.go
@@ -204,7 +204,15 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 		}
 	}
 
-	llmConf := llm.Config{AIActionClient: spec.AIActionClient, ResponseFormat: llm.ResponseFormatDiagnosis}
+	llmConf := llm.Config{AIActionClient: spec.AIActionClient}
+
+	// Use diagnosis schema when the requested output format needs it.
+	for _, format := range spec.Formats {
+		if format == v1.AIActionFormatSlack || format == v1.AIActionFormatRecommendPlaybook {
+			llmConf.ResponseFormat = llm.ResponseFormatDiagnosis
+			break
+		}
+	}
 
 	// Resolve custom output schema if provided
 	customSchema := false
@@ -228,9 +236,9 @@ func (t *aiAction) Run(ctx context.Context, spec v1.AIAction) (*AIActionResult, 
 	result.JSON = response
 	result.GenerationInfo = append(result.GenerationInfo, genInfo...)
 
-	// When using a custom schema, skip DiagnosisReport unmarshaling
+	// Only unmarshal into DiagnosisReport when the response format is diagnosis.
 	var diagnosisReport llm.DiagnosisReport
-	if !customSchema {
+	if llmConf.ResponseFormat == llm.ResponseFormatDiagnosis {
 		if err := json.Unmarshal([]byte(response), &diagnosisReport); err != nil {
 			return nil, ctx.Oops().With("response", response).Wrapf(err, "failed to unmarshal diagnosis report")
 		}


### PR DESCRIPTION
Only use diagnosis schema when the requested output formats (slack, recommendPlaybook) actually need it. Otherwise let the LLM respond freely without any schema constraint.

Also only unmarshal into DiagnosisReport when the response format is actually diagnosis, rather than always attempting it.

Fixes #3255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved AI action response handling so diagnosis data is only parsed when the requested output formats include Slack or playbook recommendations, leading to more accurate results and fewer incorrect interpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->