### PR TITLE
fix(git): allow cloning public repos without credentials

### DIFF
--- a/pkg/clients/git/connectors/git_access_token.go
+++ b/pkg/clients/git/connectors/git_access_token.go
@@ -76,7 +76,13 @@ func NewAccessTokenClient(url, service, accessToken string) (Connector, error) {
 		owner:      owner,
 		repoName:   repoName,
 		repository: owner + "/" + repoName,
-		auth:       &http.BasicAuth{Username: "token", Password: accessToken},
+	}
+	// Only attach BasicAuth when a token is configured. go-git cannot clone
+	// public repositories anonymously if an (empty) BasicAuth is supplied —
+	// GitHub rejects it with "authentication required". nil auth lets go-git
+	// clone public repos without credentials.
+	if accessToken != "" {
+		client.auth = &http.BasicAuth{Username: "token", Password: accessToken}
 	}
 	return client, nil
 }


### PR DESCRIPTION
## Problem

`git.Clone(ctx, spec)` could not clone a **public** GitHub repository without credentials:

```
failed to clone repo https://github.com/flanksource/claude-code-plugin (remoteBranch: main, localBranch: main):
authentication required: Invalid username or token. Password authentication is not supported for Git operations.
```

## Root cause

`GitAccessTokenClient` (in `pkg/clients/git/connectors/git_access_token.go`) **always** attached an HTTP `BasicAuth` to every clone request — even when no access token was configured:

```go
auth: &http.BasicAuth{Username: "token", Password: accessToken}, // Password == "" when no token
```

go-git cannot clone public repositories anonymously when an (empty) `BasicAuth` is supplied. GitHub sees present-but-invalid credentials and returns `ErrAuthorizationRequired`, indistinguishable from a private/nonexistent repo. This is confirmed by upstream go-git issue [#489](https://github.com/go-git/go-git/issues/489):

> "I was able to clone a public repo only by either passing in correct credentials when the Auth object is set **or by not including the Auth object at all.**"

## Fix

Only attach `BasicAuth` when an access token is present; otherwise leave `auth` nil so go-git clones public repos anonymously.

```go
if accessToken != "" {
    client.auth = &http.BasicAuth{Username: "token", Password: accessToken}
}
```

Push/PR operations naturally require a token and will fail at the server when none is configured — which is the correct behavior.

## Verification

- `go build ./pkg/clients/git/...` and `go vet` pass.
- Wrote a Ginkgo spec that clones `https://github.com/flanksource/claude-code-plugin` with no credentials:
  - **With the fix** → ✅ clones successfully.
  - **Fix reverted, test kept** → ❌ fails with the **exact** error from the issue (`authentication required: Invalid username or token...`), confirming the test reproduces the bug.
  - **Fix restored** → ✅ passes again.
- The live-network test was intentionally **not** committed (network/flake dependent, and skipped in CI via `ignore_local`). The explanatory code comment documents the why.

## Files changed

- `pkg/clients/git/connectors/git_access_token.go` — guard `BasicAuth` on non-empty token.