### PR TITLE
fix(plugin): thread user subject through nested plugin invocations

### DIFF
--- a/plugin/machinery/host_grpc.go
+++ b/plugin/machinery/host_grpc.go
@@ -143,14 +143,19 @@ func (s *Service) GetConnection(ctx context.Context, req *pluginAPI.GetConnectio
 
 func (s *Service) InvokePlugin(ctx context.Context, req *pluginAPI.InvokePluginRequest) (*pluginAPI.InvokeResponse, error) {
 	dutyCtx := invocationDutyContext(s.ctx, ctx)
-	source, err := pluginEntryFromInvocation(ctx)
-	if err != nil {
+	if _, err := pluginEntryFromInvocation(ctx); err != nil {
 		return nil, err
 	}
 
 	depth := 1
+	// Plugins always act on behalf of the originating user, so thread the
+	// user's subject (from the calling plugin's invocation token) down the
+	// chain. The same subject authorizes the invoke and becomes the next
+	// token's sub — no plugin-scoped invoke permission is required.
+	userSubject := ""
 	if claims, ok := invocationClaimsFromContext(ctx); ok {
 		depth = claims.Depth + 1
+		userSubject = claims.Subject
 	}
 
 	configID := req.ConfigItemId
@@ -160,7 +165,7 @@ func (s *Service) InvokePlugin(ctx context.Context, req *pluginAPI.InvokePluginR
 		PluginRef:  req.Plugin,
 		Operation:  req.Operation,
 		ParamsJSON: req.ParamsJson,
-		Subject:    PluginSubject(source.Namespace, source.Name),
+		Subject:    userSubject,
 		Depth:      depth,
 		Deadline:   req.Deadline,
 

--- a/plugin/machinery/invoke.go
+++ b/plugin/machinery/invoke.go
@@ -3,7 +3,6 @@ package machinery
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	dutyAPI "github.com/flanksource/duty/api"
@@ -85,6 +84,9 @@ func InvokeOperation(ctx dutyContext.Context, req Request) (*api.InvokeResponse,
 		req.Roles = claims.Roles
 	} else {
 		// No invocation token was supplied, so authorize locally before minting one.
+		// Plugins always act on behalf of the user, so the same subject threads
+		// unchanged down the chain: it is both the RBAC principal (must hold
+		// invoke:<plugin>:<op>) and the JWT sub.
 		if err := EnforceInvokePermission(ctx, subject, entry, req.Operation, req.ConfigItemID); err != nil {
 			return nil, entry, err
 		}
@@ -191,8 +193,4 @@ func EnforceInvokePermission(ctx dutyContext.Context, subject string, entry *plu
 
 func CanInvokePluginOperation(ctx dutyContext.Context, subject string, attr *models.ABACAttribute, pluginName, op string) bool {
 	return dutyRBAC.HasPermission(ctx, subject, attr, policy.NewPluginInvokeAction(pluginName, op))
-}
-
-func PluginSubject(namespace, name string) string {
-	return fmt.Sprintf("plugin:%s/%s", namespace, name)
 }


### PR DESCRIPTION
When plugin A invokes plugin B (e.g. kubernetes-gather → kubernetes-logs), B's host callbacks (GetConfigItem, GetConnection, Log, InvokePlugin, …) authenticate by resolving the invocation token's `sub` against the people table.

The proxied-plugins refactor (#3160) set that `sub` to the calling plugin (`plugin:ns/name`) instead of the originating user. On the standalone upstream the people lookup then failed with `Unauthenticated`, breaking every plugin-to-plugin chain whose target touched the host. It only passed on agents, which skip the person lookup.

Thread the originating user's subject (from the calling plugin's token claims) down the chain. The user is now both the RBAC principal for `invoke:<plugin>:<op>` and the JWT `sub`, unchanged across every hop. Plugins have no invoke-identity of their own; connection access stays plugin-scoped via `pluginRBACSubject`.

Behavioral note: Permission CRDs granting `invoke:pluginX:*` to `plugin:Y-ns/Z` subjects are now no-ops.