### PR TITLE
feat(faro): group dynamic plugin/playbook commands in --help

### DIFF
--- a/clientcmd/groups.go
+++ b/clientcmd/groups.go
@@ -1,0 +1,80 @@
+package clientcmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Command group IDs used to organize the top-level --help output into titled
+// sections. The dynamic playbook and plugin commands are tagged with their
+// respective IDs as they are registered; any remaining top-level command (the
+// static client, catalog, version and server commands) is folded into the core
+// group by FinalizeCommandGroups.
+const (
+	GroupCore      = "core"
+	GroupPlaybooks = "playbooks"
+	GroupPlugins   = "plugins"
+)
+
+// commandGroupTitles maps a group ID to the heading cobra renders for it.
+// Titles carry a trailing colon to match the existing "Logging flags:" /
+// "Format flags:" flag-section style.
+var commandGroupTitles = map[string]string{
+	GroupCore:      "Core Commands:",
+	GroupPlaybooks: "Playbook Commands:",
+	GroupPlugins:   "Plugin Commands:",
+}
+
+// ensureCommandGroup registers groupID on parent, idempotently. Commands are
+// tagged with groupID before being attached, and cobra panics in
+// checkCommandGroups if the group does not exist on the parent, so this must be
+// called whenever a grouped command is added.
+func ensureCommandGroup(parent *cobra.Command, groupID string) {
+	if parent == nil || groupID == "" {
+		return
+	}
+	if parent.ContainsGroup(groupID) {
+		return
+	}
+	title, ok := commandGroupTitles[groupID]
+	if !ok {
+		title = groupID
+	}
+	parent.AddGroup(&cobra.Group{ID: groupID, Title: title})
+}
+
+// normalizeShort trims surrounding whitespace from a remote description before
+// it is used as a cobra command's Short field, so multi-line / padded
+// descriptions don't render verbatim in the --help command listing. The
+// per-command Long help keeps the full description.
+func normalizeShort(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// FinalizeCommandGroups folds every remaining top-level command that has no
+// explicit group (the static client, catalog, version and server commands),
+// plus the auto-generated help and completion commands, into the core group so
+// --help renders clean sections with no "Additional Commands" bucket.
+//
+// Grouping is only enabled when at least one dynamic command was registered
+// (plugin or playbook): without dynamic commands the help output keeps its
+// original flat "Available Commands" form. The core group itself is registered
+// by the dynamic command registration (always before the dynamic groups) so the
+// Core section always renders first.
+func FinalizeCommandGroups(root *cobra.Command) {
+	if root == nil {
+		return
+	}
+	if !root.ContainsGroup(GroupPlugins) && !root.ContainsGroup(GroupPlaybooks) {
+		return
+	}
+	ensureCommandGroup(root, GroupCore)
+	root.SetHelpCommandGroupID(GroupCore)
+	root.SetCompletionCommandGroupID(GroupCore)
+	for _, cmd := range root.Commands() {
+		if cmd.GroupID == "" {
+			cmd.GroupID = GroupCore
+		}
+	}
+}

--- a/clientcmd/groups_test.go
+++ b/clientcmd/groups_test.go
@@ -1,0 +1,146 @@
+package clientcmd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/flanksource/clicky/rpc"
+	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/plugin/manifestcache"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+// runnable returns a real (runnable) command so cobra lists it as an available
+// command rather than an "additional help topic".
+func runnable(use, short string) *cobra.Command {
+	return &cobra.Command{Use: use, Short: short, Run: func(*cobra.Command, []string) {}}
+}
+
+var _ = ginkgo.Describe("normalizeShort", func() {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "trims surrounding whitespace", in: "  hello  ", want: "hello"},
+		{name: "strips trailing newline", in: "Make a request.\n", want: "Make a request."},
+		{name: "keeps internal whitespace unchanged", in: "Deletes all failed  / completed", want: "Deletes all failed  / completed"},
+	}
+	for _, tt := range tests {
+		ginkgo.It(tt.name, func() {
+			Expect(normalizeShort(tt.in)).To(Equal(tt.want))
+		})
+	}
+})
+
+var _ = ginkgo.Describe("command grouping", func() {
+	ginkgo.It("groups cached plugins under the Plugin Commands section", func() {
+		cleanup := manifestcache.SetDirForTest(filepath.Join(ginkgo.GinkgoT().TempDir(), "plugins"))
+		defer cleanup()
+
+		Expect(manifestcache.Write(manifestcache.Entry{
+			Source: manifestcache.SourceRemoteServer,
+			Service: rpc.RPCService{
+				Name:        "postgres",
+				Description: "Postgres diagnostics",
+				Operations:  []rpc.RPCOperation{{Name: "sessions"}},
+			},
+		})).To(Succeed())
+
+		root := &cobra.Command{Use: "faro"}
+		plugin := &cobra.Command{Use: "plugin"}
+		root.AddCommand(plugin)
+		root.AddCommand(runnable("version", "print version"))
+
+		Expect(registerCachedPluginCommands(plugin, root)).To(Succeed())
+		FinalizeCommandGroups(root)
+		Expect(root.ContainsGroup(GroupPlugins)).To(BeTrue())
+		Expect(root.ContainsGroup(GroupCore)).To(BeTrue())
+
+		top := findChildCommand(root, "postgres")
+		Expect(top).NotTo(BeNil())
+		Expect(top.GroupID).To(Equal(GroupPlugins))
+
+		// static command folded into Core
+		Expect(findChildCommand(root, "version").GroupID).To(Equal(GroupCore))
+
+		stdout, _, err := executeCommand(root, "--help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("Core Commands:"))
+		Expect(stdout).To(ContainSubstring("Plugin Commands:"))
+		Expect(stdout).To(ContainSubstring("postgres"))
+		Expect(stdout).NotTo(ContainSubstring("Additional Commands:"))
+	})
+
+	ginkgo.It("groups cached playbooks under the Playbook Commands section", func() {
+		root := &cobra.Command{Use: "faro"}
+		playbook := &cobra.Command{Use: "playbook"}
+		runCmd := &cobra.Command{Use: "run"}
+		playbook.AddCommand(runCmd)
+		root.AddCommand(playbook)
+
+		Expect(registerCachedPlaybookCommands(playbook, root, []api.PlaybookListItem{{
+			Name: "http",
+		}})).To(Succeed())
+		FinalizeCommandGroups(root)
+		Expect(root.ContainsGroup(GroupPlaybooks)).To(BeTrue())
+
+		top := findChildCommand(root, "http")
+		Expect(top).NotTo(BeNil())
+		Expect(top.GroupID).To(Equal(GroupPlaybooks))
+
+		// the nested copy under `playbook run` stays ungrouped
+		Expect(findChildCommand(runCmd, "http").GroupID).To(BeEmpty())
+
+		stdout, _, err := executeCommand(root, "--help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("Playbook Commands:"))
+	})
+
+	ginkgo.It("keeps flat help output when there are no dynamic commands", func() {
+		root := &cobra.Command{Use: "faro"}
+		root.AddCommand(runnable("version", "print version"))
+		root.AddCommand(runnable("whoami", "current context"))
+		FinalizeCommandGroups(root)
+
+		stdout, _, err := executeCommand(root, "--help")
+		Expect(err).NotTo(HaveOccurred())
+		// No dynamic commands => no grouping, original flat form.
+		Expect(stdout).To(ContainSubstring("Available Commands:"))
+		Expect(stdout).NotTo(ContainSubstring("Core Commands:"))
+	})
+
+	ginkgo.It("renders sections in Core, Plugin, Playbook order", func() {
+		cleanup := manifestcache.SetDirForTest(filepath.Join(ginkgo.GinkgoT().TempDir(), "plugins"))
+		defer cleanup()
+		Expect(manifestcache.Write(manifestcache.Entry{
+			Source:  manifestcache.SourceRemoteServer,
+			Service: rpc.RPCService{Name: "s3", Operations: []rpc.RPCOperation{{Name: "ls"}}},
+		})).To(Succeed())
+
+		root := &cobra.Command{Use: "faro"}
+		root.AddCommand(runnable("version", "v"))
+		plugin := &cobra.Command{Use: "plugin"}
+		root.AddCommand(plugin)
+		playbook := &cobra.Command{Use: "playbook"}
+		playbook.AddCommand(&cobra.Command{Use: "run"})
+		root.AddCommand(playbook)
+
+		// plugins are registered before playbooks (see SetupContextCachedPluginCommands)
+		Expect(registerCachedPluginCommands(plugin, root)).To(Succeed())
+		Expect(registerCachedPlaybookCommands(playbook, root, []api.PlaybookListItem{{Name: "http"}})).To(Succeed())
+		FinalizeCommandGroups(root)
+
+		stdout, _, err := executeCommand(root, "--help")
+		Expect(err).NotTo(HaveOccurred())
+		coreIdx := strings.Index(stdout, "Core Commands:")
+		pluginIdx := strings.Index(stdout, "Plugin Commands:")
+		playbookIdx := strings.Index(stdout, "Playbook Commands:")
+		Expect(coreIdx).To(BeNumerically(">", -1))
+		Expect(pluginIdx).To(BeNumerically(">", coreIdx))
+		Expect(playbookIdx).To(BeNumerically(">", pluginIdx))
+	})
+})

--- a/clientcmd/playbook_cache.go
+++ b/clientcmd/playbook_cache.go
@@ -84,6 +84,10 @@ func registerCachedPlaybookCommands(playbookRoot, root *cobra.Command, items []a
 	if runRoot == nil {
 		return nil
 	}
+	// Register the core group before the playbook group so the Core section
+	// always precedes the dynamic sections in --help.
+	ensureCommandGroup(root, GroupCore)
+	ensureCommandGroup(root, GroupPlaybooks)
 	sort.SliceStable(items, func(i, j int) bool { return playbookRef(items[i]) < playbookRef(items[j]) })
 	for _, item := range items {
 		name := cachedPlaybookCommandName(runRoot, item)
@@ -94,7 +98,12 @@ func registerCachedPlaybookCommands(playbookRoot, root *cobra.Command, items []a
 			runRoot.AddCommand(newCachedPlaybookCommand(item, name))
 		}
 		if root != nil && !commandExists(root, name) {
-			root.AddCommand(newCachedPlaybookCommand(item, name))
+			// Top-level playbook commands are surfaced directly on root; group
+			// them under the "Playbook Commands" section of --help. (The copy
+			// nested under `playbook run` intentionally stays ungrouped.)
+			cmd := newCachedPlaybookCommand(item, name)
+			cmd.GroupID = GroupPlaybooks
+			root.AddCommand(cmd)
 		}
 	}
 	return nil
@@ -130,9 +139,9 @@ func newCachedPlaybookCommand(item api.PlaybookListItem, name string) *cobra.Com
 	var wait = true
 	var pollInterval = 2 * time.Second
 	var configID, componentID, checkID, paramFile string
-	short := item.Description
+	short := normalizeShort(item.Description)
 	if short == "" {
-		short = item.Title
+		short = normalizeShort(item.Title)
 	}
 	if short == "" {
 		short = fmt.Sprintf("Run playbook %s", playbookRef(item))

--- a/clientcmd/plugin_help.go
+++ b/clientcmd/plugin_help.go
@@ -40,6 +40,13 @@ func registerCachedPluginCommandEntries(pluginRoot, root *cobra.Command, entries
 			pluginRoot.AddCommand(nested)
 		}
 		if root != nil && !commandExists(root, top.Name()) {
+			// Top-level plugin commands are surfaced directly on root; group them
+			// under "Plugin Commands". The core group is registered first so the
+			// Core section always precedes the dynamic sections in --help. (The
+			// nested copy under `plugin <name>` intentionally stays ungrouped.)
+			ensureCommandGroup(root, GroupCore)
+			ensureCommandGroup(root, GroupPlugins)
+			top.GroupID = GroupPlugins
 			root.AddCommand(top)
 		}
 	}
@@ -63,7 +70,7 @@ func buildPluginCommands(entry manifestcache.Entry) (nested, top *cobra.Command)
 }
 
 func newPluginRoot(entry manifestcache.Entry, topLevel bool) *cobra.Command {
-	short := entry.Service.Description
+	short := normalizeShort(entry.Service.Description)
 	if short == "" {
 		short = fmt.Sprintf("Operations for the %q plugin", entry.Service.Name)
 	}
@@ -105,7 +112,7 @@ func newOperationCommandWithDispatcher(plugin string, op rpc.RPCOperation, dispa
 	)
 	cmd := &cobra.Command{
 		Use:          op.Name,
-		Short:        op.Description,
+		Short:        normalizeShort(op.Description),
 		Long:         formatOperationLong(op),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, _ []string) error {

--- a/faro/main.go
+++ b/faro/main.go
@@ -118,6 +118,7 @@ func main() {
 	if c, _, err := root.Find([]string{"catalog"}); err == nil && c != nil {
 		clicky.BindAllFlags(c.PersistentFlags(), "format")
 	}
+	clientcmd.FinalizeCommandGroups(root)
 	silenceUsage(root)
 
 	harFlush := func() error { return nil }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	if catalogCmd, _, err := cmd.Root.Find([]string{"catalog"}); err == nil && catalogCmd != nil {
 		clicky.BindAllFlags(catalogCmd.PersistentFlags(), "format")
 	}
+	clientcmd.FinalizeCommandGroups(cmd.Root)
 
 	if err := cmd.Root.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
`faro` and `incident-commander` register a command per remote playbook/plugin directly on the root, so `--help` shows one long flat list that mixes core commands (auth, context, catalog, version, …) with dozens of dynamic ones.

This tags the dynamic commands with cobra command groups so `--help` renders three titled sections:

- **Core Commands** — the static client/server/catalog/version commands (plus help/completion)
- **Plugin Commands** — per-plugin commands registered from the context cache
- **Playbook Commands** — per-playbook commands registered from the context cache

```sh
faro --help
```
```
Slim Mission Control client

Usage:
  faro [command]

Core Commands:
  auth                           Authentication commands
  catalog                        Manage catalog resources
  completion                     Generate the autocompletion script for the specified shell
  connection                     Manage connections
  context                        Manage Mission Control contexts
  help                           Help about any command
  playbook
  plugin                         Invoke an operation exposed by a Mission Control plugin
  refresh-cache                  Refresh cached metadata for the current Mission Control context
  version                        Print the version of faro
  whoami                         Show the current Mission Control context and connectivity

Plugin Commands:
  arthas                         Attach Arthas to JVMs running in Kubernetes workloads and inspect threads, memory, MBeans, logging, and the Arthas web console.
  golang                         Inspect Go runtime diagnostics from Kubernetes workloads that expose gops and/or pprof on localhost-only ports.
  inspektor-gadget               Run Inspektor Gadget eBPF traces against Kubernetes workloads through the configured Kubernetes API connection.
  kubernetes-logs                Stream logs from a Pod or any of its workload ancestors (Deployment / StatefulSet / DaemonSet / Job).
  postgres                       Inspect Postgres health, sessions, locks, vacuum state, slow queries, and run ad-hoc SQL against managed-safe Postgres deployments.
  s3                             Browse S3 buckets from Mission Control connection items.

Playbook Commands:
  Content                        Content types
  Delay                          Delay
  Query                          Query Test
  Test                           Test python
  ai-diagnose                    Diagnoses the health of a resource using AI, optionally sending the result to Slack
  catalog-report                 Generates a catalog report for the selected config item (plus any extra config IDs) and uploads it as an artifact. When Facet URI is empty the report is rendered with the local facet CLI; otherwise the report data and template are sent to the facet server for rendering.
  cleanup-failed-pod             Deletes all failed  / completed / evicted pods
  clear-event-queue              Deletes old events and fully retried events
  flux-reconcile                 Triggers a reconciliation of the selected Flux object
  flux-request-namespace-access  Grants a user access to a GitOps managed namespace by creating a RoleBinding and pushing it to Git, optionally removing it after a period of time
  flux-resume                    Resumes the reconciliation of the selected Flux resources
  flux-suspend                   Suspends the reconciliation of the selected Flux resources
  http                           Make an HTTP request to a specified URL.
  kubernetes-cordon-node         Cordons a node using kubectl
  kubernetes-create-deployment   Creates a new deployment with kubectl
  kubernetes-delete              Deletes a resource using kubectl
  kubernetes-deploy-helm-chart   Deploys a Helm Chart using the Helm CLI
  kubernetes-drain-node          Drain Node
  kubernetes-ignore-changes      Ignore Changes
  kubernetes-namespace-access    Grants a user access to a namespace using kubectl, optionally removing it after a period of time
  kubernetes-restart             Restart a resource using kubectl rollout restart
  kubernetes-scale               Scales a resource using kubectl
  kubernetes-uncordon-node       Uncordon Node
  kubernetes-update-image        Updates the image using kubectl set image
  kubernetes-update-resources    Update Resources
  kustomize-create-deployment    Creates a Deployment in a GitOps managed namespace by submitting a Git PR
  kustomize-create-helmrelease   Creates a new Helm Release in a GitOps managed namespace by submitting a Git PR
  kustomize-create-kustomization Creates a new kustomization in a GitOps managed namespace by submitting a Git PR
  kustomize-create-namespace     Create a new namespace in a GitOps managed Kustomization by submitting a Git PR
  kustomize-edit                 Updates the source of a GitOps managed object by submitting a Git PR
  kustomize-scale                Scales GitOps managed objects by submitting a git PR
  kustomize-update-resources     Updates resource requests/limits for a GitOps managed object by submitting a git PR
  recommend-playbook             Diagnoses the health of a resource using AI, and then recommends playbooks to fix the issue, sending the results to Slack
  run-canary                     Runs the canary on a canary-checker pod with configurable log level
  update-helm-chart-version      Update the version of a GitOps managed Helm chart by submitting a Git PR
  update-helm-values             Update the values of a GitOps managed HelmRelease by submitting a Git PR
  vacuum-mission-control-tables  Vacuum mission control database tables to improve performance

Flags:
      --color              Print logs using color (default true)
      --context string     Mission Control context to use
      --har string         Write outbound HTTP traffic as a HAR file at this path
  -h, --help               help for faro
      --json-logs          Print logs in json format to stderr
      --log-level string   Set the default log level (default "info")
      --log-to-stderr      Deprecated: logs always go to stderr (default true)
  -v, --loglevel count     Increase logging level
      --report-caller      Report log caller info

Use "faro [command] --help" for more information about a command.

version: latest built at 2026-06-24 20:30:56
```