### PR TITLE
feat(plugin): add manual latest upgrade endpoint

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -21,7 +21,6 @@ import (
 	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/flanksource/incident-commander/notification"
 	"github.com/flanksource/incident-commander/playbook"
-	"github.com/flanksource/incident-commander/plugin/machinery"
 	"github.com/flanksource/incident-commander/shorturl"
 )
 
@@ -125,14 +124,6 @@ func Start(ctx context.Context, mcpServer *server.MCPServer) {
 	if err := job.NewJob(ctx, "Cleanup Short URLs", CleanupExpiredShortURLsSchedule, shorturl.CleanupExpired).
 		AddToScheduler(FuncScheduler); err != nil {
 		logger.Errorf("Failed to schedule job for cleaning up short URLs: %v", err)
-	}
-
-	if interval := ctx.Properties().Duration("plugin.interval", 0); interval > 0 {
-		if err := job.NewJob(ctx, "Plugin Refresh", fmt.Sprintf("@every %s", interval), func(jr job.JobRuntime) error {
-			return machinery.RefreshLatestPlugins(jr.Context)
-		}).AddToScheduler(FuncScheduler); err != nil {
-			logger.Errorf("Failed to schedule Plugin Refresh job: %v", err)
-		}
 	}
 
 	for _, job := range query.Jobs {

--- a/plugin/gateway/http.go
+++ b/plugin/gateway/http.go
@@ -8,6 +8,10 @@
 //	    given config item. Used by the frontend to populate the tab bar
 //	    on the catalog detail page.
 //
+//	POST /api/plugins/:name/upgrade
+//	    Resolves latest for a local plugin and restarts it when a new version
+//	    is available.
+//
 //	POST /api/plugins/:name/invoke/:op?config_id=X
 //	    Invokes a plugin operation. The body is the operation's params
 //	    (JSON). The response body is whatever the plugin returned via
@@ -46,6 +50,7 @@ func init() {
 func RegisterRoutes(e *echo.Echo) {
 	g := e.Group("/api/plugins")
 	g.GET("", ListPlugins, rbac.Authorization(policy.ObjectCatalog, policy.ActionRead))
+	g.POST("/:name/upgrade", UpgradePlugin, rbac.Authorization(policy.ObjectRBAC, policy.ActionUpdate))
 	g.POST("/:name/invoke/:op", InvokeOperation)
 
 	registerProxyRoutes(e)
@@ -139,6 +144,25 @@ func listPluginsClickyRPC(c echo.Context) error {
 		})
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// UpgradePlugin resolves latest for a local plugin and restarts it when a new
+// version is available.
+func UpgradePlugin(c echo.Context) error {
+	ctx := c.Request().Context().(dutyContext.Context)
+	pluginRef := c.Param("name")
+
+	entry, err := machinery.ResolvePlugin(ctx, pluginRef)
+	if err != nil {
+		return dutyAPI.WriteError(c, err)
+	}
+
+	result, err := machinery.RefreshLatestPlugin(ctx, entry)
+	if err != nil {
+		return dutyAPI.WriteError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, result)
 }
 
 // InvokeOperation invokes a plugin operation. Local plugins are invoked through

--- a/plugin/machinery/refresh.go
+++ b/plugin/machinery/refresh.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	dutyAPI "github.com/flanksource/duty/api"
 	dutyContext "github.com/flanksource/duty/context"
 	"github.com/google/uuid"
 
@@ -22,6 +23,17 @@ type refreshOps struct {
 	stop          func(id uuid.UUID) error
 	start         func(ctx dutyContext.Context, id uuid.UUID) error
 	removeVersion func(name, source, version string) error
+}
+
+// LatestPluginRefreshResult describes the result of resolving and optionally
+// restarting a plugin that tracks latest.
+type LatestPluginRefreshResult struct {
+	PluginID        uuid.UUID `json:"-"`
+	Plugin          string    `json:"plugin"`
+	PreviousVersion string    `json:"previousVersion,omitempty"`
+	ResolvedVersion string    `json:"resolvedVersion,omitempty"`
+	InstalledPath   string    `json:"installedPath,omitempty"`
+	Restarted       bool      `json:"restarted"`
 }
 
 func defaultRefreshOps() refreshOps {
@@ -41,6 +53,21 @@ func RefreshLatestPlugins(ctx dutyContext.Context) error {
 	return refreshLatestPlugins(ctx, defaultRefreshOps())
 }
 
+func RefreshLatestPlugin(ctx dutyContext.Context, entry *plugin.Entry) (*LatestPluginRefreshResult, error) {
+	if entry == nil {
+		return nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin is required")
+	}
+	switch entry.Kind {
+	case "", api.PluginKindLocal:
+	default:
+		return nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin %s has unsupported connection kind %q", entry.Name, entry.Kind)
+	}
+	if !local.IsLatest(entry.Spec.Version) {
+		return nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin %s is pinned to version %q", entry.Name, entry.Spec.Version)
+	}
+	return defaultRefreshOps().refreshPlugin(ctx, entry)
+}
+
 func refreshLatestPlugins(ctx dutyContext.Context, ops refreshOps) error {
 	var errs []error
 	for _, entry := range plugin.DefaultRegistry.List() {
@@ -52,7 +79,7 @@ func refreshLatestPlugins(ctx dutyContext.Context, ops refreshOps) error {
 		if !local.IsLatest(entry.Spec.Version) {
 			continue
 		}
-		if err := ops.refreshPlugin(ctx, entry); err != nil {
+		if _, err := ops.refreshPlugin(ctx, entry); err != nil {
 			ctx.Logger.Errorf("plugin %s: refresh failed: %v", entry.Name, err)
 			errs = append(errs, fmt.Errorf("plugin %s: %w", entry.Name, err))
 		}
@@ -60,24 +87,37 @@ func refreshLatestPlugins(ctx dutyContext.Context, ops refreshOps) error {
 	return errors.Join(errs...)
 }
 
-func (ops refreshOps) refreshPlugin(ctx dutyContext.Context, entry *plugin.Entry) error {
-	_, newVersion, err := ops.resolveLatest(ctx, entry.Name, entry.Spec.Source)
+func (ops refreshOps) refreshPlugin(ctx dutyContext.Context, entry *plugin.Entry) (*LatestPluginRefreshResult, error) {
+	installedPath, newVersion, err := ops.resolveLatest(ctx, entry.Name, entry.Spec.Source)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	oldVersion := local.VersionFromBinaryPath(entry.InstalledPath)
+	result := &LatestPluginRefreshResult{
+		PluginID:        entry.ID,
+		Plugin:          entry.Name,
+		PreviousVersion: oldVersion,
+		ResolvedVersion: newVersion,
+		InstalledPath:   installedPath,
+	}
 	if newVersion == oldVersion {
 		ctx.Logger.V(3).Infof("plugin %s: already at latest version %s", entry.Name, newVersion)
-		return nil
+		return result, nil
 	}
 
 	ctx.Logger.Infof("plugin %s: new version %s available (was %s); restarting", entry.Name, newVersion, oldVersion)
 	if err := ops.stop(entry.ID); err != nil {
-		return fmt.Errorf("stop plugin %s: %w", entry.Name, err)
+		return nil, fmt.Errorf("stop plugin %s: %w", entry.Name, err)
 	}
 	if err := ops.start(ctx, entry.ID); err != nil {
-		return fmt.Errorf("start plugin %s: %w", entry.Name, err)
+		return nil, fmt.Errorf("start plugin %s: %w", entry.Name, err)
+	}
+	result.Restarted = true
+
+	if updated := plugin.DefaultRegistry.Get(entry.ID); updated != nil && updated.InstalledPath != "" {
+		result.InstalledPath = updated.InstalledPath
+		result.ResolvedVersion = local.VersionFromBinaryPath(updated.InstalledPath)
 	}
 
 	if oldVersion != "" && oldVersion != newVersion {
@@ -86,5 +126,5 @@ func (ops refreshOps) refreshPlugin(ctx dutyContext.Context, entry *plugin.Entry
 		}
 	}
 
-	return nil
+	return result, nil
 }

--- a/plugin/machinery/refresh.go
+++ b/plugin/machinery/refresh.go
@@ -57,9 +57,7 @@ func RefreshLatestPlugin(ctx dutyContext.Context, entry *plugin.Entry) (*LatestP
 	if entry == nil {
 		return nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin is required")
 	}
-	switch entry.Kind {
-	case "", api.PluginKindLocal:
-	default:
+	if entry.Kind != "" && entry.Kind != api.PluginKindLocal {
 		return nil, dutyAPI.Errorf(dutyAPI.EINVALID, "plugin %s has unsupported connection kind %q", entry.Name, entry.Kind)
 	}
 	if !local.IsLatest(entry.Spec.Version) {


### PR DESCRIPTION
Latest-tracking plugins could be refreshed by a global interval, which could restart stateful plugin processes without explicit operator action.

Remove the scheduled refresh job and expose an admin-only endpoint to upgrade one local latest-tracking plugin on demand.

The endpoint resolves latest, restarts the plugin only when a newer version is available, and returns the resolved upgrade result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new manual plugin upgrade endpoint (`POST /api/plugins/:name/upgrade`) to refresh a specific plugin to its latest version on demand.
  * The upgrade response returns the refreshed plugin details, including the resolved version and whether a restart occurred.
* **Bug Fixes**
  * Removed the automatic scheduled “plugin refresh” job, so plugin updates are no longer processed in the background on a timer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->