### PR TITLE
feat(faro): add catalog search subcommand using PEG grammar

### DIFF
--- a/faro/catalog_search.go
+++ b/faro/catalog_search.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/query"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/incident-commander/clientcmd"
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchAgent string
+	searchLimit int
+)
+
+// Search backs `catalog search <QUERY>`. Unlike `catalog list`, which composes
+// individual filter flags, search takes the full PEG search grammar as a single
+// query and forwards it to the remote /resources/search endpoint — the same
+// surface the web UI uses (e.g. `tags.cluster=beta type=pod my-app`).
+var Search = &cobra.Command{
+	Use:   "search <QUERY>",
+	Short: "Search catalog resources using the PEG search grammar",
+	Long: `Search catalog resources using the PEG search grammar used by the web UI.
+
+The query is matched against resource name, type, tags and labels. Multiple
+clauses are space-separated and ANDed together.
+
+Examples:
+  catalog search type=Kubernetes::Pod
+  catalog search tags.cluster=beta-cluster type=pod mission-control
+  catalog search "name=api*" --agent all --limit 50`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		results, err := remoteSearch(strings.Join(args, " "), searchAgent, searchLimit)
+		if err != nil {
+			return err
+		}
+		clicky.MustPrint(results, clicky.Flags.FormatOptions)
+		return nil
+	},
+}
+
+// remoteSearch runs the grammar search against the remote server and maps the
+// lightweight search hits to models.ConfigItem so they render like `catalog list`.
+func remoteSearch(searchQuery, agent string, limit int) ([]models.ConfigItem, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
+		Limit: limit,
+		Configs: []types.ResourceSelector{{
+			Search: searchQuery,
+			Agent:  agent,
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.ConfigItem, 0, len(resp.Configs))
+	for _, s := range resp.Configs {
+		out = append(out, selectedResourceToConfigItem(s))
+	}
+	return out, nil
+}
+
+func init() {
+	Search.Flags().StringVar(&searchAgent, "agent", "all", "Filter by agent id or name ('all' for every agent)")
+	Search.Flags().IntVar(&searchLimit, "limit", 100, "Maximum number of results")
+	clicky.RegisterSubCommand("catalog", Search)
+}

--- a/faro/catalog_search_test.go
+++ b/faro/catalog_search_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/query"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("faro catalog search", func() {
+	ginkgo.BeforeEach(func() {
+		dir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", dir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", dir)
+	})
+
+	ginkgo.It("forwards the grammar query, agent and limit to /resources/search", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/resources/search"))
+
+			var got query.SearchResourcesRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(25))
+			Expect(got.Configs).To(HaveLen(1))
+			Expect(got.Configs[0].Search).To(Equal("tags.cluster=beta-cluster type=pod mission-control"))
+			Expect(got.Configs[0].Agent).To(Equal("all"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","health":"healthy","status":"Running"}]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearch("tags.cluster=beta-cluster type=pod mission-control", "all", 25)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(*items[0].Name).To(Equal("api"))
+		Expect(*items[0].Type).To(Equal("Kubernetes::Pod"))
+	})
+
+	ginkgo.It("defaults an empty limit to 100", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var got query.SearchResourcesRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(100))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"configs":[]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		_, err := remoteSearch("type=Kubernetes::Pod", "all", 0)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## What

Adds a `search` subcommand to the `faro catalog` command, alongside the existing `get` and `list`:

```
Available Commands:
  get         Get a catalog by ID
  list        List catalog resources
  search      Search catalog resources using the PEG search grammar
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `catalog search <QUERY>` command to search catalog resources from the CLI.
  * Supports optional `--agent` and `--limit` flags, including a default limit when a non-positive value is provided.

* **Tests**
  * Added coverage for forwarding search requests and parsing returned results.
  * Verified that a provided limit of `0` falls back to the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->