### PR TITLE
feat(faro): add catalog change commands

### DIFF
--- a/faro/catalog_change.go
+++ b/faro/catalog_change.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/duty/query"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/incident-commander/clientcmd"
+	"github.com/spf13/cobra"
+)
+
+var changeSearchLimit int
+
+type catalogChangeSearchHit struct {
+	ID         string `json:"id"`
+	Agent      string `json:"agent,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	ChangeType string `json:"change_type,omitempty"`
+}
+
+var CatalogChange = &cobra.Command{
+	Use:     "change",
+	Aliases: []string{"changes"},
+	Short:   "Search and inspect catalog changes",
+}
+
+var CatalogChangeSearch = &cobra.Command{
+	Use:   "search <QUERY>",
+	Short: "Search catalog changes using the PEG search grammar",
+	Long: `Search catalog changes using the PEG search grammar used by the web UI.
+
+Examples:
+  catalog change search change_type=diff
+  catalog change search "change_type=diff type=deployment"
+  catalog change search "severity=critical source=kubernetes" --limit 50`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		results, err := remoteSearchChanges(strings.Join(args, " "), changeSearchLimit)
+		if err != nil {
+			return err
+		}
+		clicky.MustPrint(results, clicky.Flags.FormatOptions)
+		return nil
+	},
+}
+
+var CatalogChangeGet = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get full details for a catalog change",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		change, err := remoteGetChange(args[0])
+		if err != nil {
+			return err
+		}
+		clicky.MustPrint(change, clicky.Flags.FormatOptions)
+		return nil
+	},
+}
+
+func remoteSearchChanges(searchQuery string, limit int) ([]catalogChangeSearchHit, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
+		Limit: limit,
+		ConfigChanges: []types.ResourceSelector{{
+			Search: searchQuery,
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]catalogChangeSearchHit, 0, len(resp.ConfigChanges))
+	for _, s := range resp.ConfigChanges {
+		out = append(out, catalogChangeSearchHit{
+			ID:         s.ID,
+			Agent:      s.Agent,
+			Name:       s.Name,
+			Namespace:  s.Namespace,
+			ChangeType: s.Type,
+		})
+	}
+	return out, nil
+}
+
+func remoteGetChange(id string) (any, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetCatalogChange(context.Background(), id)
+}
+
+func init() {
+	CatalogChangeSearch.Flags().IntVar(&changeSearchLimit, "limit", 100, "Maximum number of results")
+	CatalogChange.AddCommand(CatalogChangeSearch, CatalogChangeGet)
+	clicky.RegisterSubCommand("catalog", CatalogChange)
+}

--- a/faro/catalog_change_test.go
+++ b/faro/catalog_change_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/query"
+	"github.com/flanksource/incident-commander/sdk"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("faro catalog change", func() {
+	ginkgo.BeforeEach(func() {
+		dir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", dir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", dir)
+	})
+
+	ginkgo.It("forwards change search grammar and limit to /resources/search", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/resources/search"))
+
+			var got query.SearchResourcesRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(25))
+			Expect(got.ConfigChanges).To(HaveLen(1))
+			Expect(got.ConfigChanges[0].Search).To(Equal("change_type=diff type=deployment"))
+			Expect(got.ConfigChanges[0].Agent).To(BeEmpty())
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"config_changes":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","agent":"00000000-0000-0000-0000-000000000000","name":"status","namespace":"kube-system","type":"diff"}]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearchChanges("change_type=diff type=deployment", 25)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(items[0].ID).To(Equal("0274d556-6257-426a-b651-0a9bc35c26d8"))
+		Expect(items[0].ChangeType).To(Equal("diff"))
+	})
+
+	ginkgo.It("defaults change search empty limit to 100", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var got query.SearchResourcesRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(100))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"config_changes":[]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		_, err := remoteSearchChanges("change_type=diff", 0)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	ginkgo.It("gets full change details from the PostgREST endpoint", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/api/db/config_changes"))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq.521bae33-e4c3-42eb-a9c5-071ab92940b5"))
+			Expect(r.URL.Query().Get("select")).To(ContainSubstring("diff,details,patches"))
+			Expect(r.URL.Query().Get("select")).To(ContainSubstring("config:configs"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"521bae33-e4c3-42eb-a9c5-071ab92940b5","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","change_type":"Failed","created_at":"2026-06-24T16:41:38Z","source":"kubernetes/","details":{"reason":"Failed"},"config":{"id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","name":"opensearch-fail","type":"MissionControl::Canary","config_class":"Canary"},"artifacts":[]}]`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL + "/api")
+
+		result, err := remoteGetChange("521bae33-e4c3-42eb-a9c5-071ab92940b5")
+
+		Expect(err).ToNot(HaveOccurred())
+		change := result.(*sdk.CatalogChangeDetail)
+		Expect(change.ChangeType).To(Equal("Failed"))
+		Expect(change.Config).ToNot(BeNil())
+		Expect(change.Config.ConfigClass).To(Equal("Canary"))
+	})
+})

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
@@ -18,6 +19,30 @@ type CatalogRelationships struct {
 	Incoming *query.ConfigTreeNode `json:"incoming"`
 	Outgoing *query.ConfigTreeNode `json:"outgoing"`
 }
+
+type CatalogChangeConfig struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	ConfigClass string `json:"config_class"`
+}
+
+type CatalogChangeDetail struct {
+	ID                string               `json:"id"`
+	ConfigID          string               `json:"config_id"`
+	ChangeType        string               `json:"change_type"`
+	CreatedAt         *time.Time           `json:"created_at,omitempty"`
+	ExternalCreatedBy *string              `json:"external_created_by,omitempty"`
+	Source            *string              `json:"source,omitempty"`
+	Diff              *string              `json:"diff,omitempty"`
+	Details           map[string]any       `json:"details,omitempty"`
+	Patches           any                  `json:"patches,omitempty"`
+	CreatedBy         *uuid.UUID           `json:"created_by,omitempty"`
+	Config            *CatalogChangeConfig `json:"config,omitempty"`
+	Artifacts         []map[string]any     `json:"artifacts,omitempty"`
+}
+
+const catalogChangeDetailSelect = "id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class),artifacts:artifacts(*)::jsonb"
 
 // SearchCatalog runs a resource search against the remote server
 // (POST /resources/search).
@@ -58,6 +83,32 @@ func (c *Client) GetCatalogItem(ctx context.Context, id string) (*models.ConfigI
 		return nil, err
 	}
 	return &out, nil
+}
+
+// GetCatalogChange fetches full details for a catalog change from PostgREST.
+func (c *Client) GetCatalogChange(ctx context.Context, id string) (*CatalogChangeDetail, error) {
+	r, err := c.R(ctx).
+		QueryParam("id", "eq."+id).
+		QueryParam("select", catalogChangeDetailSelect).
+		Get(c.apiPath("/db/config_changes"))
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		body, _ := r.AsString()
+		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
+			return nil, ErrHTMLResponse
+		}
+		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
+	}
+	var out []CatalogChangeDetail
+	if err := decodeJSON(r, &out); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, ErrNotFound
+	}
+	return &out[0], nil
 }
 
 // GetCatalogRelationships fetches the incoming/outgoing config tree for a

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 
@@ -43,6 +44,36 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(item.Name).ToNot(BeNil())
 		Expect(*item.Name).To(Equal("my-config"))
+	})
+
+	ginkgo.It("gets full catalog change details from PostgREST", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/db/config_changes"))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq.521bae33-e4c3-42eb-a9c5-071ab92940b5"))
+			Expect(r.URL.Query().Get("select")).To(Equal(catalogChangeDetailSelect))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"521bae33-e4c3-42eb-a9c5-071ab92940b5","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","change_type":"Failed","created_at":"2026-06-24T16:41:38Z","source":"kubernetes/","details":{"reason":"Failed"},"config":{"id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","name":"opensearch-fail","type":"MissionControl::Canary","config_class":"Canary"},"artifacts":[]}]`))
+		}))
+		defer server.Close()
+
+		change, err := New(server.URL, "tok").GetCatalogChange(context.Background(), "521bae33-e4c3-42eb-a9c5-071ab92940b5")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(change.ChangeType).To(Equal("Failed"))
+		Expect(change.Details).To(HaveKeyWithValue("reason", "Failed"))
+		Expect(change.Config).ToNot(BeNil())
+		Expect(change.Config.Name).To(Equal("opensearch-fail"))
+	})
+
+	ginkgo.It("returns not found for an empty catalog change response", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		}))
+		defer server.Close()
+
+		_, err := New(server.URL, "tok").GetCatalogChange(context.Background(), "missing")
+		Expect(errors.Is(err, ErrNotFound)).To(BeTrue())
 	})
 
 	ginkgo.It("fetches relationships and exposes both tree directions", func() {


### PR DESCRIPTION
Adds `faro catalog change search` for querying config changes through the resources search ConfigChanges selector.\n\nAdds `faro catalog change get` backed by PostgREST `/db/config_changes` so callers can fetch full change details including diff/details/patches, config metadata, and artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to search catalog changes and view full details for a specific change ID.
  * Expanded catalog change data retrieval to include detailed information such as diffs, patches, related config, and timestamps.

* **Bug Fixes**
  * Improved default handling for search limits, using a sensible fallback when no limit is provided.
  * Returns a clear not-found error when a requested catalog change does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->