### PR TITLE
chore: bump api version in sdk

### DIFF
--- a/plugin/sdk/go.mod
+++ b/plugin/sdk/go.mod
@@ -3,15 +3,13 @@ module github.com/flanksource/incident-commander/plugin/sdk
 go 1.26.1
 
 require (
-	github.com/flanksource/incident-commander/plugin/api v0.0.1
+	github.com/flanksource/incident-commander/plugin/api v0.0.3
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 )
-
-replace github.com/flanksource/incident-commander/plugin/api => ../api
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect

--- a/plugin/sdk/go.sum
+++ b/plugin/sdk/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/flanksource/incident-commander/plugin/api v0.0.1 h1:WvO2ea7FwisQvXoyqBOYb2LdJ8LppwrLlMNgV2fyN6E=
-github.com/flanksource/incident-commander/plugin/api v0.0.1/go.mod h1:UzzKclk8Z0b5d2HMaBG4F5pgN5Ua8TjK36sr7Z9kVrU=
+github.com/flanksource/incident-commander/plugin/api v0.0.3 h1:5lLGxoI9cafz8JcBP/p8/GrdUjfpiH0jmcP35Surm0I=
+github.com/flanksource/incident-commander/plugin/api v0.0.3/go.mod h1:UzzKclk8Z0b5d2HMaBG4F5pgN5Ua8TjK36sr7Z9kVrU=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=

--- a/tests/e2e/plugins/testdata/plugins/hasher/go.mod
+++ b/tests/e2e/plugins/testdata/plugins/hasher/go.mod
@@ -6,7 +6,7 @@ require github.com/flanksource/incident-commander/plugin/sdk v0.0.0
 
 require (
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flanksource/incident-commander/plugin/api v0.0.1 // indirect
+	github.com/flanksource/incident-commander/plugin/api v0.0.3 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK’s dependency version to the latest published release.
  * Removed a local override so builds now use the packaged module version consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->