### PR TITLE
feat(faro): add catalog insights commands

### DIFF
--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -3,24 +3,30 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/flanksource/clicky"
+	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/incident-commander/clientcmd"
-	"github.com/flanksource/incident-commander/sdk"
 	"github.com/spf13/cobra"
 )
 
-var insightSearchLimit int
+var (
+	insightSearchAgent string
+	insightSearchLimit int
+)
 
 type catalogInsightSearchHit struct {
-	ID          string  `json:"id"`
-	Agent       string  `json:"agent,omitempty"`
-	Name        string  `json:"name,omitempty"`
-	Namespace   string  `json:"namespace,omitempty"`
-	InsightType string  `json:"insight_type,omitempty"`
-	Status      string  `json:"status,omitempty"`
-	Severity    *string `json:"severity,omitempty"`
+	ID          string     `json:"id"`
+	Agent       string     `json:"agent,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Namespace   string     `json:"namespace,omitempty"`
+	InsightType string     `json:"insight_type,omitempty"`
+	Status      string     `json:"status,omitempty"`
+	Severity    *string    `json:"severity,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
 }
 
 var CatalogInsight = &cobra.Command{
@@ -40,7 +46,7 @@ Examples:
   catalog insights search "analyzer=no-public-ip source=aws" --limit 50`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		results, err := remoteSearchInsights(strings.Join(args, " "), insightSearchLimit)
+		results, err := remoteSearchInsights(strings.Join(args, " "), insightSearchAgent, insightSearchLimit)
 		if err != nil {
 			return err
 		}
@@ -63,7 +69,7 @@ var CatalogInsightGet = &cobra.Command{
 	},
 }
 
-func remoteSearchInsights(searchQuery string, limit int) ([]catalogInsightSearchHit, error) {
+func remoteSearchInsights(searchQuery, agent string, limit int) ([]catalogInsightSearchHit, error) {
 	client, err := clientcmd.RemoteClient()
 	if err != nil {
 		return nil, err
@@ -73,10 +79,12 @@ func remoteSearchInsights(searchQuery string, limit int) ([]catalogInsightSearch
 		limit = 100
 	}
 
-	resp, err := client.SearchCatalogInsights(context.Background(), sdk.CatalogInsightSearchRequest{
-		Limit: limit,
+	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
+		Limit:      limit,
+		Timestamps: true,
 		ConfigAnalysis: []types.ResourceSelector{{
 			Search: searchQuery,
+			Agent:  agent,
 		}},
 	})
 	if err != nil {
@@ -93,6 +101,8 @@ func remoteSearchInsights(searchQuery string, limit int) ([]catalogInsightSearch
 			InsightType: s.Type,
 			Status:      s.Status,
 			Severity:    s.Severity,
+			CreatedAt:   s.CreatedAt,
+			UpdatedAt:   s.UpdatedAt,
 		})
 	}
 	return out, nil
@@ -107,6 +117,7 @@ func remoteGetInsight(id string) (any, error) {
 }
 
 func init() {
+	CatalogInsightSearch.Flags().StringVar(&insightSearchAgent, "agent", "all", "Filter by agent id or name ('all' for every agent)")
 	CatalogInsightSearch.Flags().IntVar(&insightSearchLimit, "limit", 100, "Maximum number of results")
 	CatalogInsight.AddCommand(CatalogInsightSearch, CatalogInsightGet)
 	clicky.RegisterSubCommand("catalog", CatalogInsight)

--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/incident-commander/clientcmd"
+	"github.com/flanksource/incident-commander/sdk"
+	"github.com/spf13/cobra"
+)
+
+var insightSearchLimit int
+
+type catalogInsightSearchHit struct {
+	ID          string  `json:"id"`
+	Agent       string  `json:"agent,omitempty"`
+	Name        string  `json:"name,omitempty"`
+	Namespace   string  `json:"namespace,omitempty"`
+	InsightType string  `json:"insight_type,omitempty"`
+	Status      string  `json:"status,omitempty"`
+	Severity    *string `json:"severity,omitempty"`
+}
+
+var CatalogInsight = &cobra.Command{
+	Use:     "insights",
+	Aliases: []string{"insight"},
+	Short:   "Search and inspect catalog insights",
+}
+
+var CatalogInsightSearch = &cobra.Command{
+	Use:   "search <QUERY>",
+	Short: "Search catalog insights using the PEG search grammar",
+	Long: `Search catalog insights using the PEG search grammar used by the web UI.
+
+Examples:
+  catalog insights search severity=critical
+  catalog insights search "status=open type=security"
+  catalog insights search "analyzer=no-public-ip source=aws" --limit 50`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		results, err := remoteSearchInsights(strings.Join(args, " "), insightSearchLimit)
+		if err != nil {
+			return err
+		}
+		clicky.MustPrint(results, clicky.Flags.FormatOptions)
+		return nil
+	},
+}
+
+var CatalogInsightGet = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get full details for a catalog insight",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		insight, err := remoteGetInsight(args[0])
+		if err != nil {
+			return err
+		}
+		clicky.MustPrint(insight, clicky.Flags.FormatOptions)
+		return nil
+	},
+}
+
+func remoteSearchInsights(searchQuery string, limit int) ([]catalogInsightSearchHit, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	resp, err := client.SearchCatalogInsights(context.Background(), sdk.CatalogInsightSearchRequest{
+		Limit: limit,
+		ConfigAnalysis: []types.ResourceSelector{{
+			Search: searchQuery,
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]catalogInsightSearchHit, 0, len(resp.ConfigAnalysis))
+	for _, s := range resp.ConfigAnalysis {
+		out = append(out, catalogInsightSearchHit{
+			ID:          s.ID,
+			Agent:       s.Agent,
+			Name:        s.Name,
+			Namespace:   s.Namespace,
+			InsightType: s.Type,
+			Status:      s.Status,
+			Severity:    s.Severity,
+		})
+	}
+	return out, nil
+}
+
+func remoteGetInsight(id string) (any, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetCatalogInsight(context.Background(), id)
+}
+
+func init() {
+	CatalogInsightSearch.Flags().IntVar(&insightSearchLimit, "limit", 100, "Maximum number of results")
+	CatalogInsight.AddCommand(CatalogInsightSearch, CatalogInsightGet)
+	clicky.RegisterSubCommand("catalog", CatalogInsight)
+}

--- a/faro/catalog_insight_test.go
+++ b/faro/catalog_insight_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/incident-commander/sdk"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("faro catalog insights", func() {
+	ginkgo.BeforeEach(func() {
+		dir := ginkgo.GinkgoT().TempDir()
+		ginkgo.GinkgoT().Setenv("HOME", dir)
+		ginkgo.GinkgoT().Setenv("XDG_CONFIG_HOME", dir)
+	})
+
+	ginkgo.It("forwards insight search grammar and limit to /resources/search", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/resources/search"))
+
+			var got sdk.CatalogInsightSearchRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(25))
+			Expect(got.ConfigAnalysis).To(HaveLen(1))
+			Expect(got.ConfigAnalysis[0].Search).To(Equal("severity=high type=security"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"config_analysis":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","name":"no-public-ip","type":"security","status":"open","severity":"high"}]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearchInsights("severity=high type=security", 25)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(items[0].ID).To(Equal("0274d556-6257-426a-b651-0a9bc35c26d8"))
+		Expect(items[0].InsightType).To(Equal("security"))
+		Expect(items[0].Severity).ToNot(BeNil())
+		Expect(*items[0].Severity).To(Equal("high"))
+	})
+
+	ginkgo.It("defaults insight search empty limit to 100", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var got sdk.CatalogInsightSearchRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.Limit).To(Equal(100))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"config_analysis":[]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		_, err := remoteSearchInsights("severity=high", 0)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	ginkgo.It("gets full insight details from the PostgREST endpoint", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/api/db/config_analysis"))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq.521bae33-e4c3-42eb-a9c5-071ab92940b5"))
+			Expect(r.URL.Query().Get("select")).To(ContainSubstring("analysis,properties"))
+			Expect(r.URL.Query().Get("select")).To(ContainSubstring("config:configs"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"521bae33-e4c3-42eb-a9c5-071ab92940b5","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","analyzer":"no-public-ip","message":"instance has public ip","summary":"public ip","status":"open","severity":"high","analysis_type":"security","analysis":{"rule":"R1"},"config":{"id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","name":"prod-instance","type":"AWS::EC2::Instance","config_class":"EC2"}}]`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL + "/api")
+
+		result, err := remoteGetInsight("521bae33-e4c3-42eb-a9c5-071ab92940b5")
+
+		Expect(err).ToNot(HaveOccurred())
+		insight := result.(*sdk.CatalogInsightDetail)
+		Expect(insight.Analyzer).To(Equal("no-public-ip"))
+		Expect(insight.Config).ToNot(BeNil())
+		Expect(insight.Config.ConfigClass).To(Equal("EC2"))
+	})
+})

--- a/faro/catalog_insight_test.go
+++ b/faro/catalog_insight_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
+	"github.com/flanksource/duty/query"
 	"github.com/flanksource/incident-commander/sdk"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,19 +24,21 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 			Expect(r.Method).To(Equal(http.MethodPost))
 			Expect(r.URL.Path).To(Equal("/resources/search"))
 
-			var got sdk.CatalogInsightSearchRequest
+			var got query.SearchResourcesRequest
 			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 			Expect(got.Limit).To(Equal(25))
+			Expect(got.Timestamps).To(BeTrue())
 			Expect(got.ConfigAnalysis).To(HaveLen(1))
 			Expect(got.ConfigAnalysis[0].Search).To(Equal("severity=high type=security"))
+			Expect(got.ConfigAnalysis[0].Agent).To(Equal("all"))
 
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"config_analysis":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","name":"no-public-ip","type":"security","status":"open","severity":"high"}]}`))
+			_, _ = w.Write([]byte(`{"config_analysis":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","name":"no-public-ip","type":"security","status":"open","severity":"high","created_at":"2026-06-24T16:41:38Z","updated_at":"2026-06-25T10:00:00Z"}]}`))
 		}))
 		defer server.Close()
 		storeRemoteContext(server.URL)
 
-		items, err := remoteSearchInsights("severity=high type=security", 25)
+		items, err := remoteSearchInsights("severity=high type=security", "all", 25)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(items).To(HaveLen(1))
@@ -42,11 +46,15 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		Expect(items[0].InsightType).To(Equal("security"))
 		Expect(items[0].Severity).ToNot(BeNil())
 		Expect(*items[0].Severity).To(Equal("high"))
+		Expect(items[0].CreatedAt).ToNot(BeNil())
+		Expect(*items[0].CreatedAt).To(Equal(time.Date(2026, 6, 24, 16, 41, 38, 0, time.UTC)))
+		Expect(items[0].UpdatedAt).ToNot(BeNil())
+		Expect(*items[0].UpdatedAt).To(Equal(time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)))
 	})
 
 	ginkgo.It("defaults insight search empty limit to 100", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var got sdk.CatalogInsightSearchRequest
+			var got query.SearchResourcesRequest
 			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 			Expect(got.Limit).To(Equal(100))
 			w.Header().Set("Content-Type", "application/json")
@@ -55,7 +63,7 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		defer server.Close()
 		storeRemoteContext(server.URL)
 
-		_, err := remoteSearchInsights("severity=high", 0)
+		_, err := remoteSearchInsights("severity=high", "all", 0)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/query"
+	"github.com/flanksource/duty/types"
 	"github.com/google/uuid"
 )
 
@@ -27,6 +28,28 @@ type CatalogChangeConfig struct {
 	ConfigClass string `json:"config_class"`
 }
 
+type CatalogSearchResource struct {
+	ID        string            `json:"id"`
+	Agent     string            `json:"agent"`
+	Icon      string            `json:"icon,omitempty"`
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace"`
+	Type      string            `json:"type"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	Health    string            `json:"health,omitempty"`
+	Status    string            `json:"status,omitempty"`
+	Severity  *string           `json:"severity,omitempty"`
+}
+
+type CatalogInsightSearchRequest struct {
+	Limit          int                      `json:"limit"`
+	ConfigAnalysis []types.ResourceSelector `json:"config_analysis"`
+}
+
+type CatalogInsightSearchResponse struct {
+	ConfigAnalysis []CatalogSearchResource `json:"config_analysis,omitempty"`
+}
+
 type CatalogChangeDetail struct {
 	ID                string               `json:"id"`
 	ConfigID          string               `json:"config_id"`
@@ -42,7 +65,27 @@ type CatalogChangeDetail struct {
 	Artifacts         []map[string]any     `json:"artifacts,omitempty"`
 }
 
+type CatalogInsightDetail struct {
+	ID            uuid.UUID            `json:"id"`
+	ConfigID      uuid.UUID            `json:"config_id"`
+	ScraperID     *uuid.UUID           `json:"scraper_id,omitempty"`
+	Analyzer      string               `json:"analyzer"`
+	Message       string               `json:"message,omitempty"`
+	Summary       string               `json:"summary,omitempty"`
+	Status        string               `json:"status,omitempty"`
+	Severity      models.Severity      `json:"severity,omitempty"`
+	AnalysisType  models.AnalysisType  `json:"analysis_type,omitempty"`
+	Analysis      types.JSONMap        `json:"analysis,omitempty"`
+	Properties    *types.Properties    `json:"properties,omitempty"`
+	Source        string               `json:"source,omitempty"`
+	FirstObserved *time.Time           `json:"first_observed,omitempty"`
+	LastObserved  *time.Time           `json:"last_observed,omitempty"`
+	IsPushed      bool                 `json:"is_pushed,omitempty"`
+	Config        *CatalogChangeConfig `json:"config,omitempty"`
+}
+
 const catalogChangeDetailSelect = "id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class),artifacts:artifacts(*)::jsonb"
+const catalogInsightDetailSelect = "id,config_id,scraper_id,analyzer,message,summary,status,severity,analysis_type,analysis,properties,source,first_observed,last_observed,is_pushed,config:configs(id,name,type,config_class)"
 
 // SearchCatalog runs a resource search against the remote server
 // (POST /resources/search).
@@ -59,6 +102,26 @@ func (c *Client) SearchCatalog(ctx context.Context, req query.SearchResourcesReq
 		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
 	}
 	var out query.SearchResourcesResponse
+	if err := decodeJSON(r, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SearchCatalogInsights runs a config insight search against POST /resources/search.
+func (c *Client) SearchCatalogInsights(ctx context.Context, req CatalogInsightSearchRequest) (*CatalogInsightSearchResponse, error) {
+	r, err := c.R(ctx).Post(c.apiPath("/resources/search"), req)
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		body, _ := r.AsString()
+		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
+			return nil, ErrHTMLResponse
+		}
+		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
+	}
+	var out CatalogInsightSearchResponse
 	if err := decodeJSON(r, &out); err != nil {
 		return nil, err
 	}
@@ -102,6 +165,32 @@ func (c *Client) GetCatalogChange(ctx context.Context, id string) (*CatalogChang
 		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
 	}
 	var out []CatalogChangeDetail
+	if err := decodeJSON(r, &out); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, ErrNotFound
+	}
+	return &out[0], nil
+}
+
+// GetCatalogInsight fetches full details for a catalog insight from PostgREST.
+func (c *Client) GetCatalogInsight(ctx context.Context, id string) (*CatalogInsightDetail, error) {
+	r, err := c.R(ctx).
+		QueryParam("id", "eq."+id).
+		QueryParam("select", catalogInsightDetailSelect).
+		Get(c.apiPath("/db/config_analysis"))
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		body, _ := r.AsString()
+		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
+			return nil, ErrHTMLResponse
+		}
+		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
+	}
+	var out []CatalogInsightDetail
 	if err := decodeJSON(r, &out); err != nil {
 		return nil, err
 	}

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -28,28 +28,6 @@ type CatalogChangeConfig struct {
 	ConfigClass string `json:"config_class"`
 }
 
-type CatalogSearchResource struct {
-	ID        string            `json:"id"`
-	Agent     string            `json:"agent"`
-	Icon      string            `json:"icon,omitempty"`
-	Name      string            `json:"name"`
-	Namespace string            `json:"namespace"`
-	Type      string            `json:"type"`
-	Tags      map[string]string `json:"tags,omitempty"`
-	Health    string            `json:"health,omitempty"`
-	Status    string            `json:"status,omitempty"`
-	Severity  *string           `json:"severity,omitempty"`
-}
-
-type CatalogInsightSearchRequest struct {
-	Limit          int                      `json:"limit"`
-	ConfigAnalysis []types.ResourceSelector `json:"config_analysis"`
-}
-
-type CatalogInsightSearchResponse struct {
-	ConfigAnalysis []CatalogSearchResource `json:"config_analysis,omitempty"`
-}
-
 type CatalogChangeDetail struct {
 	ID                string               `json:"id"`
 	ConfigID          string               `json:"config_id"`
@@ -102,26 +80,6 @@ func (c *Client) SearchCatalog(ctx context.Context, req query.SearchResourcesReq
 		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
 	}
 	var out query.SearchResourcesResponse
-	if err := decodeJSON(r, &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-// SearchCatalogInsights runs a config insight search against POST /resources/search.
-func (c *Client) SearchCatalogInsights(ctx context.Context, req CatalogInsightSearchRequest) (*CatalogInsightSearchResponse, error) {
-	r, err := c.R(ctx).Post(c.apiPath("/resources/search"), req)
-	if err != nil {
-		return nil, err
-	}
-	if !r.IsOK() {
-		body, _ := r.AsString()
-		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
-			return nil, ErrHTMLResponse
-		}
-		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
-	}
-	var out CatalogInsightSearchResponse
 	if err := decodeJSON(r, &out); err != nil {
 		return nil, err
 	}

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -31,6 +31,26 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(resp.Configs[0].Name).To(Equal("api"))
 	})
 
+	ginkgo.It("posts an insight search request and decodes config_analysis", func() {
+		var gotBody CatalogInsightSearchRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/resources/search"))
+			Expect(json.NewDecoder(r.Body).Decode(&gotBody)).To(Succeed())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"config_analysis":[{"id":"i1","name":"no-public-ip","type":"security","status":"open","severity":"high"}]}`))
+		}))
+		defer server.Close()
+
+		resp, err := New(server.URL, "tok").SearchCatalogInsights(context.Background(), CatalogInsightSearchRequest{Limit: 5})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotBody.Limit).To(Equal(5))
+		Expect(resp.ConfigAnalysis).To(HaveLen(1))
+		Expect(resp.ConfigAnalysis[0].Name).To(Equal("no-public-ip"))
+		Expect(resp.ConfigAnalysis[0].Severity).ToNot(BeNil())
+		Expect(*resp.ConfigAnalysis[0].Severity).To(Equal("high"))
+	})
+
 	ginkgo.It("gets a single catalog item by id", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))
@@ -63,6 +83,25 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(change.Details).To(HaveKeyWithValue("reason", "Failed"))
 		Expect(change.Config).ToNot(BeNil())
 		Expect(change.Config.Name).To(Equal("opensearch-fail"))
+	})
+
+	ginkgo.It("gets full catalog insight details from PostgREST", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/db/config_analysis"))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq.521bae33-e4c3-42eb-a9c5-071ab92940b5"))
+			Expect(r.URL.Query().Get("select")).To(Equal(catalogInsightDetailSelect))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"521bae33-e4c3-42eb-a9c5-071ab92940b5","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","analyzer":"no-public-ip","message":"instance has public ip","summary":"public ip","status":"open","severity":"high","analysis_type":"security","analysis":{"rule":"R1"},"config":{"id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","name":"prod-instance","type":"AWS::EC2::Instance","config_class":"EC2"}}]`))
+		}))
+		defer server.Close()
+
+		insight, err := New(server.URL, "tok").GetCatalogInsight(context.Background(), "521bae33-e4c3-42eb-a9c5-071ab92940b5")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(insight.Analyzer).To(Equal("no-public-ip"))
+		Expect(insight.Analysis).To(HaveKeyWithValue("rule", "R1"))
+		Expect(insight.Config).ToNot(BeNil())
+		Expect(insight.Config.Name).To(Equal("prod-instance"))
 	})
 
 	ginkgo.It("returns not found for an empty catalog change response", func() {

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -31,26 +31,6 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(resp.Configs[0].Name).To(Equal("api"))
 	})
 
-	ginkgo.It("posts an insight search request and decodes config_analysis", func() {
-		var gotBody CatalogInsightSearchRequest
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			Expect(r.Method).To(Equal(http.MethodPost))
-			Expect(r.URL.Path).To(Equal("/resources/search"))
-			Expect(json.NewDecoder(r.Body).Decode(&gotBody)).To(Succeed())
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"config_analysis":[{"id":"i1","name":"no-public-ip","type":"security","status":"open","severity":"high"}]}`))
-		}))
-		defer server.Close()
-
-		resp, err := New(server.URL, "tok").SearchCatalogInsights(context.Background(), CatalogInsightSearchRequest{Limit: 5})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(gotBody.Limit).To(Equal(5))
-		Expect(resp.ConfigAnalysis).To(HaveLen(1))
-		Expect(resp.ConfigAnalysis[0].Name).To(Equal("no-public-ip"))
-		Expect(resp.ConfigAnalysis[0].Severity).ToNot(BeNil())
-		Expect(*resp.ConfigAnalysis[0].Severity).To(Equal("high"))
-	})
-
 	ginkgo.It("gets a single catalog item by id", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))


### PR DESCRIPTION
Adds faro support for inspecting catalog insights.

The new `catalog insights search` command queries config_analysis via the resource search endpoint, matching the existing catalog changes flow. `catalog insights get` fetches full config_analysis details from PostgREST with config context.

Also bumps duty to the merged resource-selector support for config insights.


```
faro catalog insights search "severity=low config_id=74997f5b-1b97-e77c-2f4c-a11542c5afa4"

╭────────────────────────────────────┬─────────────────────────────┬─────────────────────────────┬─────────────────────────────┬─────────────────────────────╮
│id                                  │name                         │insight_type                 │status                       │severity                     │
├────────────────────────────────────┼─────────────────────────────┼─────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
│77414014-4e53-56af-b654-e5363f6e96b5│npm                          │security                     │open                         │low                          │
│6d2901b3-4e01-5379-9665-95c78a35ca54│go                           │security                     │open                         │low                          │
│09722894-0afa-5e0d-943a-03d03aae26a4│npm                          │security                     │open                         │low                          │
│e5091081-f06c-5f7e-a122-36024751ff62│npm                          │security                     │open                         │low                          │
│d2e95fa2-c3dd-51cb-9297-b1b22641d0eb│npm                          │security                     │open                         │low                          │
│12cbaedf-8cd1-5f9c-bbba-0a9ff93fc568│npm                          │security                     │open                         │low                          │
│a57ede2c-aa07-5081-88fd-c5db079c6b50│npm                          │security                     │open                         │low                          │
│5405bacc-9d29-5356-b194-c7464a026735│npm                          │security                     │open                         │low                          │
│24b5e333-28e0-538a-af57-b330d22eb531│npm                          │security                     │open                         │low                          │
╰────────────────────────────────────┴─────────────────────────────┴─────────────────────────────┴─────────────────────────────┴─────────────────────────────╯
[flanksource]  ~/flanksource/mission-control  chore/use-flanksource-create-release  21:48 ❯ faro catalog insights search "severity!=low config_id=74997f5b-1b97-e77c-2f4c-a11542c5afa4"

╭────────────────────────────────────┬───────────────────────────────┬─────────────────────────────┬────────────────────────────┬────────────────────────────╮
│id                                  │name                           │insight_type                 │status                      │severity                    │
├────────────────────────────────────┼───────────────────────────────┼─────────────────────────────┼────────────────────────────┼────────────────────────────┤
│2259ce8d-5339-5de5-82c9-93d0b24e6e0b│go/incorrect-integer-conversion│security                     │open                        │high                        │
│874bf00c-e638-5a81-8869-5f411c3a946f│npm                            │security                     │open                        │medium                      │
│17004d52-1808-5b1c-879b-f5388df82222│npm                            │security                     │open                        │medium                      │
│f7405a63-1585-54d8-8a0a-1823d83e40a2│npm                            │security                     │open                        │medium                      │
│fcd8c8f2-10de-5760-894d-27156b1b8cd3│npm                            │security                     │open                        │high                        │
│9781e676-a4e5-5a3d-b026-a93db751f4ed│npm                            │security                     │open                        │medium                      │
│dd8e021d-f434-5e21-94f9-2d682a9df772│npm                            │security                     │open                        │medium                      │
│ab793ff0-22f5-5406-ad32-ce65624073cb│go/incorrect-integer-conversion│security                     │open                        │high                        │
│8d7a853c-786c-50d1-b4fe-cbda47c0ba3e│js/incomplete-sanitization     │security                     │open                        │high                        │
│a8aecf45-3523-5670-b883-a54f0e5cff16│js/incomplete-sanitization     │security                     │open                        │high                        │
│ca9f363f-f8ee-5ef0-9509-69093d00557e│js/incomplete-sanitization     │security                     │open                        │high                        │
│c7185c27-1a4c-50c5-8a6c-8ddf0f6d2f0a│js/incomplete-sanitization     │security                     │open                        │high                        │
│6746d466-b435-581e-9bc2-82b7c66c16e9│js/incomplete-sanitization     │security                     │open                        │high                        │
│92310d05-7229-5334-94a4-e3d39a4604bf│js/incomplete-sanitization     │security                     │open                        │high                        │
│6a32cde5-3e53-563c-aa82-55d7aaedce41│js/incomplete-sanitization     │security                     │open                        │high                        │
│082c6788-9d7d-5357-8092-3e17741079a0│js/incomplete-sanitization     │security                     │open                        │high                        │
│2db109f7-47f4-5658-825e-49b3951b63ed│npm                            │security                     │open                        │medium                      │
│936eabb8-6e91-5cc6-9ada-4c7fd4fb254d│npm                            │security                     │open                        │medium                      │
│74025d82-388b-54f7-a4a5-ba67665f4a15│npm                            │security                     │open                        │medium                      │
│372105df-9183-5bea-bfcb-95427495e972│npm                            │security                     │open                        │medium                      │
│a6600bed-476a-571b-bfd3-19fcbb80ac12│npm                            │security                     │open                        │medium                      │
│2dfe9039-8d9a-5999-b0d8-f1fc2b2d83ac│npm                            │security                     │open                        │medium                      │
│6f998567-7f78-56ff-936e-e62e05754278│npm                            │security                     │open                        │medium                      │
│29df3548-93bb-5420-a550-9ad483775f81│npm                            │security                     │open                        │medium                      │
│0325433c-1789-58a5-83fd-9b93ba3fb35c│npm                            │security                     │open                        │medium                      │
│089d19ee-249a-5467-a879-38fa9cb88c8f│npm                            │security                     │open                        │medium                      │
│cb74055b-e96e-5741-a9f0-155b97f1f5dd│npm                            │security                     │open                        │high                        │
│5ee4e93f-02b9-5a9e-81b3-6bc715ead2b3│npm                            │security                     │open                        │high                        │
│3b1dd93b-bbcc-588c-9560-0b7e0d017234│npm                            │security                     │open                        │high                        │
│99c15b6b-7fb2-5095-984f-c612e14e401c│npm                            │security                     │open                        │high                        │
│c9125748-0d56-552f-86c3-77f03dfe6cf5│npm                            │security                     │open                        │high                        │
╰────────────────────────────────────┴───────────────────────────────┴─────────────────────────────┴────────────────────────────┴────────────────────────────╯
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog insight commands to search insights with a configurable limit and view full insight details by ID.
  * Search results now return structured insight information, and the default search limit is set to 100 when not specified.

* **Bug Fixes**
  * Improved handling of insight lookup results so missing entries are reported cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->