### PR TITLE
fix: faro search doesn't return timestamps

### DIFF
--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -29,8 +29,6 @@ type catalogGetFlags struct {
 
 func (catalogGetFlags) ClickyActionFlags() {}
 
-var catalogSearchFields = []string{"id", "name", "type", "tags", "health", "status", "created_at", "inserted_at", "updated_at"}
-
 // joinTagSelectors flattens repeated --tag values into a comma-separated label
 // selector, stripping the stray brackets clicky's []string round-trip can add.
 func joinTagSelectors(tags []string) string {
@@ -70,9 +68,9 @@ func remoteList(opts catalogListOpts) ([]models.ConfigItem, error) {
 	}
 
 	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
-		Limit:   limit,
-		Fields:  catalogSearchFields,
-		Configs: []types.ResourceSelector{selector},
+		Limit:      limit,
+		Timestamps: true,
+		Configs:    []types.ResourceSelector{selector},
 	})
 	if err != nil {
 		return nil, err
@@ -112,10 +110,8 @@ func selectedResourceToConfigItem(s query.SelectedResource) models.ConfigItem {
 	if s.CreatedAt != nil {
 		ci.CreatedAt = *s.CreatedAt
 	}
-	if s.InsertedAt != nil {
-		ci.InsertedAt = *s.InsertedAt
-	}
 	ci.UpdatedAt = s.UpdatedAt
+	ci.DeletedAt = s.DeletedAt
 	return ci
 }
 

--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -29,6 +29,8 @@ type catalogGetFlags struct {
 
 func (catalogGetFlags) ClickyActionFlags() {}
 
+var catalogSearchFields = []string{"id", "name", "type", "tags", "health", "status", "created_at", "inserted_at", "updated_at"}
+
 // joinTagSelectors flattens repeated --tag values into a comma-separated label
 // selector, stripping the stray brackets clicky's []string round-trip can add.
 func joinTagSelectors(tags []string) string {
@@ -69,6 +71,7 @@ func remoteList(opts catalogListOpts) ([]models.ConfigItem, error) {
 
 	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
 		Limit:   limit,
+		Fields:  catalogSearchFields,
 		Configs: []types.ResourceSelector{selector},
 	})
 	if err != nil {
@@ -106,6 +109,13 @@ func selectedResourceToConfigItem(s query.SelectedResource) models.ConfigItem {
 	if len(s.Tags) > 0 {
 		ci.Tags = types.JSONStringMap(s.Tags)
 	}
+	if s.CreatedAt != nil {
+		ci.CreatedAt = *s.CreatedAt
+	}
+	if s.InsertedAt != nil {
+		ci.InsertedAt = *s.InsertedAt
+	}
+	ci.UpdatedAt = s.UpdatedAt
 	return ci
 }
 

--- a/faro/catalog_search.go
+++ b/faro/catalog_search.go
@@ -57,8 +57,8 @@ func remoteSearch(searchQuery, agent string, limit int) ([]models.ConfigItem, er
 	}
 
 	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
-		Limit:  limit,
-		Fields: catalogSearchFields,
+		Limit:      limit,
+		Timestamps: true,
 		Configs: []types.ResourceSelector{{
 			Search: searchQuery,
 			Agent:  agent,

--- a/faro/catalog_search.go
+++ b/faro/catalog_search.go
@@ -57,7 +57,8 @@ func remoteSearch(searchQuery, agent string, limit int) ([]models.ConfigItem, er
 	}
 
 	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
-		Limit: limit,
+		Limit:  limit,
+		Fields: catalogSearchFields,
 		Configs: []types.ResourceSelector{{
 			Search: searchQuery,
 			Agent:  agent,

--- a/faro/catalog_search_test.go
+++ b/faro/catalog_search_test.go
@@ -26,12 +26,12 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 			var got query.SearchResourcesRequest
 			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 			Expect(got.Limit).To(Equal(25))
-			Expect(got.Fields).To(ContainElements("created_at", "inserted_at", "updated_at"))
+			Expect(got.Timestamps).To(BeTrue())
 			Expect(got.Configs).To(HaveLen(1))
 			Expect(got.Configs[0].Search).To(Equal("tags.cluster=beta-cluster type=pod mission-control"))
 			Expect(got.Configs[0].Agent).To(Equal("all"))
 
-			_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","health":"healthy","status":"Running","created_at":"2026-06-24T16:41:38Z","inserted_at":"2026-06-24T16:42:38Z","updated_at":"2026-06-24T16:43:38Z"}]}`))
+			_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","health":"healthy","status":"Running","created_at":"2026-06-24T16:41:38Z","updated_at":"2026-06-24T16:43:38Z","deleted_at":"2026-06-24T16:44:38Z"}]}`))
 		}))
 		defer server.Close()
 		storeRemoteContext(server.URL)
@@ -43,8 +43,8 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		Expect(*items[0].Name).To(Equal("api"))
 		Expect(*items[0].Type).To(Equal("Kubernetes::Pod"))
 		Expect(items[0].CreatedAt.IsZero()).To(BeFalse())
-		Expect(items[0].InsertedAt.IsZero()).To(BeFalse())
 		Expect(items[0].UpdatedAt).ToNot(BeNil())
+		Expect(items[0].DeletedAt).ToNot(BeNil())
 	})
 
 	ginkgo.It("defaults an empty limit to 100", func() {

--- a/faro/catalog_search_test.go
+++ b/faro/catalog_search_test.go
@@ -21,16 +21,17 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodPost))
 			Expect(r.URL.Path).To(Equal("/resources/search"))
+			w.Header().Set("Content-Type", "application/json")
 
 			var got query.SearchResourcesRequest
 			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 			Expect(got.Limit).To(Equal(25))
+			Expect(got.Fields).To(ContainElements("created_at", "inserted_at", "updated_at"))
 			Expect(got.Configs).To(HaveLen(1))
 			Expect(got.Configs[0].Search).To(Equal("tags.cluster=beta-cluster type=pod mission-control"))
 			Expect(got.Configs[0].Agent).To(Equal("all"))
 
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","health":"healthy","status":"Running"}]}`))
+			_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","health":"healthy","status":"Running","created_at":"2026-06-24T16:41:38Z","inserted_at":"2026-06-24T16:42:38Z","updated_at":"2026-06-24T16:43:38Z"}]}`))
 		}))
 		defer server.Close()
 		storeRemoteContext(server.URL)
@@ -41,6 +42,9 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		Expect(items).To(HaveLen(1))
 		Expect(*items[0].Name).To(Equal("api"))
 		Expect(*items[0].Type).To(Equal("Kubernetes::Pod"))
+		Expect(items[0].CreatedAt.IsZero()).To(BeFalse())
+		Expect(items[0].InsertedAt.IsZero()).To(BeFalse())
+		Expect(items[0].UpdatedAt).ToNot(BeNil())
 	})
 
 	ginkgo.It("defaults an empty limit to 100", func() {

--- a/faro/catalog_test.go
+++ b/faro/catalog_test.go
@@ -50,7 +50,7 @@ func catalogSearchServer(expectedPath string) *httptest.Server {
 		var got query.SearchResourcesRequest
 		Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 		Expect(got.Limit).To(Equal(5))
-		Expect(got.Fields).To(ContainElements("created_at", "inserted_at", "updated_at"))
+		Expect(got.Timestamps).To(BeTrue())
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
 	}))

--- a/faro/catalog_test.go
+++ b/faro/catalog_test.go
@@ -50,6 +50,7 @@ func catalogSearchServer(expectedPath string) *httptest.Server {
 		var got query.SearchResourcesRequest
 		Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 		Expect(got.Limit).To(Equal(5))
+		Expect(got.Fields).To(ContainElements("created_at", "inserted_at", "updated_at"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
 	}))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.34.0 // indirect
 	github.com/flanksource/commons v1.53.1
-	github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7
+	github.com/flanksource/duty v1.0.1336
 	github.com/flanksource/gomplate/v3 v3.24.84
 	github.com/flanksource/incident-commander/plugin/api v0.0.0
 	github.com/flanksource/kopper v1.0.22

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/fergusstrange/embedded-postgres v1.34.0 // indirect
 	github.com/flanksource/commons v1.53.1
-	github.com/flanksource/duty v1.0.1335
+	github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7
 	github.com/flanksource/gomplate/v3 v3.24.84
 	github.com/flanksource/incident-commander/plugin/api v0.0.0
 	github.com/flanksource/kopper v1.0.22

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/flanksource/deps v1.0.35 h1:tHxhkJSsJBWRmx7lR/X1rI8diz6tu0dsGb7GCROfu
 github.com/flanksource/deps v1.0.35/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
 github.com/flanksource/duty v1.0.1335 h1:np0VATL9HzfH54ea4NmRAsvF+HZUcCzGRBx9BKRJQnY=
 github.com/flanksource/duty v1.0.1335/go.mod h1:r335eY0Dw6OvEh2i0toGkexXuAZuZPAk8qITTLerbjs=
+github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7 h1:maCJwFI9uCPj94zegraToNQvK1oCfoG9mDLErnTqdrE=
+github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7/go.mod h1:r335eY0Dw6OvEh2i0toGkexXuAZuZPAk8qITTLerbjs=
 github.com/flanksource/gomplate/v3 v3.24.84 h1:UOE0yCJsczTIKRaHUvhD6tjCYrbNvOugAizuy0FVlhE=
 github.com/flanksource/gomplate/v3 v3.24.84/go.mod h1:NMMZkFsjbLy/8iY8Fip5N86Y0PP6lZeq+kmPwpVVIL0=
 github.com/flanksource/is-healthy v1.0.88 h1:ATQuKoNdp8Qfzf41/eMFajmT0qzOmZlZNG5eLK41RFo=

--- a/go.sum
+++ b/go.sum
@@ -420,10 +420,8 @@ github.com/flanksource/commons-test v0.1.13 h1:DLb3q1a7d+BpfxZDy2bdY8ZA5z1+UTYFE
 github.com/flanksource/commons-test v0.1.13/go.mod h1:T0zLA9F55jlaOhtvjj1Ot7QZQhtn2baAuflT+27ueG8=
 github.com/flanksource/deps v1.0.35 h1:tHxhkJSsJBWRmx7lR/X1rI8diz6tu0dsGb7GCROfuIQ=
 github.com/flanksource/deps v1.0.35/go.mod h1:2YRfP32WZrMxGVMYV51RlVHZfgerxf8DT3TqSgjzmTQ=
-github.com/flanksource/duty v1.0.1335 h1:np0VATL9HzfH54ea4NmRAsvF+HZUcCzGRBx9BKRJQnY=
-github.com/flanksource/duty v1.0.1335/go.mod h1:r335eY0Dw6OvEh2i0toGkexXuAZuZPAk8qITTLerbjs=
-github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7 h1:maCJwFI9uCPj94zegraToNQvK1oCfoG9mDLErnTqdrE=
-github.com/flanksource/duty v1.0.1336-0.20260626130122-6d4ba1cc51f7/go.mod h1:r335eY0Dw6OvEh2i0toGkexXuAZuZPAk8qITTLerbjs=
+github.com/flanksource/duty v1.0.1336 h1:Oyim8OYlekwrWz3eCR8smygc3JomGEcjVf/VAuVR2gM=
+github.com/flanksource/duty v1.0.1336/go.mod h1:r335eY0Dw6OvEh2i0toGkexXuAZuZPAk8qITTLerbjs=
 github.com/flanksource/gomplate/v3 v3.24.84 h1:UOE0yCJsczTIKRaHUvhD6tjCYrbNvOugAizuy0FVlhE=
 github.com/flanksource/gomplate/v3 v3.24.84/go.mod h1:NMMZkFsjbLy/8iY8Fip5N86Y0PP6lZeq+kmPwpVVIL0=
 github.com/flanksource/is-healthy v1.0.88 h1:ATQuKoNdp8Qfzf41/eMFajmT0qzOmZlZNG5eLK41RFo=


### PR DESCRIPTION
Fixes #3289.

Requests timestamp fields from SearchResources and maps them into faro catalog output.

Depends on flanksource/duty#2024.