### PR TITLE
fix(ci): replace codfish/semantic-release-action with flanksource create-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,30 +4,22 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {} # start with no permission
 
 jobs:
-  semantic-release:
+  create-release:
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
-    outputs:
-      release-version: ${{ steps.semantic.outputs.release-version }}
-      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: codfish/semantic-release-action@6abd188d2458e2fd6c99073454f6cc49196362e8 # v5.0.0
-        id: semantic
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
+
   binary:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: semantic-release
+    needs: create-release
+    if: needs.create-release.outputs.published == 'true'
     steps:
       - name: Clear up disk space
         run: |
@@ -54,15 +46,15 @@ jobs:
             cache-go-1.26-
       - run: make release
         env:
-          VERSION: v${{ needs.semantic-release.outputs.release-version }}
+          VERSION: v${{ needs.create-release.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload binaries to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "v${{ needs.semantic-release.outputs.release-version }}" ./.release/* --clobber --repo "${{ github.repository }}"
+        run: gh release upload "v${{ needs.create-release.outputs.version }}" ./.release/* --clobber --repo "${{ github.repository }}"
 
   docker:
-    needs: semantic-release
+    needs: create-release
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -117,11 +109,11 @@ jobs:
           cache-to: type=gha,mode=max
 
   update-incident-commander-chart:
-    if: needs.semantic-release.outputs.new-release-published == 'true'
+    if: needs.create-release.outputs.published == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    needs: [semantic-release, docker]
+    needs: [create-release, docker]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set version
@@ -154,13 +146,13 @@ jobs:
           branch: main
 
   publish-release:
-    if: needs.semantic-release.outputs.new-release-published == 'true'
+    if: needs.create-release.outputs.published == 'true'
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [semantic-release, binary, docker, update-incident-commander-chart]
+    needs: [create-release, binary, docker, update-incident-commander-chart]
     steps:
       - name: Publish draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "v${{ needs.semantic-release.outputs.release-version }}" --draft=false --repo "${{ github.repository }}"
+        run: gh release edit "v${{ needs.create-release.outputs.version }}" --draft=false --repo "${{ github.repository }}"


### PR DESCRIPTION
Use the flanksource/action-workflows reusable create-release workflow (@main) instead of codfish/semantic-release-action, matching the duty/config-db/mission-control-chart repos. Remap outputs (release-version -> version, new-release-published -> published) and guard the binary job behind published == 'true'.