### PR TITLE
fix(faro): return timestamps in catalog change search

### DIFF
--- a/faro/catalog_change.go
+++ b/faro/catalog_change.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/flanksource/clicky"
 	"github.com/flanksource/duty/query"
@@ -14,11 +15,12 @@ import (
 var changeSearchLimit int
 
 type catalogChangeSearchHit struct {
-	ID         string `json:"id"`
-	Agent      string `json:"agent,omitempty"`
-	Name       string `json:"name,omitempty"`
-	Namespace  string `json:"namespace,omitempty"`
-	ChangeType string `json:"change_type,omitempty"`
+	ID         string     `json:"id"`
+	Agent      string     `json:"agent,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	Namespace  string     `json:"namespace,omitempty"`
+	ChangeType string     `json:"change_type,omitempty"`
+	CreatedAt  *time.Time `json:"created_at,omitempty"`
 }
 
 var CatalogChange = &cobra.Command{
@@ -72,7 +74,8 @@ func remoteSearchChanges(searchQuery string, limit int) ([]catalogChangeSearchHi
 	}
 
 	resp, err := client.SearchCatalog(context.Background(), query.SearchResourcesRequest{
-		Limit: limit,
+		Limit:      limit,
+		Timestamps: true,
 		ConfigChanges: []types.ResourceSelector{{
 			Search: searchQuery,
 		}},
@@ -89,6 +92,7 @@ func remoteSearchChanges(searchQuery string, limit int) ([]catalogChangeSearchHi
 			Name:       s.Name,
 			Namespace:  s.Namespace,
 			ChangeType: s.Type,
+			CreatedAt:  s.CreatedAt,
 		})
 	}
 	return out, nil

--- a/faro/catalog_change_test.go
+++ b/faro/catalog_change_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/incident-commander/sdk"
@@ -26,12 +27,13 @@ var _ = ginkgo.Describe("faro catalog change", func() {
 			var got query.SearchResourcesRequest
 			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 			Expect(got.Limit).To(Equal(25))
+			Expect(got.Timestamps).To(BeTrue())
 			Expect(got.ConfigChanges).To(HaveLen(1))
 			Expect(got.ConfigChanges[0].Search).To(Equal("change_type=diff type=deployment"))
 			Expect(got.ConfigChanges[0].Agent).To(BeEmpty())
 
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"config_changes":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","agent":"00000000-0000-0000-0000-000000000000","name":"status","namespace":"kube-system","type":"diff"}]}`))
+			_, _ = w.Write([]byte(`{"config_changes":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","agent":"00000000-0000-0000-0000-000000000000","name":"status","namespace":"kube-system","type":"diff","created_at":"2026-06-24T16:41:38Z"}]}`))
 		}))
 		defer server.Close()
 		storeRemoteContext(server.URL)
@@ -42,6 +44,8 @@ var _ = ginkgo.Describe("faro catalog change", func() {
 		Expect(items).To(HaveLen(1))
 		Expect(items[0].ID).To(Equal("0274d556-6257-426a-b651-0a9bc35c26d8"))
 		Expect(items[0].ChangeType).To(Equal("diff"))
+		Expect(items[0].CreatedAt).ToNot(BeNil())
+		Expect(items[0].CreatedAt.UTC()).To(Equal(time.Date(2026, 6, 24, 16, 41, 38, 0, time.UTC)))
 	})
 
 	ginkgo.It("defaults change search empty limit to 100", func() {


### PR DESCRIPTION
## Problem

`faro catalog change search` returns no `created_at`, while `faro catalog search` (configs) does:

```
faro catalog changes search 'change_type=diff' --limit 1 --json
[{"id":"...","agent":"...","name":"...","namespace":"...","change_type":"diff"}]   # no created_at
```

Two client-side gaps (the server already supports it):
1. `remoteSearchChanges` never set `Timestamps: true` on the `/resources/search` request, so the server skipped timestamp population.
2. `catalogChangeSearchHit` had no timestamp field and the mapping never copied one.

## Change

- Set `Timestamps: true` on the change search request.
- Add `created_at` to `catalogChangeSearchHit` and map it from the response.

The server (duty) already populates `created_at` for config changes in `SearchResources`, so this is client-only.

## Test

Extended the existing change-search spec to assert the request sets `Timestamps` and that `created_at` is mapped onto the hit. Passes.