### PR TITLE
fix(faro): improve catalog command behavior

### DIFF
--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -19,6 +19,7 @@ type catalogListOpts struct {
 	Type      string   `flag:"type" help:"Filter by type (comma-separated, supports ! negation)"`
 	Namespace string   `flag:"namespace" help:"Filter by namespace"`
 	Tag       []string `flag:"tag" help:"Filter by tag as a label selector (repeatable: --tag cluster=foo)"`
+	Agent     string   `flag:"agent" help:"Filter by agent id or name ('all' for every agent)" default:"all"`
 	Limit     int      `flag:"limit" help:"Maximum number of results" default:"100"`
 }
 
@@ -54,8 +55,14 @@ func remoteList(opts catalogListOpts) ([]models.ConfigItem, error) {
 		return nil, err
 	}
 
+	agent := opts.Agent
+	if agent == "" {
+		agent = "all"
+	}
+
 	selector := types.ResourceSelector{
 		Search:      opts.Query,
+		Agent:       agent,
 		Namespace:   opts.Namespace,
 		TagSelector: joinTagSelectors(opts.Tag),
 	}

--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -15,7 +15,7 @@ import (
 
 // catalogListOpts binds the `catalog list` filter flags via clicky's `flag:` tags.
 type catalogListOpts struct {
-	Query     string   `flag:"query" help:"Free-form search (name/tag/labels)"`
+	Query     string   `flag:"query" help:"Free-form text or catalog query expression"`
 	Type      string   `flag:"type" help:"Filter by type (comma-separated, supports ! negation)"`
 	Namespace string   `flag:"namespace" help:"Filter by namespace"`
 	Tag       []string `flag:"tag" help:"Filter by tag as a label selector (repeatable: --tag cluster=foo)"`
@@ -25,7 +25,7 @@ type catalogListOpts struct {
 
 // catalogGetFlags binds the `catalog get` flags.
 type catalogGetFlags struct {
-	Relationships bool `flag:"relationships" help:"Show the config relationship tree instead of the item"`
+	Relationships bool `flag:"relationships" help:"Return the config relationship tree instead of the item"`
 }
 
 func (catalogGetFlags) ClickyActionFlags() {}

--- a/faro/catalog_help.go
+++ b/faro/catalog_help.go
@@ -1,0 +1,166 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func documentCatalogCommand(catalogCmd *cobra.Command) {
+	if catalogCmd == nil {
+		return
+	}
+
+	disableCatalogRootList(catalogCmd)
+
+	catalogCmd.Short = "List and inspect catalog resources"
+	catalogCmd.Long = `List and inspect catalog resources from the current Mission Control context.
+
+The catalog contains configuration items discovered from Kubernetes, cloud,
+Git, CI/CD, and other connected systems.
+
+Choose a subcommand for the workflow you want. Use "list" for simple flag-based
+filters. Use "search" when you want the catalog query language in one expression.`
+	catalogCmd.Example = `  faro catalog list --limit 50
+  faro catalog list --type Kubernetes::Pod --namespace default
+  faro catalog list --tag cluster=prod --agent all --limit 50
+  faro catalog search 'type=Kubernetes::Pod tags.cluster=prod name=api*'
+  faro catalog get <config-id>`
+
+	if listCmd := catalogSubcommand(catalogCmd, "list"); listCmd != nil {
+		listCmd.Short = "List catalog resources using filter flags"
+		listCmd.Long = `List catalog resources using simple, structured filter flags.
+
+This command returns lightweight catalog rows.
+
+Use --query for free-form text or a catalog query expression, --type for config
+types, --namespace for a namespace, --tag for tag label selectors, --agent to
+select an agent, and --limit to control result count.
+
+Use "faro catalog search <QUERY>" when the query expression is the main input
+and you do not need the other list filter flags.`
+		listCmd.Example = `  faro catalog list --limit 50
+  faro catalog list --type Kubernetes::Pod --namespace default
+  faro catalog list --tag cluster=prod --tag env=dev --agent all --limit 50
+  faro catalog list --query api
+  faro catalog list --type Kubernetes::Deployment`
+	}
+
+	if getCmd := catalogSubcommand(catalogCmd, "get"); getCmd != nil {
+		getCmd.Short = "Get a catalog resource by ID"
+		getCmd.Long = `Get a single catalog resource by ID.
+
+Use "faro catalog list" or "faro catalog search" to find resource IDs first.
+
+By default this returns the catalog item. Use --relationships to return the
+incoming and outgoing relationship tree instead.`
+		getCmd.Example = `  faro catalog get 018f4e6a-1234-5678-9abc-def012345678
+  faro catalog get <config-id> --relationships
+  faro catalog search 'name=api*' --limit 10`
+	}
+
+	if searchCmd := catalogSubcommand(catalogCmd, "search"); searchCmd != nil {
+		searchCmd.Short = "Search catalog resources using the query language"
+		searchCmd.Long = `Search catalog resources using the catalog query language.
+
+Use this instead of "faro catalog list" when you want field expressions in a
+single query, such as type=..., tags.cluster=..., health!=healthy, name=api*,
+or multiple clauses joined together.
+
+Queries are matched against resource name, type, tags, labels, health, status,
+and other indexed catalog fields. Multiple clauses are space-separated and ANDed
+together. Quote the query when it contains spaces or shell-special characters.`
+		searchCmd.Example = `  faro catalog search 'type=Kubernetes::Pod'
+  faro catalog search 'tags.cluster=prod type=Kubernetes::Pod api'
+  faro catalog search 'health!=healthy agent=all' --limit 50
+  faro catalog search 'name=api*' --agent all --limit 50`
+	}
+
+	if changesCmd := catalogSubcommand(catalogCmd, "change"); changesCmd != nil {
+		documentCatalogChangeCommand(changesCmd)
+	}
+
+	if insightsCmd := catalogSubcommand(catalogCmd, "insights"); insightsCmd != nil {
+		documentCatalogInsightsCommand(insightsCmd)
+	}
+}
+
+func disableCatalogRootList(catalogCmd *cobra.Command) {
+	catalogCmd.Run = nil
+	catalogCmd.RunE = nil
+	catalogCmd.Args = nil
+	catalogCmd.ValidArgsFunction = nil
+	catalogCmd.ResetFlags()
+}
+
+func documentCatalogChangeCommand(changesCmd *cobra.Command) {
+	changesCmd.Short = "Search and inspect catalog change events"
+	changesCmd.Long = `Search and inspect historical change events for catalog resources.
+
+Use "search" to find change IDs, then "get" to fetch the full change record.`
+	changesCmd.Example = `  faro catalog change search 'change_type=diff'
+  faro catalog change search 'type=Kubernetes::Deployment source=kubernetes' --limit 50
+  faro catalog change get <change-id>`
+
+	if searchCmd := catalogSubcommand(changesCmd, "search"); searchCmd != nil {
+		searchCmd.Short = "Search catalog changes using the query language"
+		searchCmd.Long = `Search catalog change events using the catalog query language.
+
+Use this to find historical changes by change type, catalog resource type,
+source, severity, name, tags, or other indexed fields. The result rows include
+change IDs that can be passed to "faro catalog change get".`
+		searchCmd.Example = `  faro catalog change search 'change_type=diff'
+  faro catalog change search 'change_type=diff type=Kubernetes::Deployment'
+  faro catalog change search 'severity=critical source=kubernetes' --limit 50`
+	}
+
+	if getCmd := catalogSubcommand(changesCmd, "get"); getCmd != nil {
+		getCmd.Short = "Get full details for a catalog change"
+		getCmd.Long = `Get the full details for a single catalog change event by ID.
+
+Use "faro catalog change search" to find change IDs first.`
+		getCmd.Example = `  faro catalog change get <change-id>
+  faro catalog change search 'change_type=diff' --limit 10`
+	}
+}
+
+func documentCatalogInsightsCommand(insightsCmd *cobra.Command) {
+	insightsCmd.Short = "Search and inspect catalog insights"
+	insightsCmd.Long = `Search and inspect catalog insights produced by analyzers.
+
+Insights are findings or observations about catalog resources, such as security,
+compliance, reliability, or operational issues. Use "search" to find insight
+IDs, then "get" to fetch the full insight record.`
+	insightsCmd.Example = `  faro catalog insights search 'severity=critical'
+  faro catalog insights search 'status=open analyzer=no-public-ip' --limit 50
+  faro catalog insights get <insight-id>`
+
+	if searchCmd := catalogSubcommand(insightsCmd, "search"); searchCmd != nil {
+		searchCmd.Short = "Search catalog insights using the query language"
+		searchCmd.Long = `Search catalog insights using the catalog query language.
+
+Use this to find findings by severity, status, analyzer, source, catalog resource
+type, name, tags, or other indexed fields. The result rows include insight IDs
+that can be passed to "faro catalog insights get".`
+		searchCmd.Example = `  faro catalog insights search 'severity=critical'
+  faro catalog insights search 'status=open type=security'
+  faro catalog insights search 'analyzer=no-public-ip source=aws' --limit 50`
+	}
+
+	if getCmd := catalogSubcommand(insightsCmd, "get"); getCmd != nil {
+		getCmd.Short = "Get full details for a catalog insight"
+		getCmd.Long = `Get the full details for a single catalog insight by ID.
+
+Use "faro catalog insights search" to find insight IDs first.`
+		getCmd.Example = `  faro catalog insights get <insight-id>
+  faro catalog insights search 'severity=critical' --limit 10`
+	}
+}
+
+func catalogSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	if parent == nil {
+		return nil
+	}
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}

--- a/faro/catalog_help_test.go
+++ b/faro/catalog_help_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = ginkgo.Describe("faro catalog help", func() {
+	ginkgo.It("keeps the catalog root help-only instead of defaulting to list", func() {
+		catalogCmd := &cobra.Command{
+			Use: "catalog",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return nil
+			},
+		}
+		catalogCmd.Flags().String("type", "", "promoted list flag")
+		catalogCmd.AddCommand(&cobra.Command{Use: "list"})
+
+		documentCatalogCommand(catalogCmd)
+
+		Expect(catalogCmd.Runnable()).To(BeFalse())
+		Expect(catalogCmd.Flags().Lookup("type")).To(BeNil())
+
+		var out bytes.Buffer
+		catalogCmd.SetOut(&out)
+		catalogCmd.SetErr(&out)
+		catalogCmd.SetArgs([]string{})
+		Expect(catalogCmd.Execute()).To(Succeed())
+		Expect(out.String()).To(ContainSubstring("Choose a subcommand"))
+		Expect(out.String()).To(ContainSubstring("faro catalog list"))
+	})
+})

--- a/faro/catalog_test.go
+++ b/faro/catalog_test.go
@@ -51,6 +51,8 @@ func catalogSearchServer(expectedPath string) *httptest.Server {
 		Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
 		Expect(got.Limit).To(Equal(5))
 		Expect(got.Timestamps).To(BeTrue())
+		Expect(got.Configs).To(HaveLen(1))
+		Expect(got.Configs[0].Agent).To(Equal("all"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
 	}))

--- a/faro/main.go
+++ b/faro/main.go
@@ -116,6 +116,7 @@ func main() {
 	// (see catalog.go) into `catalog list` / `catalog get` commands.
 	clicky.GenerateCLI(root)
 	if c, _, err := root.Find([]string{"catalog"}); err == nil && c != nil {
+		documentCatalogCommand(c)
 		clicky.BindAllFlags(c.PersistentFlags(), "format")
 	}
 	clientcmd.FinalizeCommandGroups(root)


### PR DESCRIPTION
`faro catalog list` could return an empty result because it left the agent selector unset, unlike `catalog search` which searched all agents.

Default list requests to `agent=all` and expose `--agent` explicitly.

Also keep `faro catalog` as a help-only command instead of defaulting to `list`, and add end-user help/examples for the catalog subcommands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `catalog list` now supports filtering results by agent, with a default of all agents.
  * The `faro catalog` command now includes clearer built-in help for its subcommands.
* **Bug Fixes**
  * Improved how catalog search requests are sent so agent filtering is applied consistently.
  * Updated command help behavior so the main catalog command shows guidance instead of running directly.
* **Tests**
  * Added coverage for catalog help output and agent-filtered search requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->