### PR TITLE
fix: avoid Clerk user cache collisions

### DIFF
--- a/auth/clerk_client.go
+++ b/auth/clerk_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/flanksource/commons/logger"
+	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/rbac"
@@ -27,6 +28,7 @@ import (
 
 const (
 	clerkSessionCookie = "__session"
+	clerkUserCacheTTL  = 5 * time.Minute
 )
 
 var (
@@ -151,21 +153,35 @@ func (h *ClerkHandler) getUserFromSessionToken(ctx context.Context, sessionToken
 	if err != nil {
 		return AuthResult{}, err
 	}
-	sessionID := fmt.Sprint(claims["sid"])
 
-	if user, exists := h.userCache.Get(sessionID); exists {
+	return h.getUserFromSessionClaims(ctx, claims)
+}
+
+func (h *ClerkHandler) getUserFromSessionClaims(ctx context.Context, claims jwt.MapClaims) (AuthResult, error) {
+	orgID := clerkOrgID(claims)
+	if orgID == "" {
+		return AuthResult{}, dutyAPI.Errorf(dutyAPI.EINVALID, "missing Clerk organization id")
+	}
+	if orgID != h.orgID {
+		return AuthResult{}, dutyAPI.Errorf(dutyAPI.EINVALID, "organization id does not match")
+	}
+
+	externalID := clerkUserID(claims)
+	if externalID == "" {
+		return AuthResult{}, dutyAPI.Errorf(dutyAPI.EINVALID, "missing Clerk user id")
+	}
+
+	sessionID := clerkClaimString(claims, "sid")
+	cacheKey := clerkUserCacheKey(orgID, externalID)
+	if user, exists := h.userCache.Get(cacheKey); exists {
 		return AuthResult{User: user.(*models.Person), SessionID: sessionID}, nil
 	}
 
-	if fmt.Sprint(claims["org_id"]) != h.orgID {
-		return AuthResult{}, fmt.Errorf("organization id does not match")
-	}
-
 	user := models.Person{
-		Name:       fmt.Sprint(claims["name"]),
-		Email:      fmt.Sprint(claims["email"]),
-		Avatar:     fmt.Sprint(claims["image_url"]),
-		ExternalID: fmt.Sprint(claims["user_id"]),
+		Name:       clerkClaimString(claims, "name"),
+		Email:      clerkClaimString(claims, "email"),
+		Avatar:     clerkClaimString(claims, "image_url"),
+		ExternalID: externalID,
 	}
 	dbUser, err := h.createDBUserIfNotExists(ctx, user)
 	if err != nil {
@@ -174,12 +190,89 @@ func (h *ClerkHandler) getUserFromSessionToken(ctx context.Context, sessionToken
 
 	// If session expires, and clerk role is different from our rbac
 	// we update the rbac
-	if err := h.updateRole(dbUser.ID.String(), fmt.Sprint(claims["role"])); err != nil {
-		return AuthResult{}, err
+	if err := h.updateRole(dbUser.ID.String(), clerkRole(claims)); err != nil {
+		return AuthResult{}, ctx.Oops().Wrapf(err, "update Clerk role for user %s", dbUser.ID.String())
 	}
 
-	h.userCache.SetDefault(sessionID, &dbUser)
+	h.userCache.Set(cacheKey, &dbUser, clerkUserCacheTTL)
 	return AuthResult{User: &dbUser, SessionID: sessionID}, nil
+}
+
+func clerkClaimString(claims jwt.MapClaims, key string) string {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return ""
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func clerkClaimMap(claims jwt.MapClaims, key string) map[string]any {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	switch value := raw.(type) {
+	case map[string]any:
+		return value
+	case jwt.MapClaims:
+		return map[string]any(value)
+	default:
+		return nil
+	}
+}
+
+func clerkMapString(claims map[string]any, key string) string {
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return ""
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func clerkOrgID(claims jwt.MapClaims) string {
+	if orgID := clerkClaimString(claims, "org_id"); orgID != "" {
+		return orgID
+	}
+
+	if org := clerkClaimMap(claims, "o"); org != nil {
+		return clerkMapString(org, "id")
+	}
+	return ""
+}
+
+func clerkUserID(claims jwt.MapClaims) string {
+	if userID := clerkClaimString(claims, "user_id"); userID != "" {
+		return userID
+	}
+	return clerkClaimString(claims, "sub")
+}
+
+func clerkRole(claims jwt.MapClaims) string {
+	if role := clerkClaimString(claims, "role"); role != "" {
+		return role
+	}
+	if role := clerkClaimString(claims, "org_role"); role != "" {
+		return role
+	}
+	if org := clerkClaimMap(claims, "o"); org != nil {
+		return clerkMapString(org, "rol")
+	}
+	return ""
+}
+
+func clerkUserCacheKey(orgID, externalID string) string {
+	return fmt.Sprintf("clerk:%s:%s", orgID, externalID)
 }
 
 func (h *ClerkHandler) createDBUserIfNotExists(ctx context.Context, user models.Person) (models.Person, error) {
@@ -358,13 +451,17 @@ func (c *ClerkCredentialChecker) LoginRedirectURL(authRequestID string) (string,
 	return loginURL.String(), nil
 }
 
+func (c *ClerkCredentialChecker) callbackSessionToken(ec echo.Context) string {
+	if sessionToken := ec.Request().PostFormValue("clerk_session_token"); sessionToken != "" {
+		return sessionToken
+	}
+	return c.handler.extractSessionToken(ec)
+}
+
 func (c *ClerkCredentialChecker) CallbackSubject(ec echo.Context) (string, error) {
 	ctx := ec.Request().Context().(context.Context)
 
-	sessionToken := c.handler.extractSessionToken(ec)
-	if sessionToken == "" {
-		sessionToken = ec.FormValue("clerk_session_token")
-	}
+	sessionToken := c.callbackSessionToken(ec)
 	if sessionToken == "" {
 		return "", fmt.Errorf("no Clerk session token found")
 	}

--- a/auth/clerk_client_test.go
+++ b/auth/clerk_client_test.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/flanksource/duty/models"
+	dutyRBAC "github.com/flanksource/duty/rbac"
+	"github.com/flanksource/incident-commander/rbac/adapter"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/labstack/echo/v4"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/patrickmn/go-cache"
+)
+
+var _ = ginkgo.Describe("Clerk session claims", func() {
+	ginkgo.It("does not coerce missing claims into cache identities", func() {
+		claims := jwt.MapClaims{}
+
+		Expect(clerkClaimString(claims, "sid")).To(BeEmpty())
+		Expect(clerkUserID(claims)).To(BeEmpty())
+		Expect(clerkUserCacheKey("org_1", "user_1")).ToNot(Equal(clerkUserCacheKey("org_1", "user_2")))
+	})
+
+	ginkgo.It("supports Clerk session token claim shapes", func() {
+		claims := jwt.MapClaims{
+			"sub": "user_123",
+			"o": map[string]any{
+				"id":  "org_123",
+				"rol": "admin",
+			},
+		}
+
+		Expect(clerkUserID(claims)).To(Equal("user_123"))
+		Expect(clerkOrgID(claims)).To(Equal("org_123"))
+		Expect(clerkRole(claims)).To(Equal("admin"))
+	})
+
+	ginkgo.It("prefers the relayed callback token over ambient session credentials", func() {
+		req := httptest.NewRequest(http.MethodPost, "/oidc/clerk/callback", strings.NewReader("clerk_session_token=relayed-token"))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer ambient-token")
+		ec := echo.New().NewContext(req, httptest.NewRecorder())
+
+		checker := NewClerkCredentialChecker(&ClerkHandler{})
+		Expect(checker.callbackSessionToken(ec)).To(Equal("relayed-token"))
+	})
+
+	ginkgo.It("ignores Clerk callback tokens from query parameters", func() {
+		req := httptest.NewRequest(http.MethodPost, "/oidc/clerk/callback?clerk_session_token=query-token", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer ambient-token")
+		ec := echo.New().NewContext(req, httptest.NewRecorder())
+
+		checker := NewClerkCredentialChecker(&ClerkHandler{})
+		Expect(checker.callbackSessionToken(ec)).To(Equal("ambient-token"))
+	})
+
+	ginkgo.It("does not reuse a Clerk user cache entry for another user", func() {
+		if dutyRBAC.Enforcer() == nil {
+			Expect(dutyRBAC.Init(DefaultContext, []string{}, adapter.NewPermissionAdapter)).To(Succeed())
+		}
+
+		var first, second AuthResult
+		defer func() {
+			if first.User != nil {
+				_, _ = dutyRBAC.Enforcer().DeleteRolesForUser(first.User.ID.String())
+			}
+			if second.User != nil {
+				_, _ = dutyRBAC.Enforcer().DeleteRolesForUser(second.User.ID.String())
+			}
+		}()
+
+		orgID := "org_test_" + time.Now().Format("20060102150405")
+		userA := "user_a_" + time.Now().Format("150405.000000000")
+		userB := "user_b_" + time.Now().Format("150405.000000000")
+		defer DefaultContext.DB().Where("external_id IN ?", []string{userA, userB}).Delete(&models.Person{})
+
+		handler := &ClerkHandler{
+			orgID:     orgID,
+			userCache: cache.New(3*24*time.Hour, 12*time.Hour),
+		}
+
+		var err error
+		first, err = handler.getUserFromSessionClaims(DefaultContext, jwt.MapClaims{
+			"org_id":    orgID,
+			"user_id":   userA,
+			"email":     fmt.Sprintf("%s@example.com", userA),
+			"name":      "User A",
+			"image_url": "https://example.com/a.png",
+			"role":      "viewer",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(first.SessionID).To(BeEmpty())
+		Expect(first.User.ExternalID).To(Equal(userA))
+
+		second, err = handler.getUserFromSessionClaims(DefaultContext, jwt.MapClaims{
+			"org_id":    orgID,
+			"user_id":   userB,
+			"email":     fmt.Sprintf("%s@example.com", userB),
+			"name":      "User B",
+			"image_url": "https://example.com/b.png",
+			"role":      "viewer",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(second.SessionID).To(BeEmpty())
+		Expect(second.User.ExternalID).To(Equal(userB))
+		Expect(second.User.ID).ToNot(Equal(first.User.ID))
+	})
+})


### PR DESCRIPTION
Clerk Backend JWT template tokens can omit `sid`, which caused missing claims to be coerced into shared cache keys.

This could make sid-less direct/OIDC Clerk auth reuse another user's cached identity during MCP login. Validate org/user claims before cache lookup, namespace cache keys by org/session/user, short-cache sid-less tokens, and prefer the relayed Clerk callback token over ambient credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made Clerk sign-in more reliable by validating session claims and correctly deriving identity, role, and organization context across different claim shapes.
  * Improved browser-login callback handling to reliably use the intended session token when multiple token sources are present.
  * Updated session caching to avoid cross-session data reuse, ensuring isolation between different identities.
* **Tests**
  * Added Ginkgo/Gomega coverage for session-claim parsing, callback token precedence, and cache isolation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->