### PR TITLE
feat: add MCP whoami tool

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -16,7 +16,7 @@
 | `Unhealthy catalog items` | Searches for all unhealthy items using `search_catalog` with query `health!=healthy` |
 | `troubleshoot_kubernetes_resource` | Troubleshoots Kubernetes resources. Accepts optional `query` argument (default: `health!=healthy type=Kubernetes::*`) |
 
-## Tools (21 static + dynamic)
+## Tools (22 static + dynamic)
 
 | Tool | Hints | Description |
 |------|-------|-------------|
@@ -41,6 +41,7 @@
 | [`search_catalog_access_reviews`](#search_catalog_access_reviews) | read-only | Search historical access review and certification events to verify when user permissions were last audited or validated. |
 | [`search_catalog_changes`](#search_catalog_changes) | read-only | Search and find configuration change events across catalog items. |
 | [`search_health_checks`](#search_health_checks) | read-only | Search and find health checks returning JSON array with check metadata |
+| [`whoami`](#whoami) | read-only | Return the currently authenticated MCP subject, delegated owner, roles, and permissions. |
 | `{playbook}_{namespace}_{category}` | mutating | Dynamic per-session playbook tools. Parameters derived from playbook spec. |
 | `view_{name}_{namespace}` | read-only | Dynamic view tools synced hourly. Returns table rows by default with select/page/limit controls. |
 
@@ -360,4 +361,12 @@ Search and find health checks returning JSON array with check metadata
 |------|------|----------|-------------|
 | `limit` | number |  | Number of items to return |
 | `query` | string | Yes | Search query. |
+
+### `whoami`
+
+Return the currently authenticated MCP subject, delegated owner, roles, and permissions.
+
+**Hints:** read-only
+
+**Parameters:** none
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -80,6 +80,7 @@ func RegisterStaticTools(s *server.MCPServer) {
 	registerTemplates(s)
 	registerAccess(s)
 	registerResolve(s)
+	registerWhoami(s)
 }
 
 func Server(ctx context.Context, serverOpts ...server.StreamableHTTPOption) *MCPServer {

--- a/mcp/whoami.go
+++ b/mcp/whoami.go
@@ -1,0 +1,141 @@
+package mcp
+
+import (
+	gocontext "context"
+
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/rbac"
+	"github.com/flanksource/duty/rbac/policy"
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const toolWhoami = "whoami"
+
+type whoamiPerson struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Email   string `json:"email,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Role    string `json:"role,omitempty"`
+	IsToken bool   `json:"is_token,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+type whoamiResponse struct {
+	Subject            string        `json:"subject"`
+	Authenticated      *whoamiPerson `json:"authenticated,omitempty"`
+	Owner              *whoamiPerson `json:"owner,omitempty"`
+	Delegated          bool          `json:"delegated"`
+	SubjectRoles       []string      `json:"subject_roles,omitempty"`
+	SubjectPermissions []string      `json:"subject_permissions,omitempty"`
+	OwnerRoles         []string      `json:"owner_roles,omitempty"`
+	OwnerPermissions   []string      `json:"owner_permissions,omitempty"`
+	MCPUseAllowed      bool          `json:"mcp_use_allowed"`
+}
+
+func whoamiHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ctx, err := getDutyCtx(goctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	subject := ctx.Subject()
+	owner, err := resolveOwner(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	subjectRoles, err := rbac.RolesForUser(subject)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	subjectPermissions, err := rbac.PermsForUser(subject)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	ownerRoles, err := rbac.RolesForUser(owner)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	ownerPermissions, err := rbac.PermsForUser(owner)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	allowed, err := rbac.Enforcer().Enforce(owner, policy.ObjectMCP, policy.ActionMCPUse)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	resp := whoamiResponse{
+		Subject:            subject,
+		Authenticated:      personForSubject(ctx, subject),
+		Owner:              personForSubject(ctx, owner),
+		Delegated:          owner != "" && subject != owner,
+		SubjectRoles:       subjectRoles,
+		SubjectPermissions: permissionStrings(subjectPermissions),
+		OwnerRoles:         ownerRoles,
+		OwnerPermissions:   permissionStrings(ownerPermissions),
+		MCPUseAllowed:      allowed,
+	}
+
+	return structToMCPResponse(req, resp), nil
+}
+
+func personForSubject(ctx context.Context, subject string) *whoamiPerson {
+	if subject == "" {
+		return nil
+	}
+
+	if user := ctx.User(); user != nil && user.ID.String() == subject {
+		return personToWhoami(user, subject)
+	}
+
+	id, err := uuid.Parse(subject)
+	if err != nil {
+		return &whoamiPerson{Subject: subject}
+	}
+
+	var person models.Person
+	if err := ctx.DB().Where("id = ?", id).First(&person).Error; err != nil {
+		return &whoamiPerson{Subject: subject}
+	}
+
+	return personToWhoami(&person, subject)
+}
+
+func personToWhoami(person *models.Person, subject string) *whoamiPerson {
+	if person == nil {
+		return nil
+	}
+
+	return &whoamiPerson{
+		ID:      person.ID.String(),
+		Name:    person.Name,
+		Email:   person.Email,
+		Type:    person.Type,
+		Role:    person.Properties.Role,
+		IsToken: person.Type == "access_token",
+		Subject: subject,
+	}
+}
+
+func permissionStrings(permissions []policy.Permission) []string {
+	items := make([]string, 0, len(permissions))
+	for _, p := range permissions {
+		items = append(items, p.String())
+	}
+	return items
+}
+
+func registerWhoami(s *server.MCPServer) {
+	s.AddTool(mcp.NewTool(toolWhoami,
+		mcp.WithDescription("Return the currently authenticated MCP subject, delegated owner, roles, and permissions."),
+		mcp.WithReadOnlyHintAnnotation(true)), whoamiHandler)
+}


### PR DESCRIPTION
Adds a read-only MCP `whoami` tool so clients can inspect the current authenticated subject.

The tool returns the authenticated user/token, delegated owner, delegation status, roles, permissions, and MCP access status. This helps MCP clients/debugging flows verify identity without relying on prompt injection.