### PR TITLE
fix(deps): bump shell-quote to 1.8.4 to address CVE-2026-9277

### DIFF
--- a/ui/frontend/pnpm-lock.yaml
+++ b/ui/frontend/pnpm-lock.yaml
@@ -1989,8 +1989,8 @@ packages:
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -3033,7 +3033,7 @@ snapshots:
       pretty-ms: 9.3.0
       radix-vue: 1.9.17(vue@3.5.33(typescript@5.9.3))
       set-cookie-parser: 3.1.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       vite-plugin-monaco-editor: 1.1.0(monaco-editor@0.55.1)
       vue: 3.5.33(typescript@5.9.3)
       vue-router: 5.0.4(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@5.9.3))
@@ -4772,7 +4772,7 @@ snapshots:
 
   set-cookie-parser@3.1.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
shell-quote 1.8.3's quote() function fails to escape newlines in object .op values, allowing shell command injection when the output is passed to a shell (CVE-2026-9277, CVSS 8.1).

Upgrade from 1.8.3 to 1.8.4, which replaces per-character escaping with strict allowlist validation of .op values.