### PR TITLE
chore: install faro via go install instead of cp /usr/local/bin

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -300,7 +300,7 @@ tasks:
     cmds:
       - mkdir -p {{.BIN_DIR}}
       - >-
-        go build -o {{.FARO_BINARY}} -ldflags "-X \"main.version={{.VERSION_TAG}} built at {{.BUILD_DATE}}\"" ./faro
+        go build -o {{.FARO_BINARY}} -ldflags "-X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
     sources:
       - "**/*.go"
       - "{{.TAILWIND_JS}}"
@@ -315,7 +315,8 @@ tasks:
   faro:install:
     desc: Build and install the faro client to the default go bin (go env GOBIN)
     cmds:
-      - go install ./faro
+      - >-
+        go install -ldflags "-X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
 
   faro:run:
     desc: Build and run faro (pass args after --, e.g. `task faro:run -- whoami`)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -313,11 +313,9 @@ tasks:
       - "{{.FARO_BINARY}}"
 
   faro:install:
-    desc: Build and install the faro client to /usr/local/bin
-    deps:
-      - faro:build
+    desc: Build and install the faro client to the default go bin (go env GOBIN)
     cmds:
-      - cp {{.FARO_BINARY}} /usr/local/bin/faro
+      - go install ./faro
 
   faro:run:
     desc: Build and run faro (pass args after --, e.g. `task faro:run -- whoami`)


### PR DESCRIPTION
/usr/local/bin requires sudo. Use go install ./faro to install to the default go bin instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Faro install task to install the Go package directly with `go install`.
  * The installation now uses the standard Go binary location instead of manually copying a built executable.
  * Simplified the install flow by removing the extra build dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->