### PR TITLE
docs(faro): add config_type and config_id examples to catalog insights search help

### DIFF
--- a/faro/catalog_help.go
+++ b/faro/catalog_help.go
@@ -135,12 +135,14 @@ IDs, then "get" to fetch the full insight record.`
 		searchCmd.Short = "Search catalog insights using the query language"
 		searchCmd.Long = `Search catalog insights using the catalog query language.
 
-Use this to find findings by severity, status, analyzer, source, catalog resource
-type, name, tags, or other indexed fields. The result rows include insight IDs
-that can be passed to "faro catalog insights get".`
+Use this to find findings by severity, status, analyzer, source, config_id,
+catalog resource type, name, tags, or other indexed fields. The result rows
+include insight IDs that can be passed to "faro catalog insights get".`
 		searchCmd.Example = `  faro catalog insights search 'severity=critical'
   faro catalog insights search 'status=open type=security'
-  faro catalog insights search 'analyzer=no-public-ip source=aws' --limit 50`
+  faro catalog insights search 'analyzer=no-public-ip source=aws' --limit 50
+  faro catalog insights search 'config_type=GitHub::Repository severity=critical' --limit 5
+  faro catalog insights search 'config_id=203c4012-d12b-5c6a-a1e7-2e990f6a8f0e'`
 	}
 
 	if getCmd := catalogSubcommand(insightsCmd, "get"); getCmd != nil {

--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -43,7 +43,9 @@ var CatalogInsightSearch = &cobra.Command{
 Examples:
   catalog insights search severity=critical
   catalog insights search "status=open type=security"
-  catalog insights search "analyzer=no-public-ip source=aws" --limit 50`,
+  catalog insights search "analyzer=no-public-ip source=aws" --limit 50
+  catalog insights search "config_type=GitHub::Repository severity=critical" --limit 5
+  catalog insights search "config_id=203c4012-d12b-5c6a-a1e7-2e990f6a8f0e"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		results, err := remoteSearchInsights(strings.Join(args, " "), insightSearchAgent, insightSearchLimit)


### PR DESCRIPTION
The `catalog insights search` help text was missing examples for filtering by `config_type` and `config_id`. Added:

- `faro catalog insights search 'config_type=GitHub::Repository severity=critical' --limit 5`
- `faro catalog insights search 'config_id=203c4012-d12b-5c6a-a1e7-2e990f6a8f0e'`

Also listed `config_id` as a searchable field in the Long description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `catalog insights search` help text to list `config_id` as a searchable field.
  * Added more example searches, including filters for `config_type`, `severity`, `analyzer`, `source`, and `config_id`.
  * Improved example formatting for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->