### PR TITLE
fix(playbook): align scheduled runs with shared pipeline

### DIFF
--- a/api/v1/playbook_types.go
+++ b/api/v1/playbook_types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flanksource/kopper"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -380,6 +381,19 @@ func (p PlaybookSpec) Validate() error {
 			return err
 		}
 	}
+
+	if p.On != nil && len(p.On.Schedule) > 0 {
+		if p.Approval != nil && !p.Approval.Approvers.Empty() {
+			return fmt.Errorf("scheduled playbooks cannot require approval")
+		}
+
+		for i, schedule := range p.On.Schedule {
+			if _, err := cron.ParseStandard(schedule.Schedule); err != nil {
+				return fmt.Errorf("invalid schedule[%d] %q: %w", i, schedule.Schedule, err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -94,14 +94,12 @@ func CreateOrSaveFromFile(ctx context.Context, file string) (*models.Playbook, e
 
 type playbookRunOptions struct {
 	CheckPermissions bool
-	AllowApproval    bool
 }
 
 // Run creates and saves a run from a run request after validating the run parameters.
 func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models.PlaybookRun, error) {
 	run, err := createPlaybookRun(ctx, playbook, req, playbookRunOptions{
 		CheckPermissions: true,
-		AllowApproval:    true,
 	})
 	if err != nil {
 		return nil, err
@@ -148,7 +146,7 @@ func createPlaybookRun(ctx context.Context, playbook *models.Playbook, req RunPa
 		run.CreatedBy = &ctx.User().ID
 	}
 
-	if opts.AllowApproval && spec.Approval != nil && !spec.Approval.Approvers.Empty() {
+	if spec.Approval != nil && !spec.Approval.Approvers.Empty() {
 		run.Status = models.PlaybookRunStatusPendingApproval
 	}
 

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -99,9 +99,6 @@ type playbookRunOptions struct {
 
 // Run creates and saves a run from a run request after validating the run parameters.
 func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models.PlaybookRun, error) {
-	ctx = ctx.WithObject(playbook, req).WithLoggingValues("req", req)
-	ctx.Infof("running \n%v\n", logger.Pretty(req))
-
 	run, err := createPlaybookRun(ctx, playbook, req, playbookRunOptions{
 		CheckPermissions: true,
 		AllowApproval:    true,
@@ -130,6 +127,9 @@ func createPlaybookRun(ctx context.Context, playbook *models.Playbook, req RunPa
 	if err := req.Params.Sanitize(ctx, spec.Parameters); err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to sanitize parameters")
 	}
+
+	ctx = ctx.WithObject(playbook, req).WithLoggingValues("req", req)
+	ctx.Infof("running \n%v\n", logger.Pretty(req))
 
 	run := models.PlaybookRun{
 		PlaybookID:         playbook.ID,

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -92,19 +92,44 @@ func CreateOrSaveFromFile(ctx context.Context, file string) (*models.Playbook, e
 	return db.SavePlaybook(ctx, &spec)
 }
 
-// validateAndSavePlaybookRun creates and saves a run from a run request after validating the run parameters.
+type playbookRunOptions struct {
+	CheckPermissions bool
+	AllowApproval    bool
+}
+
+// Run creates and saves a run from a run request after validating the run parameters.
 func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models.PlaybookRun, error) {
+	ctx = ctx.WithObject(playbook, req).WithLoggingValues("req", req)
+	ctx.Infof("running \n%v\n", logger.Pretty(req))
+
+	run, err := createPlaybookRun(ctx, playbook, req, playbookRunOptions{
+		CheckPermissions: true,
+		AllowApproval:    true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := saveRunAsConfigChange(ctx, playbook, *run, req.Params); err != nil {
+		ctx.Logger.Errorf("failed to save playbook run as config change: %v", err)
+	}
+
+	return run, nil
+}
+
+func createPlaybookRun(ctx context.Context, playbook *models.Playbook, req RunParams, opts playbookRunOptions) (*models.PlaybookRun, error) {
 	var spec v1.PlaybookSpec
 	if err := json.Unmarshal(playbook.Spec, &spec); err != nil {
 		return nil, err
 	}
 
+	if err := spec.Validate(); err != nil {
+		return nil, ctx.Oops().Wrapf(err, "invalid playbook spec")
+	}
+
 	if err := req.Params.Sanitize(ctx, spec.Parameters); err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to sanitize parameters")
 	}
-
-	ctx = ctx.WithObject(playbook, req).WithLoggingValues("req", req)
-	ctx.Infof("running \n%v\n", logger.Pretty(req))
 
 	run := models.PlaybookRun{
 		PlaybookID:         playbook.ID,
@@ -123,7 +148,7 @@ func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models
 		run.CreatedBy = &ctx.User().ID
 	}
 
-	if spec.Approval != nil && !spec.Approval.Approvers.Empty() {
+	if opts.AllowApproval && spec.Approval != nil && !spec.Approval.Approvers.Empty() {
 		run.Status = models.PlaybookRunStatusPendingApproval
 	}
 
@@ -168,21 +193,23 @@ func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models
 		return nil, ctx.Oops().Wrap(err)
 	}
 
-	// Must have read access on the resource (required to prevent guests from accessing unauthorized resources)
-	if !rbac.HasPermission(ctx, ctx.Subject(), templateEnv.ABACAttributes(), policy.ActionRead) {
-		return nil, ctx.Oops().
-			Code(dutyAPI.EFORBIDDEN).
-			With("permission", policy.ActionRead, "objects", templateEnv.ABACAttributes()).
-			Wrap(fmt.Errorf("access denied: read access to resource not allowed for subject: %s", ctx.Subject()))
-	}
+	if opts.CheckPermissions {
+		// Must have read access on the resource (required to prevent guests from accessing unauthorized resources)
+		if !rbac.HasPermission(ctx, ctx.Subject(), templateEnv.ABACAttributes(), policy.ActionRead) {
+			return nil, ctx.Oops().
+				Code(dutyAPI.EFORBIDDEN).
+				With("permission", policy.ActionRead, "objects", templateEnv.ABACAttributes()).
+				Wrap(fmt.Errorf("access denied: read access to resource not allowed for subject: %s", ctx.Subject()))
+		}
 
-	if attr, err := run.GetABACAttributes(ctx.DB()); err != nil {
-		return nil, ctx.Oops().Wrap(err)
-	} else if !rbac.HasPermission(ctx, ctx.Subject(), attr, policy.ActionPlaybookRun) {
-		return nil, ctx.Oops().
-			Code(dutyAPI.EFORBIDDEN).
-			With("permission", policy.ActionPlaybookRun, "objects", attr).
-			Wrap(fmt.Errorf("access denied to subject(%s): cannot run playbook on this resource", ctx.Subject()))
+		if attr, err := run.GetABACAttributes(ctx.DB()); err != nil {
+			return nil, ctx.Oops().Wrap(err)
+		} else if !rbac.HasPermission(ctx, ctx.Subject(), attr, policy.ActionPlaybookRun) {
+			return nil, ctx.Oops().
+				Code(dutyAPI.EFORBIDDEN).
+				With("permission", policy.ActionPlaybookRun, "objects", attr).
+				Wrap(fmt.Errorf("access denied to subject(%s): cannot run playbook on this resource", ctx.Subject()))
+		}
 	}
 
 	// Rest of the playbook must run using the playbook's permission.
@@ -253,10 +280,6 @@ func Run(ctx context.Context, playbook *models.Playbook, req RunParams) (*models
 
 	if err := savePlaybookRun(ctx, &run); err != nil {
 		return nil, ctx.Oops().Wrapf(err, "failed to create playbook run")
-	}
-
-	if err := saveRunAsConfigChange(ctx, playbook, run, req.Params); err != nil {
-		ctx.Logger.Errorf("failed to save playbook run as config change: %v", err)
 	}
 
 	return &run, nil

--- a/playbook/schedule.go
+++ b/playbook/schedule.go
@@ -8,12 +8,12 @@ import (
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/job"
 	"github.com/flanksource/duty/models"
-	dutyTypes "github.com/flanksource/duty/types"
 	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 
+	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/flanksource/incident-commander/vars"
+	"github.com/flanksource/incident-commander/playbook/runner"
 )
 
 type scheduleKey struct {
@@ -128,18 +128,59 @@ func triggerScheduledRun(ctx context.Context, playbookID uuid.UUID, params map[s
 	var pb models.Playbook
 	if err := ctx.DB().Where("id = ? AND deleted_at IS NULL", playbookID).First(&pb).Error; err != nil {
 		ctx.Errorf("failed to load playbook %s for scheduled run: %v", playbookID, err)
+		logToJobHistory(ctx, playbookID.String(), err.Error())
 		return
 	}
 
-	run := models.PlaybookRun{
-		PlaybookID: pb.ID,
-		Status:     models.PlaybookRunStatusScheduled,
-		Spec:       pb.Spec,
-		Parameters: dutyTypes.JSONStringMap(params),
-		Timeout:    ctx.Properties().Duration("playbook.run.timeout", vars.PlaybookRunTimeout),
+	ctx = ctx.WithNamespace(pb.Namespace)
+	if api.SystemUserID != nil {
+		ctx = ctx.WithUser(&models.Person{ID: *api.SystemUserID})
 	}
 
-	if err := ctx.DB().Create(&run).Error; err != nil {
-		ctx.Errorf("failed to create scheduled run for playbook %s: %v", playbookID, err)
+	templatedParams, err := templateScheduledRunParams(ctx, &pb, params)
+	if err != nil {
+		ctx.Errorf("failed to template scheduled run parameters for playbook %s: %v", playbookID, err)
+		logToJobHistory(ctx, playbookID.String(), err.Error())
+		return
 	}
+
+	req := RunParams{
+		ID:     pb.ID,
+		Params: templatedParams,
+	}
+	if _, err := createPlaybookRun(ctx.WithObject(&pb, req), &pb, req, playbookRunOptions{}); err != nil {
+		ctx.Errorf("failed to create scheduled run for playbook %s: %v", playbookID, err)
+		logToJobHistory(ctx, playbookID.String(), err.Error())
+	}
+}
+
+func templateScheduledRunParams(ctx context.Context, playbook *models.Playbook, params map[string]string) (PlaybookRuntimeParameters, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+
+	run := models.PlaybookRun{
+		PlaybookID: playbook.ID,
+		Spec:       playbook.Spec,
+	}
+	if ctx.User() != nil {
+		run.CreatedBy = &ctx.User().ID
+	}
+
+	templateEnv, err := runner.CreateTemplateEnv(ctx, playbook, run, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	output := make(PlaybookRuntimeParameters, len(params))
+	for k, v := range params {
+		value, err := runner.TemplateEnv(ctx, templateEnv, v)
+		if err != nil {
+			return nil, err
+		}
+
+		output[k] = value
+	}
+
+	return output, nil
 }

--- a/playbook/schedule.go
+++ b/playbook/schedule.go
@@ -3,6 +3,7 @@ package playbook
 import (
 	gocontext "context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/flanksource/duty/context"
@@ -90,14 +91,15 @@ func syncPlaybookSchedules(ctx context.Context, scheduler *cron.Cron) error {
 			}
 
 			playbookID := pb.ID
-			params := sched.Parameters
+			scheduleIndex := i
+			schedule := sched.Schedule
 			cronID, err := scheduler.AddFunc(sched.Schedule, func() {
 				// Create a fresh context for each cron execution rather than
 				// capturing the sync job's context, which may be cancelled.
 				cronCtx := context.NewContext(gocontext.Background()).
 					WithDB(ctx.DB(), ctx.Pool()).
 					WithNamespace(ctx.GetNamespace())
-				triggerScheduledRun(cronCtx, playbookID, params)
+				triggerScheduledRun(cronCtx, playbookID, scheduleIndex, schedule)
 			})
 			if err != nil {
 				ctx.Errorf("failed to register cron for playbook %s schedule[%d]: %v", pb.ID, i, err)
@@ -121,7 +123,7 @@ func syncPlaybookSchedules(ctx context.Context, scheduler *cron.Cron) error {
 	return nil
 }
 
-func triggerScheduledRun(ctx context.Context, playbookID uuid.UUID, params map[string]string) {
+func triggerScheduledRun(ctx context.Context, playbookID uuid.UUID, scheduleIndex int, schedule string) {
 	ctx = ctx.WithName("triggerScheduledRun").
 		WithLoggingValues("playbook_id", playbookID.String(), "trigger", "schedule")
 
@@ -135,6 +137,13 @@ func triggerScheduledRun(ctx context.Context, playbookID uuid.UUID, params map[s
 	ctx = ctx.WithNamespace(pb.Namespace)
 	if api.SystemUserID != nil {
 		ctx = ctx.WithUser(&models.Person{ID: *api.SystemUserID})
+	}
+
+	params, err := getScheduledRunParams(&pb, scheduleIndex, schedule)
+	if err != nil {
+		ctx.Errorf("failed to load scheduled run parameters for playbook %s: %v", playbookID, err)
+		logToJobHistory(ctx, playbookID.String(), err.Error())
+		return
 	}
 
 	templatedParams, err := templateScheduledRunParams(ctx, &pb, params)
@@ -152,6 +161,24 @@ func triggerScheduledRun(ctx context.Context, playbookID uuid.UUID, params map[s
 		ctx.Errorf("failed to create scheduled run for playbook %s: %v", playbookID, err)
 		logToJobHistory(ctx, playbookID.String(), err.Error())
 	}
+}
+
+func getScheduledRunParams(playbook *models.Playbook, scheduleIndex int, schedule string) (map[string]string, error) {
+	var spec v1.PlaybookSpec
+	if err := json.Unmarshal(playbook.Spec, &spec); err != nil {
+		return nil, err
+	}
+
+	if spec.On == nil || scheduleIndex < 0 || scheduleIndex >= len(spec.On.Schedule) {
+		return nil, fmt.Errorf("schedule[%d] no longer exists", scheduleIndex)
+	}
+
+	current := spec.On.Schedule[scheduleIndex]
+	if current.Schedule != schedule {
+		return nil, fmt.Errorf("schedule[%d] changed from %q to %q", scheduleIndex, schedule, current.Schedule)
+	}
+
+	return current.Parameters, nil
 }
 
 func templateScheduledRunParams(ctx context.Context, playbook *models.Playbook, params map[string]string) (PlaybookRuntimeParameters, error) {

--- a/playbook/schedule_test.go
+++ b/playbook/schedule_test.go
@@ -1,0 +1,159 @@
+package playbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+)
+
+var _ = ginkgo.Describe("scheduled playbook runs", func() {
+	ginkgo.It("applies defaults and spec timeout through the shared run pipeline", func() {
+		playbook := saveScheduledPlaybookForTest("scheduled-defaults", v1.PlaybookSpec{
+			Timeout: "2m",
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+				},
+			},
+			Parameters: []v1.PlaybookParameter{
+				{Name: "message", Required: true, Default: "{{.playbook.name}}"},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo {{.params.message}}"}},
+			},
+		})
+
+		agent := saveScheduledRunAgentForTest()
+		req := RunParams{
+			ID:      playbook.ID,
+			AgentID: &agent.ID,
+		}
+		run, err := createPlaybookRun(DefaultContext.WithObject(&playbook, req), &playbook, req, playbookRunOptions{})
+		Expect(err).To(Succeed())
+
+		Expect(run.Parameters["message"]).To(Equal(playbook.Name))
+		Expect(run.Timeout).To(Equal(2 * time.Minute))
+	})
+
+	ginkgo.It("templates explicit schedule parameters before validation", func() {
+		playbook := saveScheduledPlaybookForTest("scheduled-templated-params", v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{
+						Schedule: "@every 1h",
+						Parameters: map[string]string{
+							"message": "{{.playbook.name}}",
+						},
+					},
+				},
+			},
+			Parameters: []v1.PlaybookParameter{
+				{Name: "message", Required: true},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo {{.params.message}}"}},
+			},
+		})
+
+		templatedParams, err := templateScheduledRunParams(DefaultContext, &playbook, map[string]string{
+			"message": "{{.playbook.name}}",
+		})
+		Expect(err).To(Succeed())
+
+		agent := saveScheduledRunAgentForTest()
+		req := RunParams{
+			ID:      playbook.ID,
+			AgentID: &agent.ID,
+			Params:  templatedParams,
+		}
+		run, err := createPlaybookRun(DefaultContext.WithObject(&playbook, req), &playbook, req, playbookRunOptions{})
+		Expect(err).To(Succeed())
+		Expect(run.Parameters["message"]).To(Equal(playbook.Name))
+	})
+
+	ginkgo.It("records missing required parameter failures in job history", func() {
+		playbook := saveScheduledPlaybookForTest("scheduled-missing-param", v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+				},
+			},
+			Parameters: []v1.PlaybookParameter{
+				{Name: "message", Required: true},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo {{.params.message}}"}},
+			},
+		})
+
+		triggerScheduledRun(DefaultContext, playbook.ID, nil)
+
+		var runCount int64
+		Expect(DefaultContext.DB().Model(&models.PlaybookRun{}).Where("playbook_id = ?", playbook.ID).Count(&runCount).Error).To(Succeed())
+		Expect(runCount).To(BeZero())
+
+		expectScheduledRunJobHistory(playbook.ID, "missing required parameter")
+	})
+
+	ginkgo.It("records unknown parameter failures in job history", func() {
+		playbook := saveScheduledPlaybookForTest("scheduled-unknown-param", v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		})
+
+		triggerScheduledRun(DefaultContext, playbook.ID, map[string]string{"unexpected": "value"})
+
+		var runCount int64
+		Expect(DefaultContext.DB().Model(&models.PlaybookRun{}).Where("playbook_id = ?", playbook.ID).Count(&runCount).Error).To(Succeed())
+		Expect(runCount).To(BeZero())
+
+		expectScheduledRunJobHistory(playbook.ID, "unknown parameter")
+	})
+})
+
+func saveScheduledPlaybookForTest(name string, spec v1.PlaybookSpec) models.Playbook {
+	Expect(spec.Validate()).To(Succeed())
+
+	specJSON, err := json.Marshal(spec)
+	Expect(err).To(Succeed())
+
+	playbook := models.Playbook{
+		ID:        uuid.New(),
+		Namespace: "default",
+		Name:      fmt.Sprintf("%s-%s", name, uuid.NewString()),
+		Spec:      specJSON,
+		Source:    models.SourceConfigFile,
+	}
+	Expect(DefaultContext.DB().Create(&playbook).Error).To(Succeed())
+
+	return playbook
+}
+
+func expectScheduledRunJobHistory(playbookID uuid.UUID, expectedError string) {
+	var history models.JobHistory
+	Expect(DefaultContext.DB().
+		Where("name = ? AND resource_type = ? AND resource_id = ?", "SavePlaybookRun", "playbook", playbookID.String()).
+		First(&history).Error).To(Succeed())
+	Expect(history.Status).To(Equal(models.StatusFailed))
+	Expect(history.ErrorCount).To(BeNumerically(">", 0))
+	Expect(history.Details["errors"]).To(ContainElement(ContainSubstring(expectedError)))
+}
+
+func saveScheduledRunAgentForTest() models.Agent {
+	agent := models.Agent{Name: fmt.Sprintf("scheduled-run-test-%s", uuid.NewString())}
+	Expect(agent.Save(DefaultContext.DB())).To(Succeed())
+	return agent
+}

--- a/playbook/schedule_test.go
+++ b/playbook/schedule_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/tests/fixtures/dummy"
 	"github.com/google/uuid"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,6 +41,24 @@ var _ = ginkgo.Describe("scheduled playbook runs", func() {
 
 		Expect(run.Parameters["message"]).To(Equal(playbook.Name))
 		Expect(run.Timeout).To(Equal(2 * time.Minute))
+	})
+
+	ginkgo.It("keeps approval enforcement in the shared run pipeline", func() {
+		playbook := saveScheduledPlaybookForTest("approval-helper", v1.PlaybookSpec{
+			Approval: &v1.PlaybookApproval{
+				Approvers: v1.PlaybookApprovers{
+					People: []string{"approver@example.com"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		})
+
+		req := RunParams{ID: playbook.ID}
+		run, err := createPlaybookRun(DefaultContext.WithUser(&dummy.JohnDoe).WithObject(&playbook, req), &playbook, req, playbookRunOptions{})
+		Expect(err).To(Succeed())
+		Expect(run.Status).To(Equal(models.PlaybookRunStatusPendingApproval))
 	})
 
 	ginkgo.It("templates explicit schedule parameters before validation", func() {
@@ -78,6 +97,76 @@ var _ = ginkgo.Describe("scheduled playbook runs", func() {
 		Expect(run.Parameters["message"]).To(Equal(playbook.Name))
 	})
 
+	ginkgo.It("uses fresh schedule parameters when only parameters change", func() {
+		agent := saveScheduledRunAgentForTest()
+		spec := v1.PlaybookSpec{
+			RunsOn: []string{agent.ID.String()},
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{
+						Schedule: "@every 1h",
+						Parameters: map[string]string{
+							"message": "old",
+						},
+					},
+				},
+			},
+			Parameters: []v1.PlaybookParameter{
+				{Name: "message", Required: true},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo {{.params.message}}"}},
+			},
+		}
+		playbook := saveScheduledPlaybookForTest("scheduled-updated-params", spec)
+
+		spec.On.Schedule[0].Parameters["message"] = "updated {{.playbook.name}}"
+		specJSON, err := json.Marshal(spec)
+		Expect(err).To(Succeed())
+		Expect(DefaultContext.DB().Model(&models.Playbook{}).Where("id = ?", playbook.ID).Update("spec", specJSON).Error).To(Succeed())
+
+		triggerScheduledRun(DefaultContext, playbook.ID, 0, "@every 1h")
+
+		var run models.PlaybookRun
+		Expect(DefaultContext.DB().Where("playbook_id = ?", playbook.ID).First(&run).Error).To(Succeed())
+		Expect(run.Parameters["message"]).To(Equal(fmt.Sprintf("updated %s", playbook.Name)))
+	})
+
+	ginkgo.It("does not run stale scheduled triggers after schedule removal", func() {
+		playbook := saveScheduledPlaybookForTest("scheduled-removed-before-trigger", v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		})
+
+		updatedSpec := v1.PlaybookSpec{
+			Approval: &v1.PlaybookApproval{
+				Approvers: v1.PlaybookApprovers{
+					People: []string{"approver@example.com"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		}
+		Expect(updatedSpec.Validate()).To(Succeed())
+		specJSON, err := json.Marshal(updatedSpec)
+		Expect(err).To(Succeed())
+		Expect(DefaultContext.DB().Model(&models.Playbook{}).Where("id = ?", playbook.ID).Update("spec", specJSON).Error).To(Succeed())
+
+		triggerScheduledRun(DefaultContext, playbook.ID, 0, "@every 1h")
+
+		var runCount int64
+		Expect(DefaultContext.DB().Model(&models.PlaybookRun{}).Where("playbook_id = ?", playbook.ID).Count(&runCount).Error).To(Succeed())
+		Expect(runCount).To(BeZero())
+		expectScheduledRunJobHistory(playbook.ID, "schedule[0] no longer exists")
+	})
+
 	ginkgo.It("records missing required parameter failures in job history", func() {
 		playbook := saveScheduledPlaybookForTest("scheduled-missing-param", v1.PlaybookSpec{
 			On: &v1.PlaybookTrigger{
@@ -93,7 +182,7 @@ var _ = ginkgo.Describe("scheduled playbook runs", func() {
 			},
 		})
 
-		triggerScheduledRun(DefaultContext, playbook.ID, nil)
+		triggerScheduledRun(DefaultContext, playbook.ID, 0, "@every 1h")
 
 		var runCount int64
 		Expect(DefaultContext.DB().Model(&models.PlaybookRun{}).Where("playbook_id = ?", playbook.ID).Count(&runCount).Error).To(Succeed())
@@ -106,7 +195,12 @@ var _ = ginkgo.Describe("scheduled playbook runs", func() {
 		playbook := saveScheduledPlaybookForTest("scheduled-unknown-param", v1.PlaybookSpec{
 			On: &v1.PlaybookTrigger{
 				Schedule: []v1.PlaybookTriggerSchedule{
-					{Schedule: "@every 1h"},
+					{
+						Schedule: "@every 1h",
+						Parameters: map[string]string{
+							"unexpected": "value",
+						},
+					},
 				},
 			},
 			Actions: []v1.PlaybookAction{
@@ -114,7 +208,7 @@ var _ = ginkgo.Describe("scheduled playbook runs", func() {
 			},
 		})
 
-		triggerScheduledRun(DefaultContext, playbook.ID, map[string]string{"unexpected": "value"})
+		triggerScheduledRun(DefaultContext, playbook.ID, 0, "@every 1h")
 
 		var runCount int64
 		Expect(DefaultContext.DB().Model(&models.PlaybookRun{}).Where("playbook_id = ?", playbook.ID).Count(&runCount).Error).To(Succeed())

--- a/playbook/validation_test.go
+++ b/playbook/validation_test.go
@@ -40,4 +40,59 @@ var _ = Describe("PlaybookSpec validation", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("at least one action"))
 	})
+
+	It("accepts valid schedules", func() {
+		spec := v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+					{Schedule: "CRON_TZ=UTC 0 9 * * MON"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		}
+
+		Expect(spec.Validate()).To(Succeed())
+	})
+
+	It("rejects invalid schedules", func() {
+		spec := v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "not a cron"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+		}
+
+		err := spec.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid schedule[0]"))
+	})
+
+	It("rejects schedules with approval", func() {
+		spec := v1.PlaybookSpec{
+			On: &v1.PlaybookTrigger{
+				Schedule: []v1.PlaybookTriggerSchedule{
+					{Schedule: "@every 1h"},
+				},
+			},
+			Actions: []v1.PlaybookAction{
+				{Name: "echo", Exec: &v1.ExecAction{Script: "echo hi"}},
+			},
+			Approval: &v1.PlaybookApproval{
+				Approvers: v1.PlaybookApprovers{
+					People: []string{"john@doe.com"},
+				},
+			},
+		}
+
+		err := spec.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("scheduled playbooks cannot require approval"))
+	})
 })


### PR DESCRIPTION
Scheduled playbook runs were created directly from the scheduler path, bypassing the normal run preparation used by manual/webhook runs.

This meant scheduled runs skipped parameter defaulting/validation, timeout parsing, spec validation, and failure visibility in job history.

Route scheduled runs through a shared internal run creation helper, template schedule parameters before validation, and record scheduler run creation failures in job history. Also reject invalid schedule specs and schedule+approval configs up front.

Resolves #3305
Resolves #3306
Resolves #3307
Resolves #3308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for cron-based schedules, including detection of invalid expressions.
  * Scheduled playbooks now support templated parameters and updated parameter values at execution time.
  * Scheduled executions verify that the configured schedule remains current before running.

* **Bug Fixes**
  * Prevented scheduled playbooks requiring approval from being accepted.
  * Improved failure reporting by recording unsuccessful scheduled jobs in job history.
  * Applied configured defaults and timeouts consistently to scheduled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->