### PR TITLE
fix(llm): use constrained OpenAI model definitions

### DIFF
--- a/llm/llm.go
+++ b/llm/llm.go
@@ -94,6 +94,9 @@ func PromptWithHistory(ctx dutyctx.Context, config Config, history []*genkitai.M
 	}
 	if schema != nil {
 		opts = append(opts, genkitai.WithOutputSchema(schema))
+		if config.Backend == api.LLMBackendOpenAI && config.ResponseFormat == ResponseFormatCustomSchema {
+			opts = append(opts, genkitai.WithCustomConstrainedOutput())
+		}
 	}
 	if len(config.SkillPaths) > 0 {
 		opts = append(opts, genkitai.WithUse(&middleware.Skills{SkillPaths: config.SkillPaths}))
@@ -129,16 +132,18 @@ func initGenkit(config Config) (g *genkit.Genkit, modelName string, err error) {
 
 	var provider string
 	var plugin genkitapi.Plugin
+	var openAIPlugin *openaiplugin.OpenAICompatible
 	var bedrockPlugin *bedrockplugin.Bedrock
 
 	switch config.Backend {
 	case api.LLMBackendOpenAI:
 		provider = "openai"
-		plugin = &openaiplugin.OpenAICompatible{
+		openAIPlugin = &openaiplugin.OpenAICompatible{
 			Provider: provider,
 			APIKey:   config.APIKey.ValueStatic,
 			BaseURL:  config.APIURL,
 		}
+		plugin = openAIPlugin
 
 	case api.LLMBackendOllama:
 		provider = "ollama"
@@ -183,6 +188,15 @@ func initGenkit(config Config) (g *genkit.Genkit, modelName string, err error) {
 	// Use context.Background() so the genkit lifecycle isn't tied to any request context.
 	g = genkit.Init(context.Background(), genkit.WithPlugins(plugin))
 
+	if openAIPlugin != nil {
+		// Genkit uses native output schema enforcement only when the model declares
+		// constrained output support; otherwise it falls back to prompt instructions
+		// and SDK-side validation. Gemini has constrained model definitions in the
+		// registry, but OpenAI does not, so define and register one here.
+		openAIModel := openAIPlugin.DefineModel(provider, unqualifiedModelName(modelName), constrainedOpenAIModelOptions(model))
+		genkit.RegisterAction(g, openAIModel)
+	}
+
 	// Bedrock requires explicit model registration via DefineModel after Init.
 	if bedrockPlugin != nil {
 		bedrockPlugin.DefineModel(g, bedrockplugin.ModelDefinition{
@@ -192,6 +206,22 @@ func initGenkit(config Config) (g *genkit.Genkit, modelName string, err error) {
 	}
 
 	return g, modelName, nil
+}
+
+func constrainedOpenAIModelOptions(model string) genkitai.ModelOptions {
+	return genkitai.ModelOptions{
+		Label:    fmt.Sprintf("OpenAI - %s", model),
+		Stage:    genkitai.ModelStageStable,
+		Versions: []string{},
+		Supports: &genkitai.ModelSupports{
+			Multiturn:   true,
+			Tools:       true,
+			ToolChoice:  true,
+			SystemRole:  true,
+			Media:       true,
+			Constrained: genkitai.ConstrainedSupportAll,
+		},
+	}
 }
 
 func newBedrockAWSConfig(cfg Config) (aws.Config, error) {

--- a/llm/model_test.go
+++ b/llm/model_test.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+	genkitai "github.com/firebase/genkit/go/ai"
+	genkitapi "github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/flanksource/incident-commander/api"
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("initGenkit", func() {
+	for _, model := range []string{"gpt-5.1", "openai/gpt-5.1"} {
+		ginkgo.It("defines OpenAI model "+model+" with native constrained output support", func() {
+			g, modelName, err := initGenkit(Config{
+				AIActionClient: v1.AIActionClient{
+					Backend: api.LLMBackendOpenAI,
+					Model:   model,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelName).To(Equal("openai/gpt-5.1"))
+
+			resolved := genkit.LookupModel(g, modelName)
+			Expect(resolved).ToNot(BeNil())
+
+			action, ok := resolved.(genkitapi.Action)
+			Expect(ok).To(BeTrue())
+
+			modelMetadata, ok := action.Desc().Metadata["model"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			supports, ok := modelMetadata["supports"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(supports).To(HaveKeyWithValue("constrained", genkitai.ConstrainedSupportAll))
+		})
+	}
+})


### PR DESCRIPTION
AI playbook recommendation runs failed with OpenAI `gpt-5.1` because Genkit dynamically resolved the model through generic OpenAI-compatible metadata without native constrained output support. That made schema output fall back to prompt instructions, so reusing history across different schemas could produce responses matching the wrong shape.

Define OpenAI models explicitly with constrained output support and register them with Genkit so `Generate` resolves the constrained metadata from the registry. Built-in diagnosis and playbook recommendation schemas now stay on the provider `response_format` path for OpenAI.

Google, Anthropic, Ollama, and Bedrock behavior is unchanged in this PR.