### PR TITLE
fix(auth): reject backslash open-redirect in sanitizeNext

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -111,12 +111,21 @@ func sanitizeNext(raw string) string {
 	if raw == "" {
 		return "/ui"
 	}
-	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+
+	// The redirect target must be a rooted, host-relative path. A leading-slash
+	// check alone is not enough: browsers interpret both "//host" and "/\host"
+	// as protocol-relative absolute URLs, so the character after the leading
+	// slash must not be another slash or a backslash.
+	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, `/\`) {
 		return "/ui"
 	}
-	if _, err := url.Parse(raw); err != nil {
+
+	// Defense in depth: reject anything that parses as an absolute URL or
+	// carries a host component.
+	if u, err := url.Parse(raw); err != nil || u.IsAbs() || u.Host != "" {
 		return "/ui"
 	}
+
 	return raw
 }
 

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -90,3 +90,28 @@ var _ = ginkgo.Describe("extractBasicLoginCredentials", func() {
 		})
 	}
 })
+
+var _ = ginkgo.Describe("sanitizeNext", func() {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty falls back to /ui", input: "", expected: "/ui"},
+		{name: "simple relative path", input: "/ui/topology", expected: "/ui/topology"},
+		{name: "relative path with query", input: "/ui/topology?id=1", expected: "/ui/topology?id=1"},
+		{name: "protocol-relative // is rejected", input: "//evil.com", expected: "/ui"},
+		{name: "backslash-relative /\\ is rejected", input: `/\evil.com`, expected: "/ui"},
+		{name: "backslash-relative /\\/ is rejected", input: `/\/evil.com`, expected: "/ui"},
+		{name: "absolute http URL is rejected", input: "http://evil.com", expected: "/ui"},
+		{name: "absolute https URL is rejected", input: "https://evil.com", expected: "/ui"},
+		{name: "scheme-only target is rejected", input: "javascript:alert(1)", expected: "/ui"},
+		{name: "path not starting with slash is rejected", input: "evil.com", expected: "/ui"},
+	}
+
+	for _, tt := range tests {
+		ginkgo.It(tt.name, func() {
+			Expect(sanitizeNext(tt.input)).To(Equal(tt.expected))
+		})
+	}
+})


### PR DESCRIPTION
## Summary

Fixes CodeQL code scanning alert [#124](https://github.com/flanksource/mission-control/security/code-scanning/124) — **`go/bad-redirect-check` (CWE-601, Open Redirect)** at `auth/basic.go:114`.

`sanitizeNext` validates the `next` redirect target used after basic-auth login. It required a leading `/` and rejected `//host`, but **did not reject `/\host`**. Browsers interpret both `//` and `/\` immediately after a leading slash as protocol-relative absolute URLs, so a value like `/\evil.com` passed the check and flowed into `c.Redirect(...)` in `BasicLogin`, allowing an attacker-controlled off-site redirect.

## Changes

- `auth/basic.go`: reject `/\` after the leading slash in addition to `//`, and add a defense-in-depth `url.Parse` check that rejects any value that is an absolute URL or carries a host component. Rejected inputs fall back to the safe default `/ui`, unchanged.
- `auth/basic_test.go`: add `sanitizeNext` unit tests covering the redirect vectors (`//host`, `/\host`, `/\/host`, absolute `http`/`https` URLs, scheme-only, and non-rooted paths) plus valid relative paths.

## Testing

- `go vet ./auth/` passes.
- New table-driven Ginkgo tests assert every rejected vector falls back to `/ui` and legitimate relative paths pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjs2UAxC4PvvKC45zSeEo8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect validation to block unsafe or malformed destinations.
  * Unsafe, empty, or invalid redirect targets now safely fall back to the application interface.

* **Tests**
  * Added coverage for protocol-relative URLs, backslash-based paths, absolute URLs, unsupported schemes, and invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->