### PR TITLE
feat: faro --full mode and more columns in default --pretty mode

### DIFF
--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -94,7 +94,25 @@ func catalogItemsFromSearch(ctx context.Context, client *sdk.Client, items []que
 		for i, item := range items {
 			ids[i] = item.ID
 		}
-		return client.GetCatalogItems(ctx, ids)
+		fullItems, err := client.GetCatalogItems(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+
+		fullItemsByID := make(map[string]models.ConfigItem, len(fullItems))
+		for _, item := range fullItems {
+			fullItemsByID[item.ID.String()] = item
+		}
+
+		out := make([]models.ConfigItem, 0, len(items))
+		for _, item := range items {
+			if fullItem, ok := fullItemsByID[item.ID]; ok {
+				out = append(out, fullItem)
+			} else {
+				out = append(out, selectedResourceToConfigItem(item))
+			}
+		}
+		return out, nil
 	}
 
 	out := make([]models.ConfigItem, 0, len(items))

--- a/faro/catalog.go
+++ b/faro/catalog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/incident-commander/clientcmd"
+	"github.com/flanksource/incident-commander/sdk"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ type catalogListOpts struct {
 	Tag       []string `flag:"tag" help:"Filter by tag as a label selector (repeatable: --tag cluster=foo)"`
 	Agent     string   `flag:"agent" help:"Filter by agent id or name ('all' for every agent)" default:"all"`
 	Limit     int      `flag:"limit" help:"Maximum number of results" default:"100"`
+	Full      bool     `flag:"full" help:"Return complete catalog items"`
 }
 
 // catalogGetFlags binds the `catalog get` flags.
@@ -47,8 +49,8 @@ func joinTagSelectors(tags []string) string {
 	return strings.Join(parts, ",")
 }
 
-// remoteList backs `catalog list`, searching the remote server and mapping the
-// lightweight search hits to models.ConfigItem for clicky rendering.
+// remoteList backs `catalog list`, returning lightweight search hits by default
+// and hydrating complete items only when requested.
 func remoteList(opts catalogListOpts) ([]models.ConfigItem, error) {
 	client, err := clientcmd.RemoteClient()
 	if err != nil {
@@ -83,9 +85,21 @@ func remoteList(opts catalogListOpts) ([]models.ConfigItem, error) {
 		return nil, err
 	}
 
-	out := make([]models.ConfigItem, 0, len(resp.Configs))
-	for _, s := range resp.Configs {
-		out = append(out, selectedResourceToConfigItem(s))
+	return catalogItemsFromSearch(context.Background(), client, resp.Configs, opts.Full)
+}
+
+func catalogItemsFromSearch(ctx context.Context, client *sdk.Client, items []query.SelectedResource, full bool) ([]models.ConfigItem, error) {
+	if full {
+		ids := make([]string, len(items))
+		for i, item := range items {
+			ids[i] = item.ID
+		}
+		return client.GetCatalogItems(ctx, ids)
+	}
+
+	out := make([]models.ConfigItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, selectedResourceToConfigItem(item))
 	}
 	return out, nil
 }
@@ -132,7 +146,11 @@ func remoteGet(id string, flags map[string]string) (any, error) {
 	if flags["relationships"] == "true" {
 		return client.GetCatalogRelationships(context.Background(), id)
 	}
-	return client.GetCatalogItem(context.Background(), id)
+	item, err := client.GetCatalogItem(context.Background(), id)
+	if err != nil {
+		return nil, err
+	}
+	return &catalogItemDetail{ConfigItem: *item}, nil
 }
 
 func completeCatalogIDs(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/faro/catalog_help.go
+++ b/faro/catalog_help.go
@@ -31,7 +31,8 @@ This command returns lightweight catalog rows.
 
 Use --query for free-form text or a catalog query expression, --type for config
 types, --namespace for a namespace, --tag for tag label selectors, --agent to
-select an agent, and --limit to control result count.
+select an agent, and --limit to control result count. Use --full to fetch complete
+catalog items instead of lightweight search records.
 
 Use "faro catalog search <QUERY>" when the query expression is the main input
 and you do not need the other list filter flags.`
@@ -39,7 +40,8 @@ and you do not need the other list filter flags.`
   faro catalog list --type Kubernetes::Pod --namespace default
   faro catalog list --tag cluster=prod --tag env=dev --agent all --limit 50
   faro catalog list --query api
-  faro catalog list --type Kubernetes::Deployment`
+  faro catalog list --type Kubernetes::Deployment
+  faro catalog list --type Kubernetes::Deployment --full --json`
 	}
 
 	if getCmd := catalogSubcommand(catalogCmd, "get"); getCmd != nil {
@@ -65,11 +67,13 @@ or multiple clauses joined together.
 
 Queries are matched against resource name, type, tags, labels, health, status,
 and other indexed catalog fields. Multiple clauses are space-separated and ANDed
-together. Quote the query when it contains spaces or shell-special characters.`
+together. Quote the query when it contains spaces or shell-special characters.
+Use --full to fetch complete catalog items instead of lightweight search records.`
 		searchCmd.Example = `  faro catalog search 'type=Kubernetes::Pod'
   faro catalog search 'tags.cluster=prod type=Kubernetes::Pod api'
   faro catalog search 'health!=healthy agent=all' --limit 50
-  faro catalog search 'name=api*' --agent all --limit 50`
+  faro catalog search 'name=api*' --agent all --limit 50
+  faro catalog search 'name=api*' --full --json`
 	}
 
 	if changesCmd := catalogSubcommand(catalogCmd, "change"); changesCmd != nil {
@@ -126,9 +130,11 @@ func documentCatalogInsightsCommand(insightsCmd *cobra.Command) {
 
 Insights are findings or observations about catalog resources, such as security,
 compliance, reliability, or operational issues. Running this command without a
-subcommand searches open insights. Use "get" to fetch a full insight record.`
+subcommand searches open insights. Use --full to return complete insight records,
+or use "get" to fetch one complete insight by ID.`
 	insightsCmd.Example = `  faro catalog insights
   faro catalog insights 'severity=critical'
+  faro catalog insights --full --json
   faro catalog insights search 'status=open analyzer=no-public-ip' --limit 50
   faro catalog insights get <insight-id>`
 
@@ -138,12 +144,14 @@ subcommand searches open insights. Use "get" to fetch a full insight record.`
 
 Use this to find findings by severity, status, analyzer, source, config_id,
 catalog resource type, name, tags, or other indexed fields. The result rows
-include insight IDs that can be passed to "faro catalog insights get".`
+include insight IDs that can be passed to "faro catalog insights get". Use
+--full to return complete insight records instead of compact search results.`
 		searchCmd.Example = `  faro catalog insights search 'severity=critical'
   faro catalog insights search 'status=open type=security'
   faro catalog insights search 'analyzer=no-public-ip source=aws' --limit 50
   faro catalog insights search 'config_type=GitHub::Repository severity=critical' --limit 5
-  faro catalog insights search 'config_id=203c4012-d12b-5c6a-a1e7-2e990f6a8f0e'`
+  faro catalog insights search 'config_id=203c4012-d12b-5c6a-a1e7-2e990f6a8f0e'
+  faro catalog insights search 'severity=critical' --full --json`
 	}
 
 	if getCmd := catalogSubcommand(insightsCmd, "get"); getCmd != nil {

--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	insightSearchAgent string
+	insightSearchFull  bool
 	insightSearchLimit int
 )
 
@@ -44,6 +45,7 @@ type catalogInsightConfig struct {
 
 type catalogInsightSearchResult struct {
 	Items        []catalogInsightSearchHit
+	Details      []sdk.CatalogInsightDetail
 	Limited      bool
 	TotalAtLeast int
 }
@@ -55,6 +57,9 @@ type catalogInsightCompactRow struct {
 func (r catalogInsightCompactRow) Columns() []clickyapi.ColumnDef {
 	return []clickyapi.ColumnDef{
 		clickyapi.Column("ID").Build(),
+		clickyapi.Column("ConfigID").Label("Config ID").Build(),
+		clickyapi.Column("ConfigName").Label("Config Name").Build(),
+		clickyapi.Column("ConfigType").Label("Config Type").Build(),
 		clickyapi.Column("Name").Build(),
 		clickyapi.Column("Summary").Build(),
 		clickyapi.Column("InsightType").Label("Insight Type").Build(),
@@ -65,6 +70,13 @@ func (r catalogInsightCompactRow) Columns() []clickyapi.ColumnDef {
 }
 
 func (r catalogInsightCompactRow) Row() map[string]any {
+	var configID, configName, configType string
+	if r.Config != nil {
+		configID = r.Config.ID
+		configName = r.Config.Name
+		configType = r.Config.Type
+	}
+
 	severity := ""
 	if r.Severity != nil {
 		severity = *r.Severity
@@ -72,6 +84,9 @@ func (r catalogInsightCompactRow) Row() map[string]any {
 
 	return map[string]any{
 		"ID":           r.ID,
+		"ConfigID":     configID,
+		"ConfigName":   configName,
+		"ConfigType":   configType,
 		"Name":         r.Name,
 		"Summary":      r.Summary,
 		"InsightType":  r.InsightType,
@@ -156,11 +171,16 @@ func runCatalogInsightSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	printCatalogInsightLimitWarning(cmd, result)
-	clicky.MustPrint(catalogInsightSearchOutput(result.Items, clicky.Flags.FormatOptions), clicky.Flags.FormatOptions)
+	clicky.MustPrint(catalogInsightSearchOutput(result, insightSearchFull, clicky.Flags.FormatOptions), clicky.Flags.FormatOptions)
 	return nil
 }
 
-func catalogInsightSearchOutput(items []catalogInsightSearchHit, opts clicky.FormatOptions) any {
+func catalogInsightSearchOutput(result *catalogInsightSearchResult, full bool, opts clicky.FormatOptions) any {
+	if full {
+		return result.Details
+	}
+
+	items := result.Items
 	format := opts.ResolveFormat()
 	if format != "pretty" && format != "table" {
 		return items
@@ -249,6 +269,7 @@ func remoteSearchInsights(searchQuery, agent string, limit int) (*catalogInsight
 	}
 
 	out := make([]catalogInsightSearchHit, 0, len(resp.ConfigAnalysis))
+	orderedDetails := make([]sdk.CatalogInsightDetail, 0, len(resp.ConfigAnalysis))
 	for _, s := range resp.ConfigAnalysis {
 		hit := catalogInsightSearchHit{
 			ID:            s.ID,
@@ -262,6 +283,7 @@ func remoteSearchInsights(searchQuery, agent string, limit int) (*catalogInsight
 			LastObserved:  s.UpdatedAt,
 		}
 		if detail, ok := detailsByID[s.ID]; ok {
+			orderedDetails = append(orderedDetails, detail)
 			hit.Summary = detail.Summary
 			if detail.Config != nil {
 				hit.Config = &catalogInsightConfig{
@@ -274,7 +296,7 @@ func remoteSearchInsights(searchQuery, agent string, limit int) (*catalogInsight
 		}
 		out = append(out, hit)
 	}
-	return &catalogInsightSearchResult{Items: out, Limited: limited, TotalAtLeast: totalAtLeast}, nil
+	return &catalogInsightSearchResult{Items: out, Details: orderedDetails, Limited: limited, TotalAtLeast: totalAtLeast}, nil
 }
 
 func catalogInsightIssueIDs(detail sdk.CatalogInsightDetail) []string {
@@ -307,6 +329,8 @@ func remoteGetInsight(id string) (any, error) {
 func init() {
 	CatalogInsight.PersistentFlags().StringVar(&insightSearchAgent, "agent", "all", "Filter by agent id or name ('all' for every agent)")
 	CatalogInsight.PersistentFlags().IntVar(&insightSearchLimit, "limit", 100, "Maximum number of results")
+	CatalogInsight.Flags().BoolVar(&insightSearchFull, "full", false, "Return full insight records")
+	CatalogInsightSearch.Flags().BoolVar(&insightSearchFull, "full", false, "Return full insight records")
 	CatalogInsight.AddCommand(CatalogInsightSearch, CatalogInsightGet)
 	clicky.RegisterSubCommand("catalog", CatalogInsight)
 }

--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -50,11 +50,7 @@ type catalogInsightSearchResult struct {
 	TotalAtLeast int
 }
 
-type catalogInsightCompactRow struct {
-	catalogInsightSearchHit
-}
-
-func (r catalogInsightCompactRow) Columns() []clickyapi.ColumnDef {
+func (r catalogInsightSearchHit) Columns() []clickyapi.ColumnDef {
 	return []clickyapi.ColumnDef{
 		clickyapi.Column("ID").Build(),
 		clickyapi.Column("ConfigID").Label("Config ID").Build(),
@@ -69,7 +65,7 @@ func (r catalogInsightCompactRow) Columns() []clickyapi.ColumnDef {
 	}
 }
 
-func (r catalogInsightCompactRow) Row() map[string]any {
+func (r catalogInsightSearchHit) Row() map[string]any {
 	var configID, configName, configType string
 	if r.Config != nil {
 		configID = r.Config.ID
@@ -93,52 +89,6 @@ func (r catalogInsightCompactRow) Row() map[string]any {
 		"Status":       r.Status,
 		"Severity":     severity,
 		"LastObserved": r.LastObserved,
-	}
-}
-
-func (r catalogInsightSearchHit) Columns() []clickyapi.ColumnDef {
-	return []clickyapi.ColumnDef{
-		clickyapi.Column("ID").Build(),
-		clickyapi.Column("ConfigID").Label("Config ID").Build(),
-		clickyapi.Column("ConfigName").Label("Config Name").Build(),
-		clickyapi.Column("ConfigType").Label("Config Type").Build(),
-		clickyapi.Column("Summary").Build(),
-		clickyapi.Column("IssueIDs").Label("Issue IDs").Build(),
-		clickyapi.Column("Analyzer").Build(),
-		clickyapi.Column("InsightType").Label("Insight Type").Build(),
-		clickyapi.Column("Status").Build(),
-		clickyapi.Column("Severity").Build(),
-		clickyapi.Column("FirstObserved").Label("First Observed").Build(),
-		clickyapi.Column("LastObserved").Label("Last Observed").Build(),
-	}
-}
-
-func (r catalogInsightSearchHit) Row() map[string]any {
-	var configID, configName, configType string
-	if r.Config != nil {
-		configID = r.Config.ID
-		configName = r.Config.Name
-		configType = r.Config.Type
-	}
-
-	severity := ""
-	if r.Severity != nil {
-		severity = *r.Severity
-	}
-
-	return map[string]any{
-		"ID":            r.ID,
-		"ConfigID":      configID,
-		"ConfigName":    configName,
-		"ConfigType":    configType,
-		"Summary":       r.Summary,
-		"IssueIDs":      strings.Join(r.IssueIDs, ", "),
-		"Analyzer":      r.Name,
-		"InsightType":   r.InsightType,
-		"Status":        r.Status,
-		"Severity":      severity,
-		"FirstObserved": r.FirstObserved,
-		"LastObserved":  r.LastObserved,
 	}
 }
 
@@ -171,26 +121,15 @@ func runCatalogInsightSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	printCatalogInsightLimitWarning(cmd, result)
-	clicky.MustPrint(catalogInsightSearchOutput(result, insightSearchFull, clicky.Flags.FormatOptions), clicky.Flags.FormatOptions)
+	clicky.MustPrint(catalogInsightSearchOutput(result, insightSearchFull), clicky.Flags.FormatOptions)
 	return nil
 }
 
-func catalogInsightSearchOutput(result *catalogInsightSearchResult, full bool, opts clicky.FormatOptions) any {
+func catalogInsightSearchOutput(result *catalogInsightSearchResult, full bool) any {
 	if full {
 		return result.Details
 	}
-
-	items := result.Items
-	format := opts.ResolveFormat()
-	if format != "pretty" && format != "table" {
-		return items
-	}
-
-	rows := make([]catalogInsightCompactRow, len(items))
-	for i, item := range items {
-		rows[i] = catalogInsightCompactRow{catalogInsightSearchHit: item}
-	}
-	return rows
+	return result.Items
 }
 
 func catalogInsightSearchQuery(args []string) string {

--- a/faro/catalog_insight.go
+++ b/faro/catalog_insight.go
@@ -101,8 +101,9 @@ var CatalogInsight = &cobra.Command{
 }
 
 var CatalogInsightSearch = &cobra.Command{
-	Use:   "search [QUERY]",
-	Short: "Search catalog insights using the PEG search grammar",
+	Use:     "search [QUERY]",
+	Aliases: []string{"list"},
+	Short:   "Search catalog insights using the PEG search grammar",
 	Long: `Search catalog insights using the PEG search grammar used by the web UI.
 
 Examples:

--- a/faro/catalog_insight_test.go
+++ b/faro/catalog_insight_test.go
@@ -185,10 +185,15 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		Expect(insight.Config.ConfigClass).To(Equal("EC2"))
 	})
 
-	ginkgo.It("registers full only on insight search entry points", func() {
+	ginkgo.It("registers full on insight search entry points and resolves list as an alias", func() {
 		Expect(CatalogInsight.Flags().Lookup("full")).ToNot(BeNil())
 		Expect(CatalogInsightSearch.Flags().Lookup("full")).ToNot(BeNil())
 		Expect(CatalogInsightGet.Flags().Lookup("full")).To(BeNil())
-		Expect(catalogSubcommand(CatalogInsight, "list")).To(BeNil())
+
+		command, args, err := CatalogInsight.Find([]string{"list", "severity=critical"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(command).To(BeIdenticalTo(CatalogInsightSearch))
+		Expect(args).To(Equal([]string{"severity=critical"}))
+		Expect(catalogInsightSearchQuery(nil)).To(Equal("status=open"))
 	})
 })

--- a/faro/catalog_insight_test.go
+++ b/faro/catalog_insight_test.go
@@ -61,9 +61,9 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		Expect(result.Details[0].Message).To(Equal("instance has public ip"))
 		Expect(result.Details[0].Analysis).To(HaveKeyWithValue("rule", "R1"))
 
-		compact := catalogInsightSearchOutput(result, false, clicky.FormatOptions{JSON: true})
+		compact := catalogInsightSearchOutput(result, false)
 		Expect(compact).To(BeAssignableToTypeOf([]catalogInsightSearchHit{}))
-		full := catalogInsightSearchOutput(result, true, clicky.FormatOptions{JSON: true})
+		full := catalogInsightSearchOutput(result, true)
 		Expect(full).To(BeAssignableToTypeOf([]sdk.CatalogInsightDetail{}))
 		compactJSON, err := json.Marshal(compact)
 		Expect(err).ToNot(HaveOccurred())
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 			ContainSubstring(`"properties":[{"name":"port"`),
 		))
 
-		row := catalogInsightCompactRow{catalogInsightSearchHit: result.Items[0]}
+		row := result.Items[0]
 		Expect(row.Columns()).To(HaveLen(10))
 		Expect(row.Row()).To(And(
 			HaveKeyWithValue("ConfigID", "21e7586d-31fb-453c-a205-d73dc6b58eaa"),
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 			HaveKey("Severity"),
 			HaveKey("LastObserved"),
 		))
-		rendered, err := clicky.Format([]catalogInsightCompactRow{row}, clicky.FormatOptions{Pretty: true, NoColor: true})
+		rendered, err := clicky.Format([]catalogInsightSearchHit{row}, clicky.FormatOptions{Pretty: true, NoColor: true})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rendered).To(And(
 			ContainSubstring("Config ID"),
@@ -98,6 +98,54 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 			ContainSubstring("prod-instance"),
 		))
 	})
+
+	formats := []struct {
+		name string
+		opts clicky.FormatOptions
+	}{
+		{name: "pretty", opts: clicky.FormatOptions{Pretty: true, NoColor: true}},
+		{name: "CSV", opts: clicky.FormatOptions{CSV: true}},
+		{name: "Markdown", opts: clicky.FormatOptions{Markdown: true}},
+		{name: "HTML", opts: clicky.FormatOptions{HTML: true}},
+	}
+	for _, format := range formats {
+		ginkgo.It("uses the same insight columns for "+format.name, func() {
+			severity := "high"
+			firstObserved := time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)
+			lastObserved := time.Date(2031, 1, 1, 0, 0, 0, 0, time.UTC)
+			hit := catalogInsightSearchHit{
+				ID:            "id",
+				Name:          "name",
+				Summary:       "summary",
+				InsightType:   "kind",
+				Status:        "open",
+				Severity:      &severity,
+				IssueIDs:      []string{"hidden-issue"},
+				FirstObserved: &firstObserved,
+				LastObserved:  &lastObserved,
+				Config: &catalogInsightConfig{
+					ID:   "cid",
+					Name: "cfg",
+					Type: "type",
+				},
+			}
+
+			columns := hit.Columns()
+			labels := make([]string, len(columns))
+			for i, column := range columns {
+				labels[i] = column.DisplayLabel()
+			}
+			Expect(labels).To(Equal([]string{"Id", "Config ID", "Config Name", "Config Type", "Name", "Summary", "Insight Type", "Status", "Severity", "Last Observed"}))
+
+			rendered, err := clicky.Format([]catalogInsightSearchHit{hit}, format.opts)
+			Expect(err).ToNot(HaveOccurred())
+			for _, value := range []string{"cid", "cfg", "type", "name", "summary", "kind", "open", "high", "2031"} {
+				Expect(rendered).To(ContainSubstring(value))
+			}
+			Expect(rendered).ToNot(ContainSubstring("hidden-issue"))
+			Expect(rendered).ToNot(ContainSubstring("1999"))
+		})
+	}
 
 	ginkgo.It("defaults insight search empty limit to 100", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/faro/catalog_insight_test.go
+++ b/faro/catalog_insight_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/flanksource/clicky"
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/incident-commander/sdk"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -36,7 +37,7 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 
 				_, _ = w.Write([]byte(`{"config_analysis":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","name":"no-public-ip","type":"security","status":"open","severity":"high","created_at":"2026-06-24T16:41:38Z","updated_at":"2026-06-25T10:00:00Z"}]}`))
 			case "/db/config_analysis":
-				_, _ = w.Write([]byte(`[]`))
+				_, _ = w.Write([]byte(`[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","analyzer":"no-public-ip","message":"instance has public ip","summary":"public ip","status":"open","severity":"high","analysis_type":"security","analysis":{"rule":"R1"},"properties":[{"name":"port","value":443}],"config":{"id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","name":"prod-instance","type":"AWS::EC2::Instance"}}]`))
 			default:
 				ginkgo.Fail("unexpected request: " + r.URL.Path)
 			}
@@ -56,6 +57,46 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		Expect(*result.Items[0].FirstObserved).To(Equal(time.Date(2026, 6, 24, 16, 41, 38, 0, time.UTC)))
 		Expect(result.Items[0].LastObserved).ToNot(BeNil())
 		Expect(*result.Items[0].LastObserved).To(Equal(time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)))
+		Expect(result.Details).To(HaveLen(1))
+		Expect(result.Details[0].Message).To(Equal("instance has public ip"))
+		Expect(result.Details[0].Analysis).To(HaveKeyWithValue("rule", "R1"))
+
+		compact := catalogInsightSearchOutput(result, false, clicky.FormatOptions{JSON: true})
+		Expect(compact).To(BeAssignableToTypeOf([]catalogInsightSearchHit{}))
+		full := catalogInsightSearchOutput(result, true, clicky.FormatOptions{JSON: true})
+		Expect(full).To(BeAssignableToTypeOf([]sdk.CatalogInsightDetail{}))
+		compactJSON, err := json.Marshal(compact)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(compactJSON)).ToNot(ContainSubstring(`"message"`))
+		fullJSON, err := json.Marshal(full)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(fullJSON)).To(And(
+			ContainSubstring(`"message":"instance has public ip"`),
+			ContainSubstring(`"analysis":{"rule":"R1"}`),
+			ContainSubstring(`"properties":[{"name":"port"`),
+		))
+
+		row := catalogInsightCompactRow{catalogInsightSearchHit: result.Items[0]}
+		Expect(row.Columns()).To(HaveLen(10))
+		Expect(row.Row()).To(And(
+			HaveKeyWithValue("ConfigID", "21e7586d-31fb-453c-a205-d73dc6b58eaa"),
+			HaveKeyWithValue("ConfigName", "prod-instance"),
+			HaveKeyWithValue("ConfigType", "AWS::EC2::Instance"),
+			HaveKey("Name"),
+			HaveKey("Summary"),
+			HaveKey("InsightType"),
+			HaveKey("Status"),
+			HaveKey("Severity"),
+			HaveKey("LastObserved"),
+		))
+		rendered, err := clicky.Format([]catalogInsightCompactRow{row}, clicky.FormatOptions{Pretty: true, NoColor: true})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rendered).To(And(
+			ContainSubstring("Config ID"),
+			ContainSubstring("Config Name"),
+			ContainSubstring("Config Type"),
+			ContainSubstring("prod-instance"),
+		))
 	})
 
 	ginkgo.It("defaults insight search empty limit to 100", func() {
@@ -94,5 +135,12 @@ var _ = ginkgo.Describe("faro catalog insights", func() {
 		Expect(insight.Analyzer).To(Equal("no-public-ip"))
 		Expect(insight.Config).ToNot(BeNil())
 		Expect(insight.Config.ConfigClass).To(Equal("EC2"))
+	})
+
+	ginkgo.It("registers full only on insight search entry points", func() {
+		Expect(CatalogInsight.Flags().Lookup("full")).ToNot(BeNil())
+		Expect(CatalogInsightSearch.Flags().Lookup("full")).ToNot(BeNil())
+		Expect(CatalogInsightGet.Flags().Lookup("full")).To(BeNil())
+		Expect(catalogSubcommand(CatalogInsight, "list")).To(BeNil())
 	})
 })

--- a/faro/catalog_pretty.go
+++ b/faro/catalog_pretty.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/clicky/api"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/google/uuid"
+)
+
+// catalogItemDetail keeps the ConfigItem wire shape while expanding its human-readable view.
+type catalogItemDetail struct {
+	models.ConfigItem
+}
+
+func (r catalogItemDetail) Pretty() api.Text {
+	t := r.ConfigItem.Pretty().NewLine().Append(catalogItemDetails(r.ConfigItem))
+
+	if r.Properties != nil && len(*r.Properties) > 0 {
+		t = t.NewLine().AddText("Properties", "font-bold").NewLine().Append(catalogItemProperties(*r.Properties))
+	}
+
+	if r.Config != nil && *r.Config != "" {
+		t = t.NewLine().Append(clicky.Collapsed("Config", catalogConfigCodeBlock(*r.Config)))
+	}
+
+	return t
+}
+
+func catalogItemDetails(c models.ConfigItem) api.DescriptionList {
+	items := []api.KeyValuePair{
+		{Key: "ID", Value: c.ID.String()},
+		{Key: "Type", Value: stringValue(c.Type, "-")},
+		{Key: "Class", Value: c.ConfigClass},
+		{Key: "Ready", Value: strconv.FormatBool(c.Ready)},
+	}
+
+	if c.Health != nil {
+		items = append(items, api.KeyValuePair{Key: "Health", Value: c.Health.Pretty()})
+	}
+	if c.Status != nil {
+		items = append(items, api.KeyValuePair{Key: "Status", Value: *c.Status})
+	}
+	if c.Description != nil && *c.Description != "" {
+		items = append(items, api.KeyValuePair{Key: "Description", Value: *c.Description})
+	}
+	if c.Source != nil && *c.Source != "" {
+		items = append(items, api.KeyValuePair{Key: "Source", Value: *c.Source})
+	}
+	if c.ScraperID != nil && *c.ScraperID != "" {
+		items = append(items, api.KeyValuePair{Key: "Scraper", Value: *c.ScraperID})
+	}
+	if c.AgentID != uuid.Nil {
+		items = append(items, api.KeyValuePair{Key: "Agent", Value: c.AgentID.String()})
+	}
+	if c.Path != "" {
+		items = append(items, api.KeyValuePair{Key: "Path", Value: c.Path})
+	}
+	if c.ParentID != nil {
+		items = append(items, api.KeyValuePair{Key: "Parent", Value: c.ParentID.String()})
+	}
+	if len(c.ExternalID) > 0 {
+		items = append(items, api.KeyValuePair{Key: "External ID", Value: strings.Join(c.ExternalID, ", ")})
+	}
+	if c.CostPerMinute != 0 {
+		items = append(items, api.KeyValuePair{Key: "Cost per Minute", Value: fmt.Sprintf("$%.6f", c.CostPerMinute)})
+	}
+	if c.CostTotal1d != 0 {
+		items = append(items, api.KeyValuePair{Key: "Cost (1d)", Value: fmt.Sprintf("$%.2f", c.CostTotal1d)})
+	}
+	if c.CostTotal7d != 0 {
+		items = append(items, api.KeyValuePair{Key: "Cost (7d)", Value: fmt.Sprintf("$%.2f", c.CostTotal7d)})
+	}
+	if c.CostTotal30d != 0 {
+		items = append(items, api.KeyValuePair{Key: "Cost (30d)", Value: fmt.Sprintf("$%.2f", c.CostTotal30d)})
+	}
+	if !c.CreatedAt.IsZero() {
+		items = append(items, api.KeyValuePair{Key: "Created", Value: c.CreatedAt.Format(time.RFC3339)})
+	}
+	if !c.InsertedAt.IsZero() {
+		items = append(items, api.KeyValuePair{Key: "Inserted", Value: c.InsertedAt.Format(time.RFC3339)})
+	}
+	if c.UpdatedAt != nil {
+		items = append(items, api.KeyValuePair{Key: "Updated", Value: c.UpdatedAt.Format(time.RFC3339)})
+	}
+	if c.DeletedAt != nil {
+		items = append(items, api.KeyValuePair{Key: "Deleted", Value: c.DeletedAt.Format(time.RFC3339)})
+	}
+	if c.DeleteReason != "" {
+		items = append(items, api.KeyValuePair{Key: "Delete Reason", Value: c.DeleteReason})
+	}
+	if c.Labels != nil && len(*c.Labels) > 0 {
+		items = append(items, api.KeyValuePair{Key: "Labels", Value: clicky.Map(*c.Labels, "text-xs")})
+	}
+	if len(c.Tags) > 0 {
+		items = append(items, api.KeyValuePair{Key: "Tags", Value: clicky.Map(c.Tags, "text-xs")})
+	}
+
+	return api.DescriptionList{Items: items}
+}
+
+func catalogItemProperties(properties types.Properties) api.DescriptionList {
+	items := make([]api.KeyValuePair, 0, len(properties))
+	for i, property := range properties {
+		label := fmt.Sprintf("Property %d", i+1)
+		if property != nil {
+			if property.Label != "" {
+				label = property.Label
+			} else if property.Name != "" {
+				label = property.Name
+			}
+		}
+		items = append(items, api.KeyValuePair{Key: label, Value: catalogPropertyValue(property)})
+	}
+	return api.DescriptionList{Items: items}
+}
+
+func catalogPropertyValue(property *types.Property) string {
+	if property == nil {
+		return "-"
+	}
+
+	value := property.Text
+	if value == "" && property.Value != nil {
+		value = strconv.FormatInt(*property.Value, 10)
+		if property.Max != nil {
+			value += "/" + strconv.FormatInt(*property.Max, 10)
+		}
+	}
+	if value == "" && len(property.Links) > 0 {
+		value = property.Links[0].URL
+	}
+	if property.Unit != "" && value != "" {
+		value += " " + property.Unit
+	}
+	if property.Status != "" {
+		if value == "" {
+			value = property.Status
+		} else {
+			value += " (" + property.Status + ")"
+		}
+	}
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func catalogConfigCodeBlock(configJSON string) api.Code {
+	var parsed any
+	if err := json.Unmarshal([]byte(configJSON), &parsed); err == nil {
+		if pretty, err := json.MarshalIndent(parsed, "", "  "); err == nil {
+			configJSON = string(pretty)
+		}
+	}
+	return api.CodeBlock("json", configJSON)
+}
+
+func stringValue(value *string, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}

--- a/faro/catalog_pretty.go
+++ b/faro/catalog_pretty.go
@@ -16,7 +16,7 @@ import (
 
 // catalogItemDetail keeps the ConfigItem wire shape while expanding its human-readable view.
 type catalogItemDetail struct {
-	models.ConfigItem
+	models.ConfigItem `yaml:",inline"`
 }
 
 func (r catalogItemDetail) Pretty() api.Text {

--- a/faro/catalog_pretty_test.go
+++ b/faro/catalog_pretty_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/flanksource/clicky/formatters"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
 	"github.com/google/uuid"
@@ -80,7 +81,7 @@ var _ = ginkgo.Describe("faro catalog pretty output", func() {
 		}
 	})
 
-	ginkgo.It("preserves the ConfigItem JSON shape", func() {
+	ginkgo.It("preserves the ConfigItem JSON and YAML shapes", func() {
 		name := "api"
 		typ := "Kubernetes::Pod"
 		item := models.ConfigItem{ID: uuid.New(), Name: &name, Type: &typ, ConfigClass: "Pod"}
@@ -91,5 +92,14 @@ var _ = ginkgo.Describe("faro catalog pretty output", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(wrapped).To(MatchJSON(original))
+
+		yamlFormatter := formatters.NewYAMLFormatter()
+		originalYAML, err := yamlFormatter.FormatValue(item)
+		Expect(err).ToNot(HaveOccurred())
+		wrappedYAML, err := yamlFormatter.FormatValue(catalogItemDetail{ConfigItem: item})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(wrappedYAML).To(MatchYAML(originalYAML))
+		Expect(wrappedYAML).ToNot(ContainSubstring("configitem:"))
 	})
 })

--- a/faro/catalog_pretty_test.go
+++ b/faro/catalog_pretty_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("faro catalog pretty output", func() {
+	ginkgo.It("shows complete properties and additional config metadata", func() {
+		name := "api"
+		typ := "Kubernetes::Deployment"
+		status := "Running"
+		description := "production API"
+		source := "kubernetes"
+		scraper := "cluster-prod"
+		parentID := uuid.New()
+		updatedAt := time.Date(2026, 7, 20, 12, 30, 0, 0, time.UTC)
+		configJSON := `{"apiVersion":"apps/v1","spec":{"replicas":3}}`
+		zero := int64(0)
+		max := int64(10)
+		labels := types.JSONStringMap{"app": "api"}
+
+		item := models.ConfigItem{
+			ID:            uuid.New(),
+			ScraperID:     &scraper,
+			AgentID:       uuid.New(),
+			ConfigClass:   "Deployment",
+			ExternalID:    []string{"default/api"},
+			Type:          &typ,
+			Status:        &status,
+			Ready:         true,
+			Name:          &name,
+			Description:   &description,
+			Config:        &configJSON,
+			Source:        &source,
+			ParentID:      &parentID,
+			Path:          "cluster/default/api",
+			CostPerMinute: 0.00125,
+			CostTotal1d:   1.8,
+			CostTotal7d:   12.6,
+			CostTotal30d:  54,
+			Labels:        &labels,
+			Tags:          types.JSONStringMap{"environment": "production"},
+			Properties: &types.Properties{
+				{Label: "Namespace", Text: "default"},
+				{Name: "restart_count", Value: &zero, Max: &max, Unit: "restarts", Status: "stable"},
+				{Name: "documentation", Links: []types.Link{{URL: "https://example.com/api"}}},
+				{Name: "empty_property"},
+			},
+			CreatedAt:  time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC),
+			InsertedAt: time.Date(2026, 7, 1, 8, 1, 0, 0, time.UTC),
+			UpdatedAt:  &updatedAt,
+		}
+
+		output := (catalogItemDetail{ConfigItem: item}).Pretty().String()
+
+		for _, expected := range []string{
+			"production API",
+			"cluster-prod",
+			"cluster/default/api",
+			"default/api",
+			"Cost per Minute",
+			"2026-07-01T08:00:00Z",
+			"Properties",
+			"Namespace",
+			"default",
+			"restart_count",
+			"0/10 restarts (stable)",
+			"https://example.com/api",
+			"empty_property",
+			"replicas",
+		} {
+			Expect(output).To(ContainSubstring(expected))
+		}
+	})
+
+	ginkgo.It("preserves the ConfigItem JSON shape", func() {
+		name := "api"
+		typ := "Kubernetes::Pod"
+		item := models.ConfigItem{ID: uuid.New(), Name: &name, Type: &typ, ConfigClass: "Pod"}
+
+		original, err := json.Marshal(item)
+		Expect(err).ToNot(HaveOccurred())
+		wrapped, err := json.Marshal(catalogItemDetail{ConfigItem: item})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(wrapped).To(MatchJSON(original))
+	})
+})

--- a/faro/catalog_search.go
+++ b/faro/catalog_search.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	searchAgent string
+	searchFull  bool
 	searchLimit int
 )
 
@@ -35,7 +36,7 @@ Examples:
   catalog search "name=api*" --agent all --limit 50`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		results, err := remoteSearch(strings.Join(args, " "), searchAgent, searchLimit)
+		results, err := remoteSearch(strings.Join(args, " "), searchAgent, searchLimit, searchFull)
 		if err != nil {
 			return err
 		}
@@ -44,9 +45,9 @@ Examples:
 	},
 }
 
-// remoteSearch runs the grammar search against the remote server and maps the
-// lightweight search hits to models.ConfigItem so they render like `catalog list`.
-func remoteSearch(searchQuery, agent string, limit int) ([]models.ConfigItem, error) {
+// remoteSearch runs the grammar search against the remote server and mirrors
+// the compact or full result shape selected by `catalog list`.
+func remoteSearch(searchQuery, agent string, limit int, full bool) ([]models.ConfigItem, error) {
 	client, err := clientcmd.RemoteClient()
 	if err != nil {
 		return nil, err
@@ -68,15 +69,12 @@ func remoteSearch(searchQuery, agent string, limit int) ([]models.ConfigItem, er
 		return nil, err
 	}
 
-	out := make([]models.ConfigItem, 0, len(resp.Configs))
-	for _, s := range resp.Configs {
-		out = append(out, selectedResourceToConfigItem(s))
-	}
-	return out, nil
+	return catalogItemsFromSearch(context.Background(), client, resp.Configs, full)
 }
 
 func init() {
 	Search.Flags().StringVar(&searchAgent, "agent", "all", "Filter by agent id or name ('all' for every agent)")
+	Search.Flags().BoolVar(&searchFull, "full", false, "Return complete catalog items")
 	Search.Flags().IntVar(&searchLimit, "limit", 100, "Maximum number of results")
 	clicky.RegisterSubCommand("catalog", Search)
 }

--- a/faro/catalog_search_test.go
+++ b/faro/catalog_search_test.go
@@ -87,4 +87,31 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		Expect(items[0].Properties).ToNot(BeNil())
 		Expect(*items[0].Properties).To(HaveLen(1))
 	})
+
+	ginkgo.It("falls back to lightweight results when an item vanishes during hydration", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/resources/search":
+				_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"vanished","type":"Kubernetes::Pod"},{"id":"00000000-0000-0000-0000-000000000002","name":"api","type":"Kubernetes::Pod"}]}`))
+			case "/db/config_items":
+				_, _ = w.Write([]byte(`[{"id":"00000000-0000-0000-0000-000000000002","name":"api","type":"Kubernetes::Pod","config_class":"Pod","description":"full record"}]`))
+			default:
+				ginkgo.Fail("unexpected request: " + r.URL.Path)
+			}
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearch("type=Kubernetes::Pod", "all", 25, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(2))
+		Expect(items[0].ID.String()).To(Equal("00000000-0000-0000-0000-000000000001"))
+		Expect(*items[0].Name).To(Equal("vanished"))
+		Expect(items[0].Description).To(BeNil())
+		Expect(items[1].ID.String()).To(Equal("00000000-0000-0000-0000-000000000002"))
+		Expect(items[1].Description).ToNot(BeNil())
+		Expect(*items[1].Description).To(Equal("full record"))
+	})
 })

--- a/faro/catalog_search_test.go
+++ b/faro/catalog_search_test.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		defer server.Close()
 		storeRemoteContext(server.URL)
 
-		items, err := remoteSearch("tags.cluster=beta-cluster type=pod mission-control", "all", 25)
+		items, err := remoteSearch("tags.cluster=beta-cluster type=pod mission-control", "all", 25, false)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(items).To(HaveLen(1))
@@ -58,7 +58,33 @@ var _ = ginkgo.Describe("faro catalog search", func() {
 		defer server.Close()
 		storeRemoteContext(server.URL)
 
-		_, err := remoteSearch("type=Kubernetes::Pod", "all", 0)
+		_, err := remoteSearch("type=Kubernetes::Pod", "all", 0, false)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	ginkgo.It("hydrates complete catalog items when full is requested", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/resources/search":
+				_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
+			case "/db/config_items":
+				Expect(r.URL.Query().Get("id")).To(Equal("in.(00000000-0000-0000-0000-000000000001)"))
+				_, _ = w.Write([]byte(`[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","config_class":"Pod","description":"full record","config":{"kind":"Pod"},"properties":[{"name":"namespace","text":"production"}]}]`))
+			default:
+				ginkgo.Fail("unexpected request: " + r.URL.Path)
+			}
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearch("type=Kubernetes::Pod", "all", 25, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(items[0].Description).ToNot(BeNil())
+		Expect(*items[0].Description).To(Equal("full record"))
+		Expect(items[0].Properties).ToNot(BeNil())
+		Expect(*items[0].Properties).To(HaveLen(1))
 	})
 })

--- a/faro/catalog_test.go
+++ b/faro/catalog_test.go
@@ -41,6 +41,30 @@ var _ = ginkgo.Describe("faro catalog API paths", func() {
 		Expect(items).To(HaveLen(1))
 		Expect(*items[0].Name).To(Equal("api"))
 	})
+
+	ginkgo.It("hydrates complete catalog items for full list output", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/resources/search":
+				_, _ = w.Write([]byte(`{"configs":[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod"}]}`))
+			case "/db/config_items":
+				_, _ = w.Write([]byte(`[{"id":"00000000-0000-0000-0000-000000000001","name":"api","type":"Kubernetes::Pod","config_class":"Pod","source":"kubernetes","properties":[{"label":"Namespace","text":"production"}]}]`))
+			default:
+				ginkgo.Fail("unexpected request: " + r.URL.Path)
+			}
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteList(catalogListOpts{Limit: 5, Full: true})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(items[0].Source).ToNot(BeNil())
+		Expect(*items[0].Source).To(Equal("kubernetes"))
+		Expect(items[0].Properties).ToNot(BeNil())
+	})
 })
 
 func catalogSearchServer(expectedPath string) *httptest.Server {

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -76,9 +77,17 @@ type CatalogInsightIncident struct {
 	IncidentID string `json:"incident_id,omitempty"`
 }
 
+// catalogItemResponse bridges PostgREST's native JSONB config to ConfigItem's JSON string field.
+type catalogItemResponse struct {
+	models.ConfigItem
+	Config json.RawMessage `json:"config"`
+}
+
 const catalogChangeDetailSelect = "id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class),artifacts:artifacts(*)::jsonb"
 const catalogInsightDetailSelect = "id,config_id,scraper_id,analyzer,message,summary,status,severity,analysis_type,analysis,properties,source,first_observed,last_observed,is_pushed,config:configs(id,name,type,config_class)"
 const catalogInsightSearchDetailSelect = catalogInsightDetailSelect + ",evidences(hypothesis:hypotheses(incident:incidents(incident_id)))"
+const catalogItemBatchSize = 200
+const catalogItemBatchConcurrency = 4
 const catalogInsightBatchSize = 200
 const catalogInsightBatchConcurrency = 4
 
@@ -121,6 +130,91 @@ func (c *Client) GetCatalogItem(ctx context.Context, id string) (*models.ConfigI
 		return nil, err
 	}
 	return &out, nil
+}
+
+// GetCatalogItems fetches complete catalog items in bounded batches and preserves the requested order.
+func (c *Client) GetCatalogItems(ctx context.Context, ids []string) ([]models.ConfigItem, error) {
+	if len(ids) == 0 {
+		return []models.ConfigItem{}, nil
+	}
+
+	batchCount := (len(ids) + catalogItemBatchSize - 1) / catalogItemBatchSize
+	batches := make([][]models.ConfigItem, batchCount)
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(catalogItemBatchConcurrency)
+
+	for batchIndex := range batchCount {
+		start := batchIndex * catalogItemBatchSize
+		end := min(start+catalogItemBatchSize, len(ids))
+		group.Go(func() error {
+			batch, err := c.getCatalogItemsBatch(groupCtx, ids[start:end])
+			if err != nil {
+				return fmt.Errorf("catalog items batch %d: %w", batchIndex+1, err)
+			}
+			batches[batchIndex] = batch
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	itemsByID := make(map[string]models.ConfigItem, len(ids))
+	for _, batch := range batches {
+		for _, item := range batch {
+			itemsByID[item.ID.String()] = item
+		}
+	}
+
+	result := make([]models.ConfigItem, 0, len(ids))
+	for _, id := range ids {
+		item, ok := itemsByID[id]
+		if !ok {
+			return nil, fmt.Errorf("catalog item %s was not returned", id)
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func (c *Client) getCatalogItemsBatch(ctx context.Context, ids []string) ([]models.ConfigItem, error) {
+	r, err := c.R(ctx).
+		QueryParam("id", "in.("+strings.Join(ids, ",")+")").
+		QueryParam("select", "*").
+		Get(c.apiPath("/db/config_items"))
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		body, _ := r.AsString()
+		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
+			return nil, ErrHTMLResponse
+		}
+		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
+	}
+
+	var response []catalogItemResponse
+	if err := decodeJSON(r, &response); err != nil {
+		return nil, err
+	}
+
+	out := make([]models.ConfigItem, 0, len(response))
+	for _, raw := range response {
+		item := raw.ConfigItem
+		rawConfig := strings.TrimSpace(string(raw.Config))
+		if rawConfig != "" && rawConfig != "null" {
+			config := rawConfig
+			if rawConfig[0] == '"' {
+				if err := json.Unmarshal([]byte(rawConfig), &config); err != nil {
+					return nil, err
+				}
+			}
+			item.Config = &config
+		}
+		out = append(out, item)
+	}
+	return out, nil
 }
 
 // GetCatalogChange fetches full details for a catalog change from PostgREST.

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -86,9 +86,9 @@ type catalogItemResponse struct {
 const catalogChangeDetailSelect = "id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class),artifacts:artifacts(*)::jsonb"
 const catalogInsightDetailSelect = "id,config_id,scraper_id,analyzer,message,summary,status,severity,analysis_type,analysis,properties,source,first_observed,last_observed,is_pushed,config:configs(id,name,type,config_class)"
 const catalogInsightSearchDetailSelect = catalogInsightDetailSelect + ",evidences(hypothesis:hypotheses(incident:incidents(incident_id)))"
-const catalogItemBatchSize = 200
+const catalogItemBatchSize = 100
 const catalogItemBatchConcurrency = 4
-const catalogInsightBatchSize = 200
+const catalogInsightBatchSize = 100
 const catalogInsightBatchConcurrency = 4
 
 // SearchCatalog runs a resource search against the remote server
@@ -132,7 +132,8 @@ func (c *Client) GetCatalogItem(ctx context.Context, id string) (*models.ConfigI
 	return &out, nil
 }
 
-// GetCatalogItems fetches complete catalog items in bounded batches and preserves the requested order.
+// GetCatalogItems fetches available catalog items in bounded batches, preserves
+// requested order, and omits IDs that are no longer visible during hydration.
 func (c *Client) GetCatalogItems(ctx context.Context, ids []string) ([]models.ConfigItem, error) {
 	if len(ids) == 0 {
 		return []models.ConfigItem{}, nil
@@ -170,10 +171,9 @@ func (c *Client) GetCatalogItems(ctx context.Context, ids []string) ([]models.Co
 	result := make([]models.ConfigItem, 0, len(ids))
 	for _, id := range ids {
 		item, ok := itemsByID[id]
-		if !ok {
-			return nil, fmt.Errorf("catalog item %s was not returned", id)
+		if ok {
+			result = append(result, item)
 		}
-		result = append(result, item)
 	}
 	return result, nil
 }

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 
 	"github.com/flanksource/duty/query"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -44,6 +47,68 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(item.Name).ToNot(BeNil())
 		Expect(*item.Name).To(Equal("my-config"))
+	})
+
+	ginkgo.It("gets complete catalog items in bounded batches and preserves requested order", func() {
+		ids := make([]string, catalogItemBatchSize+1)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)
+		}
+
+		var requestCount atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/db/config_items"))
+			Expect(r.URL.Query().Get("select")).To(Equal("*"))
+
+			filter := strings.TrimSuffix(strings.TrimPrefix(r.URL.Query().Get("id"), "in.("), ")")
+			batchIDs := strings.Split(filter, ",")
+			response := make([]map[string]any, 0, len(batchIDs))
+			for i := len(batchIDs) - 1; i >= 0; i-- {
+				item := map[string]any{
+					"id":           batchIDs[i],
+					"name":         "config-" + batchIDs[i],
+					"type":         "Kubernetes::Pod",
+					"config_class": "Pod",
+				}
+				if batchIDs[i] == ids[0] {
+					item["description"] = "full record"
+					item["config"] = map[string]any{"kind": "Pod"}
+					item["properties"] = []map[string]any{{"name": "namespace", "text": "production"}}
+				}
+				response = append(response, item)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			Expect(json.NewEncoder(w).Encode(response)).To(Succeed())
+		}))
+		defer server.Close()
+
+		items, err := New(server.URL, "tok").GetCatalogItems(context.Background(), ids)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requestCount.Load()).To(Equal(int32(2)))
+		Expect(items).To(HaveLen(len(ids)))
+		for i := range ids {
+			Expect(items[i].ID.String()).To(Equal(ids[i]))
+		}
+		Expect(items[0].Description).ToNot(BeNil())
+		Expect(*items[0].Description).To(Equal("full record"))
+		Expect(items[0].Config).ToNot(BeNil())
+		Expect(*items[0].Config).To(MatchJSON(`{"kind":"Pod"}`))
+		Expect(items[0].Properties).ToNot(BeNil())
+	})
+
+	ginkgo.It("reports when a requested full catalog item is missing", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		}))
+		defer server.Close()
+
+		_, err := New(server.URL, "tok").GetCatalogItems(context.Background(), []string{"00000000-0000-0000-0000-000000000001"})
+
+		Expect(err).To(MatchError("catalog item 00000000-0000-0000-0000-000000000001 was not returned"))
 	})
 
 	ginkgo.It("gets full catalog change details from PostgREST", func() {

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("catalog client", func() {
 	})
 
 	ginkgo.It("gets complete catalog items in bounded batches and preserves requested order", func() {
-		ids := make([]string, catalogItemBatchSize+1)
+		ids := make([]string, 201)
 		for i := range ids {
 			ids[i] = fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)
 		}
@@ -64,6 +64,8 @@ var _ = ginkgo.Describe("catalog client", func() {
 
 			filter := strings.TrimSuffix(strings.TrimPrefix(r.URL.Query().Get("id"), "in.("), ")")
 			batchIDs := strings.Split(filter, ",")
+			Expect(len(batchIDs)).To(BeNumerically("<=", 100))
+			Expect(len(r.RequestURI)).To(BeNumerically("<", 8_000))
 			response := make([]map[string]any, 0, len(batchIDs))
 			for i := len(batchIDs) - 1; i >= 0; i-- {
 				item := map[string]any{
@@ -87,7 +89,7 @@ var _ = ginkgo.Describe("catalog client", func() {
 		items, err := New(server.URL, "tok").GetCatalogItems(context.Background(), ids)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(requestCount.Load()).To(Equal(int32(2)))
+		Expect(requestCount.Load()).To(Equal(int32(3)))
 		Expect(items).To(HaveLen(len(ids)))
 		for i := range ids {
 			Expect(items[i].ID.String()).To(Equal(ids[i]))
@@ -99,16 +101,44 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(items[0].Properties).ToNot(BeNil())
 	})
 
-	ginkgo.It("reports when a requested full catalog item is missing", func() {
+	ginkgo.It("omits a requested full catalog item that is no longer visible", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[]`))
 		}))
 		defer server.Close()
 
-		_, err := New(server.URL, "tok").GetCatalogItems(context.Background(), []string{"00000000-0000-0000-0000-000000000001"})
+		items, err := New(server.URL, "tok").GetCatalogItems(context.Background(), []string{"00000000-0000-0000-0000-000000000001"})
 
-		Expect(err).To(MatchError("catalog item 00000000-0000-0000-0000-000000000001 was not returned"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(BeEmpty())
+	})
+
+	ginkgo.It("keeps catalog insight hydration requests below common proxy limits", func() {
+		ids := make([]string, catalogInsightBatchSize+1)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)
+		}
+
+		var requestCount atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/db/config_analysis"))
+			Expect(r.URL.Query().Get("select")).To(Equal(catalogInsightSearchDetailSelect))
+			filter := strings.TrimSuffix(strings.TrimPrefix(r.URL.Query().Get("id"), "in.("), ")")
+			Expect(len(strings.Split(filter, ","))).To(BeNumerically("<=", 100))
+			Expect(len(r.RequestURI)).To(BeNumerically("<", 8_000))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		}))
+		defer server.Close()
+
+		insights, err := New(server.URL, "tok").GetCatalogInsights(context.Background(), ids)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(insights).To(BeEmpty())
+		Expect(requestCount.Load()).To(Equal(int32(2)))
 	})
 
 	ginkgo.It("gets full catalog change details from PostgREST", func() {


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--full` to catalog listing, catalog search, and insights search to return fully hydrated records.
  * Enhanced catalog item “pretty” output to include properties plus a collapsible config JSON section.
  * Improved insights table rows/columns with configuration metadata and full/compact output selection.
  * Expanded command help text and examples for `list`, `search`, and `insights`.
* **Bug Fixes**
  * Preserved requested catalog item ordering during full hydration.
  * Improved handling for missing/empty/quoted configuration data and missing hydrated items.
* **Documentation**
  * Updated Cobra help text and examples to reflect `--full` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->