### PR TITLE
feat: faro playbook apply, get, delete and history

### DIFF
--- a/api/v1/playbook_validation.go
+++ b/api/v1/playbook_validation.go
@@ -1,0 +1,26 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/flanksource/incident-commander/config/schemas"
+)
+
+// ParseAndValidatePlaybookSpec applies the generated schema and semantic validation to a raw playbook spec.
+func ParseAndValidatePlaybookSpec(data []byte) (*PlaybookSpec, error) {
+	if validationErr, err := schemas.ValidatePlaybookSpec(data); err != nil {
+		return nil, err
+	} else if validationErr != nil {
+		return nil, validationErr
+	}
+
+	var spec PlaybookSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("invalid playbook spec: %w", err)
+	}
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	return &spec, nil
+}

--- a/api/v1/playbook_validation_test.go
+++ b/api/v1/playbook_validation_test.go
@@ -1,0 +1,37 @@
+package v1
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("ParseAndValidatePlaybookSpec", func() {
+	ginkgo.It("accepts schema-valid playbooks", func() {
+		spec, err := ParseAndValidatePlaybookSpec([]byte(`{
+			"actions": [{"name": "echo", "exec": {"script": "echo ok"}}]
+		}`))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.Actions).To(HaveLen(1))
+	})
+
+	ginkgo.It("rejects properties outside the generated schema", func() {
+		_, err := ParseAndValidatePlaybookSpec([]byte(`{
+			"actions": [{"name": "echo", "exec": {"script": "echo ok"}}],
+			"unexpected": true
+		}`))
+
+		Expect(err).To(MatchError(ContainSubstring("Additional property unexpected is not allowed")))
+	})
+
+	ginkgo.It("applies semantic validation after schema validation", func() {
+		_, err := ParseAndValidatePlaybookSpec([]byte(`{
+			"actions": [
+				{"name": "echo", "exec": {"script": "echo one"}},
+				{"name": "echo", "exec": {"script": "echo two"}}
+			]
+		}`))
+
+		Expect(err).To(MatchError(ContainSubstring("all actions should have unique names")))
+	})
+})

--- a/clientcmd/playbook_apply.go
+++ b/clientcmd/playbook_apply.go
@@ -1,0 +1,117 @@
+package clientcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/sdk"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+var playbookApplyFile string
+
+var ApplyPlaybook = &cobra.Command{
+	Use:          "apply -f <playbook.yaml>",
+	Short:        "Create or update a playbook from a manifest",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		manifest, err := readPlaybookManifest(cmd, playbookApplyFile)
+		if err != nil {
+			return err
+		}
+		params, err := parsePlaybookManifest(manifest)
+		if err != nil {
+			return err
+		}
+
+		_, client, err := playbookAPIClient(cmd)
+		if err != nil {
+			return err
+		}
+		result, err := client.ApplyPlaybook(cmd.Context(), *params)
+		if err != nil {
+			return err
+		}
+		action := "configured"
+		if result.Created {
+			action = "created"
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "playbook %s/%s %s\n", params.Namespace, params.Name, action)
+		return err
+	},
+}
+
+type playbookManifest struct {
+	APIVersion string           `json:"apiVersion"`
+	Kind       string           `json:"kind"`
+	Metadata   playbookMetadata `json:"metadata"`
+	Spec       json.RawMessage  `json:"spec"`
+}
+
+type playbookMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func readPlaybookManifest(cmd *cobra.Command, filename string) ([]byte, error) {
+	if filename == "-" {
+		return io.ReadAll(cmd.InOrStdin())
+	}
+	return os.ReadFile(filename)
+}
+
+func parsePlaybookManifest(manifest []byte) (*sdk.PlaybookApplyParams, error) {
+	jsonManifest, err := yaml.YAMLToJSON(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("invalid playbook YAML: %w", err)
+	}
+
+	var playbook playbookManifest
+	if err := json.Unmarshal(jsonManifest, &playbook); err != nil {
+		return nil, fmt.Errorf("invalid playbook manifest: %w", err)
+	}
+	if playbook.Kind != "" && !strings.EqualFold(playbook.Kind, "Playbook") {
+		return nil, fmt.Errorf("manifest kind must be Playbook, got %q", playbook.Kind)
+	}
+	if strings.TrimSpace(playbook.Metadata.Name) == "" {
+		return nil, fmt.Errorf("playbook metadata.name is required")
+	}
+	if len(playbook.Spec) == 0 || string(playbook.Spec) == "null" {
+		return nil, fmt.Errorf("playbook spec is required")
+	}
+
+	spec, err := v1.ParseAndValidatePlaybookSpec(playbook.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("invalid playbook spec: %w", err)
+	}
+	namespace := playbook.Metadata.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	title := spec.Title
+	if title == "" {
+		title = playbook.Metadata.Name
+	}
+
+	return &sdk.PlaybookApplyParams{
+		Namespace:   namespace,
+		Name:        playbook.Metadata.Name,
+		Title:       title,
+		Icon:        spec.Icon,
+		Description: spec.Description,
+		Category:    spec.Category,
+		Spec:        playbook.Spec,
+	}, nil
+}
+
+func init() {
+	ApplyPlaybook.Flags().StringVarP(&playbookApplyFile, "file", "f", "", "Playbook manifest to apply; use - for stdin")
+	_ = ApplyPlaybook.MarkFlagRequired("file")
+	Playbook.AddCommand(ApplyPlaybook)
+}

--- a/clientcmd/playbook_apply_test.go
+++ b/clientcmd/playbook_apply_test.go
@@ -1,0 +1,78 @@
+package clientcmd
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("playbook apply manifest", func() {
+	ginkgo.It("converts a Playbook CRD into apply parameters", func() {
+		params, err := parsePlaybookManifest([]byte(`
+apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  name: restart
+  namespace: ops
+spec:
+  title: Restart workload
+  category: Kubernetes
+  description: Restarts a workload
+  actions:
+    - name: echo
+      exec:
+        script: echo ok
+`))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(params.Namespace).To(Equal("ops"))
+		Expect(params.Name).To(Equal("restart"))
+		Expect(params.Title).To(Equal("Restart workload"))
+		Expect(params.Category).To(Equal("Kubernetes"))
+		Expect(params.Description).To(Equal("Restarts a workload"))
+		Expect(params.Spec).To(MatchJSON(`{"title":"Restart workload","category":"Kubernetes","description":"Restarts a workload","actions":[{"name":"echo","exec":{"script":"echo ok"}}]}`))
+	})
+
+	ginkgo.It("defaults the namespace and title", func() {
+		params, err := parsePlaybookManifest([]byte(`
+kind: Playbook
+metadata:
+  name: diagnose
+spec:
+  actions:
+    - name: echo
+      exec:
+        script: echo ok
+`))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(params.Namespace).To(Equal("default"))
+		Expect(params.Title).To(Equal("diagnose"))
+	})
+
+	ginkgo.It("rejects schema-invalid manifests before making a request", func() {
+		_, err := parsePlaybookManifest([]byte(`
+kind: Playbook
+metadata:
+  name: invalid
+spec:
+  unexpected: true
+  actions:
+    - name: echo
+      exec:
+        script: echo ok
+`))
+
+		Expect(err).To(MatchError(ContainSubstring("Additional property unexpected is not allowed")))
+	})
+
+	ginkgo.It("rejects other manifest kinds", func() {
+		_, err := parsePlaybookManifest([]byte(`
+kind: Connection
+metadata:
+  name: invalid
+spec: {}
+`))
+
+		Expect(err).To(MatchError(`manifest kind must be Playbook, got "Connection"`))
+	})
+})

--- a/clientcmd/playbook_read.go
+++ b/clientcmd/playbook_read.go
@@ -40,6 +40,31 @@ var GetPlaybook = &cobra.Command{
 	},
 }
 
+var DeletePlaybook = &cobra.Command{
+	Use:          "delete <playbook-id|namespace/name|name>",
+	Short:        "Delete an API-created playbook",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		item, err := getRemotePlaybook(cmd, args[0])
+		if err != nil {
+			return err
+		}
+		if item.Source != models.SourceUI {
+			return fmt.Errorf("playbook %s/%s was not created through the API and cannot be deleted", item.Namespace, item.Name)
+		}
+		_, client, err := playbookAPIClient(cmd)
+		if err != nil {
+			return err
+		}
+		if _, err := client.DeletePlaybook(cmd.Context(), item.ID); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "playbook %s/%s deleted\n", item.Namespace, item.Name)
+		return err
+	},
+}
+
 var PlaybookHistory = &cobra.Command{
 	Use:          "history <playbook-id|namespace/name|name>",
 	Short:        "List execution history for a playbook",
@@ -147,5 +172,5 @@ func init() {
 	PlaybookHistory.Flags().IntVar(&playbookHistoryLimit, "limit", 20, "Maximum number of runs")
 	PlaybookHistory.Flags().StringSliceVar(&playbookHistoryStatus, "status", nil, "Filter by run status (repeatable or comma-separated)")
 	clicky.BindAllFlags(PlaybookHistory.Flags(), "format")
-	Playbook.AddCommand(GetPlaybook, PlaybookHistory)
+	Playbook.AddCommand(GetPlaybook, DeletePlaybook, PlaybookHistory)
 }

--- a/clientcmd/playbook_read.go
+++ b/clientcmd/playbook_read.go
@@ -1,0 +1,151 @@
+package clientcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/flanksource/clicky"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/sdk"
+	"github.com/spf13/cobra"
+)
+
+var (
+	playbookGetJSON       bool
+	playbookHistoryLimit  int
+	playbookHistoryStatus []string
+)
+
+var GetPlaybook = &cobra.Command{
+	Use:          "get <playbook-id|namespace/name|name>",
+	Short:        "Get a playbook manifest from the configured Mission Control API",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		item, err := getRemotePlaybook(cmd, args[0])
+		if err != nil {
+			return err
+		}
+		manifest, err := playbookManifestFromItem(*item)
+		if err != nil {
+			return err
+		}
+		format := "yaml"
+		if playbookGetJSON {
+			format = "json"
+		}
+		return SaveOutputToWriter(cmd.OutOrStdout(), manifest, "", format)
+	},
+}
+
+var PlaybookHistory = &cobra.Command{
+	Use:          "history <playbook-id|namespace/name|name>",
+	Short:        "List execution history for a playbook",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		item, err := getRemotePlaybook(cmd, args[0])
+		if err != nil {
+			return err
+		}
+		statuses, err := parsePlaybookRunStatuses(playbookHistoryStatus)
+		if err != nil {
+			return err
+		}
+		_, client, err := playbookAPIClient(cmd)
+		if err != nil {
+			return err
+		}
+		runs, err := client.ListPlaybookRuns(cmd.Context(), sdk.PlaybookRunListOptions{
+			PlaybookID: &item.ID,
+			Statuses:   statuses,
+			Limit:      playbookHistoryLimit,
+		})
+		if err != nil {
+			return err
+		}
+		return printClicky(cmd.OutOrStdout(), runs, "pretty")
+	},
+}
+
+func getRemotePlaybook(cmd *cobra.Command, ref string) (*api.PlaybookListItem, error) {
+	items, err := listRemotePlaybooks(cmd, sdk.PlaybookListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return resolvePlaybookRef(items, ref, playbookNamespace)
+}
+
+func playbookManifestFromItem(item api.PlaybookListItem) (*playbookManifest, error) {
+	var spec map[string]any
+	if err := json.Unmarshal(item.Spec, &spec); err != nil {
+		return nil, fmt.Errorf("invalid stored playbook spec: %w", err)
+	}
+	if item.Title != "" {
+		spec["title"] = item.Title
+	}
+	if item.Description != "" {
+		spec["description"] = item.Description
+	}
+	if item.Icon != "" {
+		spec["icon"] = item.Icon
+	}
+	if item.Category != "" {
+		spec["category"] = item.Category
+	}
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshal playbook spec: %w", err)
+	}
+
+	namespace := item.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &playbookManifest{
+		APIVersion: "mission-control.flanksource.com/v1",
+		Kind:       "Playbook",
+		Metadata: playbookMetadata{
+			Name:      item.Name,
+			Namespace: namespace,
+		},
+		Spec: specJSON,
+	}, nil
+}
+
+func parsePlaybookRunStatuses(values []string) ([]models.PlaybookRunStatus, error) {
+	valid := map[models.PlaybookRunStatus]struct{}{
+		models.PlaybookRunStatusCancelled:       {},
+		models.PlaybookRunStatusTimedOut:        {},
+		models.PlaybookRunStatusCompleted:       {},
+		models.PlaybookRunStatusFailed:          {},
+		models.PlaybookRunStatusPendingApproval: {},
+		models.PlaybookRunStatusRunning:         {},
+		models.PlaybookRunStatusScheduled:       {},
+		models.PlaybookRunStatusSleeping:        {},
+		models.PlaybookRunStatusRetrying:        {},
+		models.PlaybookRunStatusWaiting:         {},
+	}
+
+	var statuses []models.PlaybookRunStatus
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			status := models.PlaybookRunStatus(strings.TrimSpace(part))
+			if _, ok := valid[status]; !ok {
+				return nil, fmt.Errorf("invalid playbook run status %q", part)
+			}
+			statuses = append(statuses, status)
+		}
+	}
+	return statuses, nil
+}
+
+func init() {
+	GetPlaybook.Flags().BoolVar(&playbookGetJSON, "json", false, "Print the playbook manifest as JSON")
+	PlaybookHistory.Flags().IntVar(&playbookHistoryLimit, "limit", 20, "Maximum number of runs")
+	PlaybookHistory.Flags().StringSliceVar(&playbookHistoryStatus, "status", nil, "Filter by run status (repeatable or comma-separated)")
+	clicky.BindAllFlags(PlaybookHistory.Flags(), "format")
+	Playbook.AddCommand(GetPlaybook, PlaybookHistory)
+}

--- a/clientcmd/playbook_read_test.go
+++ b/clientcmd/playbook_read_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = ginkgo.Describe("playbook get and history", func() {
+var _ = ginkgo.Describe("playbook read and delete commands", func() {
 	ginkgo.It("renders get output as an applicable Playbook manifest", func() {
 		manifest, err := playbookManifestFromItem(api.PlaybookListItem{
 			Namespace:   "ops",
@@ -58,8 +58,9 @@ spec:
 		Expect(err).To(MatchError(`invalid playbook run status "unknown"`))
 	})
 
-	ginkgo.It("registers get and history under playbook", func() {
+	ginkgo.It("registers get, history, and delete under playbook", func() {
 		Expect(findChildCommand(Playbook, "get")).ToNot(BeNil())
 		Expect(findChildCommand(Playbook, "history")).ToNot(BeNil())
+		Expect(findChildCommand(Playbook, "delete")).ToNot(BeNil())
 	})
 })

--- a/clientcmd/playbook_read_test.go
+++ b/clientcmd/playbook_read_test.go
@@ -1,0 +1,65 @@
+package clientcmd
+
+import (
+	"bytes"
+
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/flanksource/incident-commander/api"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("playbook get and history", func() {
+	ginkgo.It("renders get output as an applicable Playbook manifest", func() {
+		manifest, err := playbookManifestFromItem(api.PlaybookListItem{
+			Namespace:   "ops",
+			Name:        "restart",
+			Title:       "Restart",
+			Category:    "Kubernetes",
+			Description: "Restarts a workload",
+			Spec:        types.JSON(`{"actions":[{"name":"echo","exec":{"script":"echo ok"}}]}`),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		var output bytes.Buffer
+
+		Expect(SaveOutputToWriter(&output, manifest, "", "yaml")).To(Succeed())
+		Expect(output.String()).To(Equal(`apiVersion: mission-control.flanksource.com/v1
+kind: Playbook
+metadata:
+  name: restart
+  namespace: ops
+spec:
+  actions:
+  - exec:
+      script: echo ok
+    name: echo
+  category: Kubernetes
+  description: Restarts a workload
+  title: Restart
+
+`))
+	})
+
+	ginkgo.It("accepts repeated and comma-separated history statuses", func() {
+		statuses, err := parsePlaybookRunStatuses([]string{"failed,timed_out", "completed"})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statuses).To(Equal([]models.PlaybookRunStatus{
+			models.PlaybookRunStatusFailed,
+			models.PlaybookRunStatusTimedOut,
+			models.PlaybookRunStatusCompleted,
+		}))
+	})
+
+	ginkgo.It("rejects invalid history statuses", func() {
+		_, err := parsePlaybookRunStatuses([]string{"unknown"})
+
+		Expect(err).To(MatchError(`invalid playbook run status "unknown"`))
+	})
+
+	ginkgo.It("registers get and history under playbook", func() {
+		Expect(findChildCommand(Playbook, "get")).ToNot(BeNil())
+		Expect(findChildCommand(Playbook, "history")).ToNot(BeNil())
+	})
+})

--- a/db/playbooks.go
+++ b/db/playbooks.go
@@ -241,16 +241,16 @@ func FindPlaybookByWebhookPath(ctx context.Context, path string) (*models.Playbo
 }
 
 func PersistPlaybookFromCRD(ctx context.Context, obj *v1.Playbook) error {
-	if err := obj.Spec.Validate(); err != nil {
-		return err
-	}
-
 	_, err := SavePlaybook(ctx, obj)
 	return err
 }
 
 func SavePlaybook(ctx context.Context, obj *v1.Playbook) (*models.Playbook, error) {
-	if err := obj.Spec.Validate(); err != nil {
+	specJSON, err := json.Marshal(obj.Spec)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := v1.ParseAndValidatePlaybookSpec(specJSON); err != nil {
 		return nil, err
 	}
 

--- a/echo/playbook_postgrest_test.go
+++ b/echo/playbook_postgrest_test.go
@@ -1,0 +1,125 @@
+package echo
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+	"github.com/google/uuid"
+	echov4 "github.com/labstack/echo/v4"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("playbook PostgREST writes", func() {
+	var createdIDs []uuid.UUID
+
+	ginkgo.AfterEach(func() {
+		if len(createdIDs) > 0 {
+			Expect(DefaultContext.DB().Unscoped().Delete(&models.Playbook{}, "id IN ?", createdIDs).Error).ToNot(HaveOccurred())
+		}
+		createdIDs = nil
+	})
+
+	newPlaybook := func(source string) models.Playbook {
+		playbook := models.Playbook{
+			ID:        uuid.New(),
+			Namespace: "default",
+			Name:      "postgrest-" + uuid.NewString(),
+			Spec:      types.JSON(`{"actions":[{"name":"echo","exec":{"script":"echo ok"}}]}`),
+			Source:    source,
+		}
+		Expect(DefaultContext.DB().Create(&playbook).Error).ToNot(HaveOccurred())
+		createdIDs = append(createdIDs, playbook.ID)
+		return playbook
+	}
+
+	execute := func(method, target string, body any) (*httptest.ResponseRecorder, bool) {
+		var payload []byte
+		if body != nil {
+			var err error
+			payload, err = json.Marshal(body)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		req := httptest.NewRequest(method, target, bytes.NewReader(payload)).WithContext(DefaultContext)
+		req.Header.Set(echov4.HeaderContentType, echov4.MIMEApplicationJSON)
+		recorder := httptest.NewRecorder()
+		ctx := echov4.New().NewContext(req, recorder)
+		called := false
+		handler := postgrestInterceptor(func(c echov4.Context) error {
+			called = true
+			return c.NoContent(http.StatusNoContent)
+		})
+		err := handler(ctx)
+		if err != nil {
+			ctx.Echo().HTTPErrorHandler(err, ctx)
+		}
+		return recorder, called
+	}
+
+	ginkgo.It("applies generated schema validation before proxying writes", func() {
+		response, called := execute(http.MethodPost, "/db/playbooks", map[string]any{
+			"namespace": "default",
+			"name":      "invalid",
+			"source":    models.SourceUI,
+			"spec": map[string]any{
+				"actions":    []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo ok"}}},
+				"unexpected": true,
+			},
+		})
+
+		Expect(called).To(BeFalse())
+		Expect(response.Code).To(Equal(http.StatusBadRequest))
+		Expect(response.Body.String()).To(ContainSubstring("Additional property unexpected is not allowed"))
+	})
+
+	ginkgo.It("allows valid UI playbook updates", func() {
+		playbook := newPlaybook(models.SourceUI)
+		response, called := execute(http.MethodPatch, "/db/playbooks?id=eq."+playbook.ID.String(), map[string]any{
+			"source": models.SourceUI,
+			"spec": map[string]any{
+				"actions": []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo changed"}}},
+			},
+		})
+
+		Expect(called).To(BeTrue())
+		Expect(response.Code).To(Equal(http.StatusNoContent))
+	})
+
+	ginkgo.It("rejects updates to Kubernetes-managed playbooks", func() {
+		playbook := newPlaybook(models.SourceCRD)
+		response, called := execute(http.MethodPatch, "/db/playbooks?id=eq."+playbook.ID.String(), map[string]any{
+			"spec": map[string]any{
+				"actions": []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo changed"}}},
+			},
+		})
+
+		Expect(called).To(BeFalse())
+		Expect(response.Code).To(Equal(http.StatusConflict))
+		Expect(response.Body.String()).To(ContainSubstring("managed by Kubernetes"))
+	})
+
+	ginkgo.It("rejects source changes", func() {
+		playbook := newPlaybook(models.SourceUI)
+		response, called := execute(http.MethodPatch, "/db/playbooks?id=eq."+playbook.ID.String(), map[string]any{
+			"source": models.SourceCRD,
+		})
+
+		Expect(called).To(BeFalse())
+		Expect(response.Code).To(Equal(http.StatusBadRequest))
+		Expect(response.Body.String()).To(ContainSubstring("source cannot be changed"))
+	})
+
+	ginkgo.It("requires an exact id for mutations", func() {
+		response, called := execute(http.MethodPatch, "/db/playbooks?name=eq.any", map[string]any{
+			"deleted_at": "now()",
+		})
+
+		Expect(called).To(BeFalse())
+		Expect(response.Code).To(Equal(http.StatusBadRequest))
+		Expect(response.Body.String()).To(ContainSubstring("exact id filter"))
+	})
+})

--- a/echo/playbook_postgrest_test.go
+++ b/echo/playbook_postgrest_test.go
@@ -89,17 +89,51 @@ var _ = ginkgo.Describe("playbook PostgREST writes", func() {
 		Expect(response.Code).To(Equal(http.StatusNoContent))
 	})
 
-	ginkgo.It("rejects updates to Kubernetes-managed playbooks", func() {
-		playbook := newPlaybook(models.SourceCRD)
-		response, called := execute(http.MethodPatch, "/db/playbooks?id=eq."+playbook.ID.String(), map[string]any{
+	for _, source := range []string{models.SourceCRD, models.SourceConfigFile} {
+		ginkgo.It("rejects updates to "+source+" playbooks", func() {
+			playbook := newPlaybook(source)
+			response, called := execute(http.MethodPatch, "/db/playbooks?id=eq."+playbook.ID.String(), map[string]any{
+				"spec": map[string]any{
+					"actions": []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo changed"}}},
+				},
+			})
+
+			Expect(called).To(BeFalse())
+			Expect(response.Code).To(Equal(http.StatusConflict))
+			Expect(response.Body.String()).To(ContainSubstring("not created through the API"))
+		})
+	}
+
+	ginkgo.It("allows deletes of API-created playbooks", func() {
+		playbook := newPlaybook(models.SourceUI)
+		response, called := execute(http.MethodDelete, "/db/playbooks?id=eq."+playbook.ID.String(), nil)
+
+		Expect(called).To(BeTrue())
+		Expect(response.Code).To(Equal(http.StatusNoContent))
+	})
+
+	ginkgo.It("rejects deletes of externally managed playbooks", func() {
+		playbook := newPlaybook(models.SourceConfigFile)
+		response, called := execute(http.MethodDelete, "/db/playbooks?id=eq."+playbook.ID.String(), nil)
+
+		Expect(called).To(BeFalse())
+		Expect(response.Code).To(Equal(http.StatusConflict))
+		Expect(response.Body.String()).To(ContainSubstring("not created through the API"))
+	})
+
+	ginkgo.It("rejects externally managed sources on create", func() {
+		response, called := execute(http.MethodPost, "/db/playbooks", map[string]any{
+			"namespace": "default",
+			"name":      "config-file",
+			"source":    models.SourceConfigFile,
 			"spec": map[string]any{
-				"actions": []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo changed"}}},
+				"actions": []any{map[string]any{"name": "echo", "exec": map[string]any{"script": "echo ok"}}},
 			},
 		})
 
 		Expect(called).To(BeFalse())
-		Expect(response.Code).To(Equal(http.StatusConflict))
-		Expect(response.Body.String()).To(ContainSubstring("managed by Kubernetes"))
+		Expect(response.Code).To(Equal(http.StatusBadRequest))
+		Expect(response.Body.String()).To(ContainSubstring("playbook source must be"))
 	})
 
 	ginkgo.It("rejects source changes", func() {

--- a/echo/serve.go
+++ b/echo/serve.go
@@ -274,8 +274,8 @@ func postgrestInterceptor(next echov4.HandlerFunc) echov4.HandlerFunc {
 		if err != nil {
 			return dutyApi.WriteError(c, err)
 		}
-		if existing != nil && existing.Source == models.SourceCRD {
-			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.ECONFLICT, "playbook %s/%s is managed by Kubernetes and cannot be modified through the API", existing.Namespace, existing.Name))
+		if existing != nil && existing.Source != models.SourceUI {
+			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.ECONFLICT, "playbook %s/%s was not created through the API and cannot be modified", existing.Namespace, existing.Name))
 		}
 		if method == http.MethodDelete {
 			return next(c)
@@ -365,8 +365,8 @@ func validatePlaybookSource(method string, requestData map[string]any, existing 
 		return nil
 	}
 	source, ok := sourceValue.(string)
-	if !ok || (source != models.SourceUI && source != models.SourceConfigFile) {
-		return dutyApi.Errorf(dutyApi.EINVALID, "playbook source must be %q or %q", models.SourceUI, models.SourceConfigFile)
+	if !ok || source != models.SourceUI {
+		return dutyApi.Errorf(dutyApi.EINVALID, "playbook source must be %q", models.SourceUI)
 	}
 	return nil
 }

--- a/echo/serve.go
+++ b/echo/serve.go
@@ -22,11 +22,13 @@ import (
 	"github.com/flanksource/duty/canary"
 	"github.com/flanksource/duty/context"
 	dutyEcho "github.com/flanksource/duty/echo"
+	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/rbac/policy"
 	"github.com/flanksource/duty/schema/openapi"
 	"github.com/flanksource/duty/shutdown"
 	"github.com/flanksource/duty/telemetry"
 	"github.com/flanksource/duty/topology"
+	"github.com/google/uuid"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	echov4 "github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -254,49 +256,149 @@ func postgrestTraceMiddleware(next echov4.HandlerFunc) echov4.HandlerFunc {
 	}
 }
 
+// postgrestInterceptor enforces write invariants that PostgREST cannot express.
 func postgrestInterceptor(next echov4.HandlerFunc) echov4.HandlerFunc {
 	return func(c echov4.Context) error {
 		path := strings.TrimPrefix(c.Request().URL.Path, "/db/")
 		table := strings.Split(path, "?")[0] // Remove query parameters
+		if table != "playbooks" {
+			return next(c)
+		}
 
-		switch table {
-		// For playbooks we need to validate the spec for create/update requests
-		case "playbooks":
-			method := c.Request().Method
-			if method != http.MethodPost && method != http.MethodPatch {
-				return next(c)
-			}
-			requestData, err := readJSONBody(c)
-			if err != nil {
-				return dutyApi.WriteError(c, err)
-			}
+		method := c.Request().Method
+		if method != http.MethodPost && method != http.MethodPatch && method != http.MethodDelete {
+			return next(c)
+		}
 
-			specValue, hasSpec := requestData["spec"]
-			if !hasSpec {
-				return next(c)
-			}
+		existing, err := playbookMutationTarget(c)
+		if err != nil {
+			return dutyApi.WriteError(c, err)
+		}
+		if existing != nil && existing.Source == models.SourceCRD {
+			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.ECONFLICT, "playbook %s/%s is managed by Kubernetes and cannot be modified through the API", existing.Namespace, existing.Name))
+		}
+		if method == http.MethodDelete {
+			return next(c)
+		}
+		if method == http.MethodPost && strings.Contains(c.Request().Header.Get("Prefer"), "resolution=merge-duplicates") {
+			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "playbook upserts are not supported; use PATCH with an id filter to update an existing playbook"))
+		}
 
-			specBytes, err := json.Marshal(specValue)
-			if err != nil {
-				return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "error marshaling json: %v", err))
-			}
-			var spec v1.PlaybookSpec
-			if err := json.Unmarshal(specBytes, &spec); err != nil {
-				return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "invalid playbook spec: %v", err))
-			}
+		requestData, err := readJSONBody(c)
+		if err != nil {
+			return dutyApi.WriteError(c, err)
+		}
+		if err := validatePlaybookSource(method, requestData, existing); err != nil {
+			return dutyApi.WriteError(c, err)
+		}
+		if err := replaceJSONBody(c, requestData); err != nil {
+			return dutyApi.WriteError(c, err)
+		}
 
-			if err := spec.Validate(); err != nil {
-				return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "playbook validation failed: %v", err))
+		specValue, hasSpec := requestData["spec"]
+		if !hasSpec {
+			if method == http.MethodPost {
+				return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "playbook spec is required"))
 			}
+			return next(c)
+		}
+
+		specBytes, err := json.Marshal(specValue)
+		if err != nil {
+			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "error marshaling playbook spec: %v", err))
+		}
+		spec, err := v1.ParseAndValidatePlaybookSpec(specBytes)
+		if err != nil {
+			return dutyApi.WriteError(c, dutyApi.Errorf(dutyApi.EINVALID, "playbook validation failed: %v", err))
+		}
+		if err := validatePlaybookWebhookPath(c, spec, existing); err != nil {
+			return dutyApi.WriteError(c, err)
 		}
 
 		return next(c)
 	}
 }
 
-// readJSONBody reads the request body for POST/PATCH requests and unmarshals it into a map.
-// Returns nil, error if there was an error reading or unmarshaling the body.
-// Returns the map, nil on success.
+// playbookMutationTarget restricts source-aware mutations to one identifiable playbook.
+func playbookMutationTarget(c echov4.Context) (*models.Playbook, error) {
+	if c.Request().Method == http.MethodPost {
+		return nil, nil
+	}
+
+	filter := c.QueryParam("id")
+	if !strings.HasPrefix(filter, "eq.") {
+		return nil, dutyApi.Errorf(dutyApi.EINVALID, "playbook mutations require an exact id filter")
+	}
+	id, err := uuid.Parse(strings.TrimPrefix(filter, "eq."))
+	if err != nil {
+		return nil, dutyApi.Errorf(dutyApi.EINVALID, "invalid playbook id: %v", err)
+	}
+
+	ctx := c.Request().Context().(context.Context)
+	var playbook models.Playbook
+	tx := ctx.DB().Select("id", "namespace", "name", "source").Where("id = ?", id).Find(&playbook)
+	if tx.Error != nil {
+		return nil, ctx.Oops().Wrap(tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return nil, nil
+	}
+	return &playbook, nil
+}
+
+// validatePlaybookSource prevents API writes from claiming or transferring reconciler ownership.
+func validatePlaybookSource(method string, requestData map[string]any, existing *models.Playbook) error {
+	sourceValue, hasSource := requestData["source"]
+	if method == http.MethodPatch {
+		if !hasSource || existing == nil {
+			return nil
+		}
+		source, ok := sourceValue.(string)
+		if !ok || source != existing.Source {
+			return dutyApi.Errorf(dutyApi.EINVALID, "playbook source cannot be changed")
+		}
+		return nil
+	}
+
+	if !hasSource {
+		requestData["source"] = models.SourceUI
+		return nil
+	}
+	source, ok := sourceValue.(string)
+	if !ok || (source != models.SourceUI && source != models.SourceConfigFile) {
+		return dutyApi.Errorf(dutyApi.EINVALID, "playbook source must be %q or %q", models.SourceUI, models.SourceConfigFile)
+	}
+	return nil
+}
+
+// validatePlaybookWebhookPath applies the uniqueness rule used by CRD persistence.
+func validatePlaybookWebhookPath(c echov4.Context, spec *v1.PlaybookSpec, existing *models.Playbook) error {
+	if spec.On == nil || spec.On.Webhook == nil || spec.On.Webhook.Path == "" {
+		return nil
+	}
+
+	ctx := c.Request().Context().(context.Context)
+	other, err := db.FindPlaybookByWebhookPath(ctx, spec.On.Webhook.Path)
+	if err != nil {
+		return ctx.Oops().Wrap(err)
+	}
+	if other != nil && (existing == nil || other.ID != existing.ID) {
+		return dutyApi.Errorf(dutyApi.ECONFLICT, "playbook with webhook path %s already exists", spec.On.Webhook.Path)
+	}
+	return nil
+}
+
+func replaceJSONBody(c echov4.Context, requestData map[string]any) error {
+	bodyBytes, err := json.Marshal(requestData)
+	if err != nil {
+		return dutyApi.Errorf(dutyApi.EINVALID, "error marshaling request body: %v", err)
+	}
+	c.Request().Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	c.Request().ContentLength = int64(len(bodyBytes))
+	return nil
+}
+
+// readJSONBody reads a request body while preserving it for the proxied handler.
 func readJSONBody(c echov4.Context) (map[string]any, error) {
 	bodyBytes, err := io.ReadAll(c.Request().Body)
 	if err != nil {

--- a/playbook/runner/runner.go
+++ b/playbook/runner/runner.go
@@ -19,7 +19,6 @@ import (
 	"gorm.io/gorm"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/flanksource/incident-commander/config/schemas"
 	"github.com/flanksource/incident-commander/db"
 	"github.com/flanksource/incident-commander/playbook/actions"
 )
@@ -36,18 +35,8 @@ func GetNextActionToRun(ctx context.Context, run models.PlaybookRun) (action *v1
 	ctx.Logger.V(3).Infof("getting next action for run %s", run.ID)
 	ctx = ctx.WithObject(run)
 
-	if validationErr, err := schemas.ValidatePlaybookSpec(run.Spec); err != nil {
-		return nil, nil, err
-	} else if validationErr != nil {
-		return nil, nil, validationErr
-	}
-
-	var playbookSpec v1.PlaybookSpec
-	if err := json.Unmarshal(run.Spec, &playbookSpec); err != nil {
-		return nil, nil, ctx.Oops().Wrap(err)
-	}
-
-	if err := playbookSpec.Validate(); err != nil {
+	playbookSpec, err := v1.ParseAndValidatePlaybookSpec(run.Spec)
+	if err != nil {
 		return nil, nil, ctx.Oops().Wrap(err)
 	}
 

--- a/sdk/playbook_apply.go
+++ b/sdk/playbook_apply.go
@@ -39,7 +39,7 @@ type playbookWrite struct {
 	Source      string     `json:"source,omitempty"`
 }
 
-// ApplyPlaybook creates a file-backed playbook or updates a non-Kubernetes playbook with the same identity.
+// ApplyPlaybook creates an API-owned playbook or updates an API-owned playbook with the same identity.
 func (c *Client) ApplyPlaybook(ctx context.Context, params PlaybookApplyParams) (*PlaybookApplyResult, error) {
 	existing, err := c.findPlaybooksForApply(ctx, params.Namespace, params.Name)
 	if err != nil {
@@ -73,15 +73,15 @@ func (c *Client) ApplyPlaybook(ctx context.Context, params PlaybookApplyParams) 
 		Spec:        types.JSON(params.Spec),
 	}
 	if target == nil {
-		write.Source = models.SourceConfigFile
+		write.Source = models.SourceUI
 		playbook, err := c.createPlaybook(ctx, write)
 		if err != nil {
 			return nil, err
 		}
 		return &PlaybookApplyResult{Playbook: *playbook, Created: true}, nil
 	}
-	if target.Source == models.SourceCRD {
-		return nil, fmt.Errorf("playbook %s/%s is managed by Kubernetes and cannot be applied", target.Namespace, target.Name)
+	if target.Source != models.SourceUI {
+		return nil, fmt.Errorf("playbook %s/%s was not created through the API and cannot be applied", target.Namespace, target.Name)
 	}
 
 	playbook, err := c.updatePlaybook(ctx, target.ID.String(), write)

--- a/sdk/playbook_apply.go
+++ b/sdk/playbook_apply.go
@@ -1,0 +1,164 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/flanksource/commons/http"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/types"
+)
+
+// PlaybookApplyParams contains the canonical database fields derived from a Playbook manifest.
+type PlaybookApplyParams struct {
+	Namespace   string
+	Name        string
+	Title       string
+	Icon        string
+	Description string
+	Category    string
+	Spec        json.RawMessage
+}
+
+// PlaybookApplyResult describes whether apply created or updated the playbook.
+type PlaybookApplyResult struct {
+	Playbook models.Playbook
+	Created  bool
+}
+
+type playbookWrite struct {
+	Namespace   string     `json:"namespace"`
+	Name        string     `json:"name"`
+	Title       string     `json:"title"`
+	Icon        string     `json:"icon"`
+	Description string     `json:"description"`
+	Category    string     `json:"category"`
+	Spec        types.JSON `json:"spec"`
+	Source      string     `json:"source,omitempty"`
+}
+
+// ApplyPlaybook creates a file-backed playbook or updates a non-Kubernetes playbook with the same identity.
+func (c *Client) ApplyPlaybook(ctx context.Context, params PlaybookApplyParams) (*PlaybookApplyResult, error) {
+	existing, err := c.findPlaybooksForApply(ctx, params.Namespace, params.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	var target *models.Playbook
+	if len(existing) == 1 {
+		target = &existing[0]
+	} else if len(existing) > 1 {
+		for i := range existing {
+			if existing[i].Category == params.Category {
+				if target != nil {
+					return nil, fmt.Errorf("multiple playbooks match %s/%s in category %q", params.Namespace, params.Name, params.Category)
+				}
+				target = &existing[i]
+			}
+		}
+		if target == nil {
+			return nil, fmt.Errorf("multiple playbooks match %s/%s; specify an existing category", params.Namespace, params.Name)
+		}
+	}
+
+	write := playbookWrite{
+		Namespace:   params.Namespace,
+		Name:        params.Name,
+		Title:       params.Title,
+		Icon:        params.Icon,
+		Description: params.Description,
+		Category:    params.Category,
+		Spec:        types.JSON(params.Spec),
+	}
+	if target == nil {
+		write.Source = models.SourceConfigFile
+		playbook, err := c.createPlaybook(ctx, write)
+		if err != nil {
+			return nil, err
+		}
+		return &PlaybookApplyResult{Playbook: *playbook, Created: true}, nil
+	}
+	if target.Source == models.SourceCRD {
+		return nil, fmt.Errorf("playbook %s/%s is managed by Kubernetes and cannot be applied", target.Namespace, target.Name)
+	}
+
+	playbook, err := c.updatePlaybook(ctx, target.ID.String(), write)
+	if err != nil {
+		return nil, err
+	}
+	return &PlaybookApplyResult{Playbook: *playbook}, nil
+}
+
+func (c *Client) findPlaybooksForApply(ctx context.Context, namespace, name string) ([]models.Playbook, error) {
+	response, err := c.R(ctx).
+		QueryParam("namespace", "eq."+namespace).
+		QueryParam("name", "eq."+name).
+		QueryParam("deleted_at", "is.null").
+		QueryParam("select", "*").
+		Get(c.apiPath("/db/playbooks"))
+	if err != nil {
+		return nil, err
+	}
+	if !response.IsOK() {
+		return nil, playbookWriteError(response)
+	}
+
+	var playbooks []models.Playbook
+	if err := decodeJSON(response, &playbooks); err != nil {
+		return nil, err
+	}
+	return playbooks, nil
+}
+
+func (c *Client) createPlaybook(ctx context.Context, write playbookWrite) (*models.Playbook, error) {
+	response, err := c.R(ctx).
+		Header("Prefer", "return=representation").
+		Post(c.apiPath("/db/playbooks"), write)
+	if err != nil {
+		return nil, err
+	}
+	return decodePlaybookWriteResponse(response)
+}
+
+func (c *Client) updatePlaybook(ctx context.Context, id string, write playbookWrite) (*models.Playbook, error) {
+	response, err := c.R(ctx).
+		Header("Prefer", "return=representation").
+		QueryParam("id", "eq."+id).
+		Patch(c.apiPath("/db/playbooks"), write)
+	if err != nil {
+		return nil, err
+	}
+	return decodePlaybookWriteResponse(response)
+}
+
+func decodePlaybookWriteResponse(response *http.Response) (*models.Playbook, error) {
+	if !response.IsOK() {
+		return nil, playbookWriteError(response)
+	}
+
+	body, err := response.AsString()
+	if err != nil {
+		return nil, err
+	}
+	var playbooks []models.Playbook
+	if err := json.Unmarshal([]byte(body), &playbooks); err != nil {
+		return nil, fmt.Errorf("failed to decode playbook write response: %w", err)
+	}
+	if len(playbooks) != 1 {
+		return nil, fmt.Errorf("playbook write returned %d records", len(playbooks))
+	}
+	return &playbooks[0], nil
+}
+
+func playbookWriteError(response *http.Response) error {
+	body, err := response.AsString()
+	if err != nil {
+		return err
+	}
+	if looksLikeHTML(response.Header.Get("Content-Type"), body) {
+		return ErrHTMLResponse
+	}
+	return newServerError(response.StatusCode, []byte(strings.TrimSpace(body)))
+}

--- a/sdk/playbook_apply.go
+++ b/sdk/playbook_apply.go
@@ -102,7 +102,7 @@ func (c *Client) findPlaybooksForApply(ctx context.Context, namespace, name stri
 		return nil, err
 	}
 	if !response.IsOK() {
-		return nil, playbookWriteError(response)
+		return nil, postgrestError(response)
 	}
 
 	var playbooks []models.Playbook
@@ -135,7 +135,7 @@ func (c *Client) updatePlaybook(ctx context.Context, id string, write playbookWr
 
 func decodePlaybookWriteResponse(response *http.Response) (*models.Playbook, error) {
 	if !response.IsOK() {
-		return nil, playbookWriteError(response)
+		return nil, postgrestError(response)
 	}
 
 	body, err := response.AsString()
@@ -152,7 +152,7 @@ func decodePlaybookWriteResponse(response *http.Response) (*models.Playbook, err
 	return &playbooks[0], nil
 }
 
-func playbookWriteError(response *http.Response) error {
+func postgrestError(response *http.Response) error {
 	body, err := response.AsString()
 	if err != nil {
 		return err

--- a/sdk/playbook_apply_test.go
+++ b/sdk/playbook_apply_test.go
@@ -1,0 +1,110 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("ApplyPlaybook", func() {
+	params := PlaybookApplyParams{
+		Namespace:   "default",
+		Name:        "restart",
+		Title:       "Restart",
+		Description: "Restart a workload",
+		Category:    "Kubernetes",
+		Spec:        json.RawMessage(`{"actions":[{"name":"echo","exec":{"script":"echo ok"}}]}`),
+	}
+
+	ginkgo.It("creates file-backed playbooks", func() {
+		id := uuid.New()
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			switch requestCount {
+			case 1:
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/db/playbooks"))
+				Expect(r.URL.Query().Get("namespace")).To(Equal("eq.default"))
+				Expect(r.URL.Query().Get("name")).To(Equal("eq.restart"))
+				_, _ = w.Write([]byte(`[]`))
+			case 2:
+				Expect(r.Method).To(Equal(http.MethodPost))
+				var body map[string]any
+				Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+				Expect(body).To(HaveKeyWithValue("source", models.SourceConfigFile))
+				Expect(body["spec"]).To(HaveKey("actions"))
+				w.Header().Set("Content-Type", "application/json")
+				Expect(json.NewEncoder(w).Encode([]models.Playbook{{
+					ID: id, Namespace: "default", Name: "restart", Source: models.SourceConfigFile,
+				}})).To(Succeed())
+			default:
+				ginkgo.Fail("unexpected request")
+			}
+		}))
+		defer server.Close()
+
+		result, err := New(server.URL, "token").ApplyPlaybook(context.Background(), params)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Created).To(BeTrue())
+		Expect(result.Playbook.ID).To(Equal(id))
+		Expect(requestCount).To(Equal(2))
+	})
+
+	ginkgo.It("updates UI-created playbooks without changing their source", func() {
+		id := uuid.New()
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			w.Header().Set("Content-Type", "application/json")
+			if requestCount == 1 {
+				Expect(json.NewEncoder(w).Encode([]models.Playbook{{
+					ID: id, Namespace: "default", Name: "restart", Source: models.SourceUI,
+				}})).To(Succeed())
+				return
+			}
+
+			Expect(r.Method).To(Equal(http.MethodPatch))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq." + id.String()))
+			var body map[string]any
+			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+			Expect(body).ToNot(HaveKey("source"))
+			Expect(json.NewEncoder(w).Encode([]models.Playbook{{
+				ID: id, Namespace: "default", Name: "restart", Source: models.SourceUI,
+			}})).To(Succeed())
+		}))
+		defer server.Close()
+
+		result, err := New(server.URL, "token").ApplyPlaybook(context.Background(), params)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Created).To(BeFalse())
+		Expect(result.Playbook.Source).To(Equal(models.SourceUI))
+		Expect(requestCount).To(Equal(2))
+	})
+
+	ginkgo.It("does not update Kubernetes-managed playbooks", func() {
+		id := uuid.New()
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requestCount++
+			w.Header().Set("Content-Type", "application/json")
+			Expect(json.NewEncoder(w).Encode([]models.Playbook{{
+				ID: id, Namespace: "default", Name: "restart", Source: models.SourceCRD,
+			}})).To(Succeed())
+		}))
+		defer server.Close()
+
+		_, err := New(server.URL, "token").ApplyPlaybook(context.Background(), params)
+
+		Expect(err).To(MatchError(ContainSubstring("managed by Kubernetes")))
+		Expect(requestCount).To(Equal(1))
+	})
+})

--- a/sdk/playbook_apply_test.go
+++ b/sdk/playbook_apply_test.go
@@ -22,7 +22,7 @@ var _ = ginkgo.Describe("ApplyPlaybook", func() {
 		Spec:        json.RawMessage(`{"actions":[{"name":"echo","exec":{"script":"echo ok"}}]}`),
 	}
 
-	ginkgo.It("creates file-backed playbooks", func() {
+	ginkgo.It("creates API-owned playbooks", func() {
 		id := uuid.New()
 		requestCount := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -38,11 +38,11 @@ var _ = ginkgo.Describe("ApplyPlaybook", func() {
 				Expect(r.Method).To(Equal(http.MethodPost))
 				var body map[string]any
 				Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
-				Expect(body).To(HaveKeyWithValue("source", models.SourceConfigFile))
+				Expect(body).To(HaveKeyWithValue("source", models.SourceUI))
 				Expect(body["spec"]).To(HaveKey("actions"))
 				w.Header().Set("Content-Type", "application/json")
 				Expect(json.NewEncoder(w).Encode([]models.Playbook{{
-					ID: id, Namespace: "default", Name: "restart", Source: models.SourceConfigFile,
+					ID: id, Namespace: "default", Name: "restart", Source: models.SourceUI,
 				}})).To(Succeed())
 			default:
 				ginkgo.Fail("unexpected request")
@@ -90,21 +90,21 @@ var _ = ginkgo.Describe("ApplyPlaybook", func() {
 		Expect(requestCount).To(Equal(2))
 	})
 
-	ginkgo.It("does not update Kubernetes-managed playbooks", func() {
+	ginkgo.It("does not update externally managed playbooks", func() {
 		id := uuid.New()
 		requestCount := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			requestCount++
 			w.Header().Set("Content-Type", "application/json")
 			Expect(json.NewEncoder(w).Encode([]models.Playbook{{
-				ID: id, Namespace: "default", Name: "restart", Source: models.SourceCRD,
+				ID: id, Namespace: "default", Name: "restart", Source: models.SourceConfigFile,
 			}})).To(Succeed())
 		}))
 		defer server.Close()
 
 		_, err := New(server.URL, "token").ApplyPlaybook(context.Background(), params)
 
-		Expect(err).To(MatchError(ContainSubstring("managed by Kubernetes")))
+		Expect(err).To(MatchError(ContainSubstring("not created through the API")))
 		Expect(requestCount).To(Equal(1))
 	})
 })

--- a/sdk/playbook_delete.go
+++ b/sdk/playbook_delete.go
@@ -1,0 +1,21 @@
+package sdk
+
+import (
+	"context"
+	"time"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+)
+
+// DeletePlaybook soft-deletes an API-owned playbook.
+func (c *Client) DeletePlaybook(ctx context.Context, id uuid.UUID) (*models.Playbook, error) {
+	response, err := c.R(ctx).
+		Header("Prefer", "return=representation").
+		QueryParam("id", "eq."+id.String()).
+		Patch(c.apiPath("/db/playbooks"), map[string]time.Time{"deleted_at": time.Now().UTC()})
+	if err != nil {
+		return nil, err
+	}
+	return decodePlaybookWriteResponse(response)
+}

--- a/sdk/playbook_delete_test.go
+++ b/sdk/playbook_delete_test.go
@@ -1,0 +1,39 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("DeletePlaybook", func() {
+	ginkgo.It("soft-deletes a playbook by exact ID", func() {
+		id := uuid.New()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPatch))
+			Expect(r.URL.Path).To(Equal("/db/playbooks"))
+			Expect(r.URL.Query().Get("id")).To(Equal("eq." + id.String()))
+			Expect(r.Header.Get("Prefer")).To(Equal("return=representation"))
+			var body map[string]any
+			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+			deletedAt, err := time.Parse(time.RFC3339Nano, body["deleted_at"].(string))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedAt).To(BeTemporally("~", time.Now(), time.Second))
+			w.Header().Set("Content-Type", "application/json")
+			Expect(json.NewEncoder(w).Encode([]models.Playbook{{ID: id, Source: models.SourceUI}})).To(Succeed())
+		}))
+		defer server.Close()
+
+		playbook, err := New(server.URL, "token").DeletePlaybook(context.Background(), id)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(playbook.ID).To(Equal(id))
+	})
+})

--- a/sdk/playbook_history.go
+++ b/sdk/playbook_history.go
@@ -1,0 +1,55 @@
+package sdk
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+)
+
+// PlaybookRunListOptions filters playbook execution history.
+type PlaybookRunListOptions struct {
+	PlaybookID *uuid.UUID
+	Statuses   []models.PlaybookRunStatus
+	Limit      int
+}
+
+// ListPlaybookRuns returns top-level playbook runs in reverse chronological order.
+func (c *Client) ListPlaybookRuns(ctx context.Context, opts PlaybookRunListOptions) ([]models.PlaybookRun, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	request := c.R(ctx).
+		QueryParam("parent_id", "is.null").
+		QueryParam("order", "created_at.desc").
+		QueryParam("limit", strconv.Itoa(limit)).
+		QueryParam("select", "*")
+	if opts.PlaybookID != nil {
+		request = request.QueryParam("playbook_id", "eq."+opts.PlaybookID.String())
+	}
+	if len(opts.Statuses) > 0 {
+		statuses := make([]string, len(opts.Statuses))
+		for i, status := range opts.Statuses {
+			statuses[i] = string(status)
+		}
+		request = request.QueryParam("status", "in.("+strings.Join(statuses, ",")+")")
+	}
+
+	response, err := request.Get(c.apiPath("/db/playbook_runs"))
+	if err != nil {
+		return nil, err
+	}
+	if !response.IsOK() {
+		return nil, postgrestError(response)
+	}
+
+	var runs []models.PlaybookRun
+	if err := decodeJSON(response, &runs); err != nil {
+		return nil, err
+	}
+	return runs, nil
+}

--- a/sdk/playbook_history_test.go
+++ b/sdk/playbook_history_test.go
@@ -1,0 +1,61 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/flanksource/duty/models"
+	"github.com/google/uuid"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("ListPlaybookRuns", func() {
+	ginkgo.It("lists top-level runs with playbook and status filters", func() {
+		playbookID := uuid.New()
+		runID := uuid.New()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodGet))
+			Expect(r.URL.Path).To(Equal("/db/playbook_runs"))
+			Expect(r.URL.Query().Get("playbook_id")).To(Equal("eq." + playbookID.String()))
+			Expect(r.URL.Query().Get("status")).To(Equal("in.(failed,timed_out)"))
+			Expect(r.URL.Query().Get("parent_id")).To(Equal("is.null"))
+			Expect(r.URL.Query().Get("order")).To(Equal("created_at.desc"))
+			Expect(r.URL.Query().Get("limit")).To(Equal("5"))
+			w.Header().Set("Content-Type", "application/json")
+			Expect(json.NewEncoder(w).Encode([]models.PlaybookRun{{
+				ID: runID, PlaybookID: playbookID, Status: models.PlaybookRunStatusFailed,
+			}})).To(Succeed())
+		}))
+		defer server.Close()
+
+		runs, err := New(server.URL, "token").ListPlaybookRuns(context.Background(), PlaybookRunListOptions{
+			PlaybookID: &playbookID,
+			Statuses: []models.PlaybookRunStatus{
+				models.PlaybookRunStatusFailed,
+				models.PlaybookRunStatusTimedOut,
+			},
+			Limit: 5,
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runs).To(HaveLen(1))
+		Expect(runs[0].ID).To(Equal(runID))
+	})
+
+	ginkgo.It("defaults the result limit", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Query().Get("limit")).To(Equal("20"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		}))
+		defer server.Close()
+
+		runs, err := New(server.URL, "token").ListPlaybookRuns(context.Background(), PlaybookRunListOptions{})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(runs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to apply, get, delete, and view playbook execution history.
  * Added SDK support for applying playbooks, deleting (soft-delete) playbooks, and listing playbook runs with filters and limits.
* **Bug Fixes**
  * Centralized playbook specification validation (schema + semantic checks) across CLI, API, persistence, and runtime execution.
  * Enforced write protections for playbook updates/deletes, including correct handling of API-owned vs externally managed playbooks and stricter mutation rules.
* **Tests**
  * Added comprehensive coverage for validation, CLI command behavior, SDK apply/delete/history, and PostgREST write paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->