### PR TITLE
feat: publish ARM64 Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         flanksource/incident-commander:latest
         flanksource/incident-commander:v${{ needs.create-release.outputs.version }}
         public.ecr.aws/k4y9r6y5/incident-commander:v${{ needs.create-release.outputs.version }}
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       login_to_ecr: true
       cache_from: type=gha
       cache_to: type=gha,mode=max


### PR DESCRIPTION
Extend the release workflow’s Docker platforms to include `linux/arm64`, matching canary-checker’s multi-architecture release setup.

Releases will now publish a manifest supporting both AMD64 and ARM64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now published for both AMD64 and ARM64 platforms, improving compatibility across hardware architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->