### PR TITLE
chore(report): cleanup resolver code

### DIFF
--- a/report/resolve.go
+++ b/report/resolve.go
@@ -3,9 +3,6 @@
 package report
 
 import (
-	"net/url"
-	"strings"
-
 	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/connection"
 	"github.com/flanksource/duty/context"
@@ -33,23 +30,6 @@ type Server struct {
 }
 
 func (s Server) Configured() bool { return s.BaseURL != "" }
-
-// requireSecureToken refuses to send the facet API key over a plaintext
-// connection, where it would be readable in transit.
-func (s Server) requireSecureToken() error {
-	if s.Token == "" {
-		return nil
-	}
-
-	parsed, err := url.Parse(s.BaseURL)
-	if err != nil {
-		return dutyAPI.Errorf(dutyAPI.EINVALID, "invalid facet server url %q: %v", s.BaseURL, err)
-	}
-	if !strings.EqualFold(parsed.Scheme, "https") {
-		return dutyAPI.Errorf(dutyAPI.EINVALID, "refusing to send the facet api key to %q over %s: use https", s.BaseURL, parsed.Scheme)
-	}
-	return nil
-}
 
 // ResolveServer resolves the facet rendering server, preferring the report
 // options and falling back to the facet.url and facet.connection properties.
@@ -133,10 +113,6 @@ func RenderWith(ctx context.Context, data any, format, entryFile, srcDir string,
 	}
 
 	if server.Configured() {
-		if err := server.requireSecureToken(); err != nil {
-			return nil, err
-		}
-
 		httpOpts := RenderHTTPOptions{TimestampURL: server.TimestampURL}
 
 		var rendered []byte

--- a/report/resolve_test.go
+++ b/report/resolve_test.go
@@ -76,16 +76,19 @@ var _ = ginkgo.Describe("ResolveServer", func() {
 
 var _ = ginkgo.Describe("Render", func() {
 	var (
-		ctx      context.Context
-		server   *httptest.Server
-		rendered = []byte("<html><body>Rendered</body></html>")
+		ctx       context.Context
+		server    *httptest.Server
+		gotAPIKey string
+		rendered  = []byte("<html><body>Rendered</body></html>")
 	)
 
 	ginkgo.BeforeEach(func() {
 		ctx = context.New()
 		ctx.ClearCache()
+		gotAPIKey = ""
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAPIKey = r.Header.Get("X-API-Key")
 			Expect(r.ParseMultipartForm(32 << 20)).To(Succeed())
 
 			var options map[string]any
@@ -113,26 +116,19 @@ var _ = ginkgo.Describe("Render", func() {
 		Expect(result.Data).To(Equal(rendered))
 	})
 
-	ginkgo.It("refuses to send the api key over plaintext http", func() {
-		_, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
+	ginkgo.It("sends the api key to the configured server", func() {
+		result, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
 			Server{BaseURL: server.URL, Token: "secret-token"})
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("refusing to send the facet api key"))
-		Expect(err.Error()).ToNot(ContainSubstring("secret-token"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Data).To(Equal(rendered))
+		Expect(gotAPIKey).To(Equal("secret-token"))
 	})
 
-	ginkgo.It("allows a token over https", func() {
-		// Fails to connect rather than being refused: the guard passed.
-		_, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
-			Server{BaseURL: "https://facet.invalid", Token: "secret-token"})
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).ToNot(ContainSubstring("refusing to send"))
-	})
-
-	ginkgo.It("allows plaintext http when no token is set", func() {
+	ginkgo.It("sends no api key when the server has no token", func() {
 		result, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
 			Server{BaseURL: server.URL})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.Data).To(Equal(rendered))
+		Expect(gotAPIKey).To(BeEmpty())
 	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured server tokens are now sent correctly when rendering facets.
  * Token transmission no longer depends on the server URL using HTTPS.
  * Requests omit the authentication header when no token is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->