### PR TITLE
fix: remove validations from playbook crd to reduce estimation cost

### DIFF
--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -740,8 +740,6 @@ type CatalogAction struct {
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" template:"true"`
 }
 
-// +kubebuilder:validation:XValidation:rule="!(has(self.view) && self.view != \"\" && (has(self.configs) || (has(self.configsFromParams) && self.configsFromParams) || has(self.file)))",message="view is mutually exclusive with configs, configsFromParams, and file"
-// +kubebuilder:validation:XValidation:rule="!(has(self.configs) && has(self.configsFromParams) && self.configsFromParams)",message="configs and configsFromParams are mutually exclusive"
 type ReportAction struct {
 	// Reference an existing View by namespace/name or just name
 	View string `json:"view,omitempty" yaml:"view,omitempty" template:"true"`
@@ -834,7 +832,6 @@ type ReportSections struct {
 
 // ReportFile selects the TSX template used to render the catalog report,
 // either from a git repository or a local file path.
-// +kubebuilder:validation:XValidation:rule="has(self.path) != has(self.git)",message="exactly one of path or git must be set"
 type ReportFile struct {
 	// Path to a local TSX file. A relative path is resolved against the
 	// working directory (e.g. "report/CatalogReport.tsx"); an absolute path is
@@ -985,6 +982,29 @@ func (p *PlaybookAction) Validate() error {
 
 	if primaryCount == 0 && p.GitOps == nil && p.Notification == nil {
 		return fmt.Errorf("action %q is empty", name)
+	}
+
+	if p.Report != nil {
+		if err := p.Report.Validate(); err != nil {
+			return fmt.Errorf("action %q: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the report action selects its config items from exactly one source.
+func (r *ReportAction) Validate() error {
+	if r.View != "" && (r.Configs != nil || r.ConfigsFromParams || r.File != nil) {
+		return fmt.Errorf("view is mutually exclusive with configs, configsFromParams, and file")
+	}
+
+	if r.Configs != nil && r.ConfigsFromParams {
+		return fmt.Errorf("configs and configsFromParams are mutually exclusive")
+	}
+
+	if r.File != nil && (r.File.Path != "") == (r.File.Git != nil) {
+		return fmt.Errorf("exactly one of path or git must be set")
 	}
 
 	return nil

--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -1007,6 +1007,10 @@ func (r *ReportAction) Validate() error {
 		return fmt.Errorf("exactly one of path or git must be set")
 	}
 
+	if r.View == "" && r.Configs == nil && !r.ConfigsFromParams {
+		return fmt.Errorf("either view, configs, or configsFromParams must be specified")
+	}
+
 	return nil
 }
 

--- a/api/v1/playbook_validation_test.go
+++ b/api/v1/playbook_validation_test.go
@@ -34,4 +34,50 @@ var _ = ginkgo.Describe("ParseAndValidatePlaybookSpec", func() {
 
 		Expect(err).To(MatchError(ContainSubstring("all actions should have unique names")))
 	})
+
+	reportSpec := func(report string) []byte {
+		return []byte(`{"actions": [{"name": "report", "report": ` + report + `}]}`)
+	}
+
+	ginkgo.It("accepts a report action with only a view", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"view": "my-view"}`))
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	ginkgo.It("rejects a report action with both view and configs", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"view": "my-view", "configs": {"name": "my-config"}}`))
+
+		Expect(err).To(MatchError(ContainSubstring("view is mutually exclusive with configs, configsFromParams, and file")))
+	})
+
+	ginkgo.It("rejects a report action with both view and configsFromParams", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"view": "my-view", "configsFromParams": true}`))
+
+		Expect(err).To(MatchError(ContainSubstring("view is mutually exclusive with configs, configsFromParams, and file")))
+	})
+
+	ginkgo.It("rejects a report action with both view and file", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"view": "my-view", "file": {"path": "report/CatalogReport.tsx"}}`))
+
+		Expect(err).To(MatchError(ContainSubstring("view is mutually exclusive with configs, configsFromParams, and file")))
+	})
+
+	ginkgo.It("rejects a report action with both configs and configsFromParams", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"configs": {"name": "my-config"}, "configsFromParams": true}`))
+
+		Expect(err).To(MatchError(ContainSubstring("configs and configsFromParams are mutually exclusive")))
+	})
+
+	ginkgo.It("rejects a report file with both path and git", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"configsFromParams": true, "file": {"path": "a.tsx", "git": {"url": "https://github.com/org/repo", "file": "b.tsx"}}}`))
+
+		Expect(err).To(MatchError(ContainSubstring("exactly one of path or git must be set")))
+	})
+
+	ginkgo.It("rejects a report file with neither path nor git", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"configsFromParams": true, "file": {}}`))
+
+		Expect(err).To(MatchError(ContainSubstring("exactly one of path or git must be set")))
+	})
 })

--- a/api/v1/playbook_validation_test.go
+++ b/api/v1/playbook_validation_test.go
@@ -45,6 +45,12 @@ var _ = ginkgo.Describe("ParseAndValidatePlaybookSpec", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	ginkgo.It("rejects a report action with no config source", func() {
+		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{}`))
+
+		Expect(err).To(MatchError(ContainSubstring("either view, configs, or configsFromParams must be specified")))
+	})
+
 	ginkgo.It("rejects a report action with both view and configs", func() {
 		_, err := ParseAndValidatePlaybookSpec(reportSpec(`{"view": "my-view", "configs": {"name": "my-config"}}`))
 

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -4530,9 +4530,6 @@ spec:
                                 used as-is. The file's directory must contain the report scaffold.
                               type: string
                           type: object
-                          x-kubernetes-validations:
-                          - message: exactly one of path or git must be set
-                            rule: has(self.path) != has(self.git)
                         filters:
                           description: |-
                             Filters are appended to the embedded report settings filters. Explicit
@@ -4613,15 +4610,6 @@ spec:
                             or just name
                           type: string
                       type: object
-                      x-kubernetes-validations:
-                      - message: view is mutually exclusive with configs, configsFromParams,
-                          and file
-                        rule: '!(has(self.view) && self.view != "" && (has(self.configs)
-                          || (has(self.configsFromParams) && self.configsFromParams)
-                          || has(self.file)))'
-                      - message: configs and configsFromParams are mutually exclusive
-                        rule: '!(has(self.configs) && has(self.configsFromParams)
-                          && self.configsFromParams)'
                     retry:
                       description: Retry specifies the retry policy for the action.
                       properties:


### PR DESCRIPTION
`Helm upgrade failed for release mission-control/mission-control-mission-control-beta-mission-control-tenant with chart mission-control@0.1.328-beta.64: failed to apply CustomResourceDefinitions: failed to update CustomResourceDefinition(s): failed to replace object: CustomResourceDefinition.apiextensions.k8s.io "playbooks.mission-control.flanksource.com" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[actions].items.properties[report].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of 1.363149x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)`