### PR TITLE
chore(playbook): add facet timeout option

### DIFF
--- a/api/v1/playbook_actions.go
+++ b/api/v1/playbook_actions.go
@@ -706,8 +706,11 @@ type FacetPDFOptions struct {
 }
 
 type FacetOptions struct {
-	Connection         string `json:"connection,omitempty" yaml:"connection,omitempty" template:"true"`
-	URL                string `json:"url,omitempty" yaml:"url,omitempty" template:"true"`
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty" template:"true"`
+	URL        string `json:"url,omitempty" yaml:"url,omitempty" template:"true"`
+	// Timeout for the render, e.g. "10m". When unset the facet server's own
+	// render timeout applies.
+	Timeout            string `json:"timeout,omitempty" yaml:"timeout,omitempty" template:"true"`
 	FacetRenderOptions `json:",inline" yaml:",inline"`
 }
 

--- a/config/crds/mission-control.flanksource.com_playbooks.yaml
+++ b/config/crds/mission-control.flanksource.com_playbooks.yaml
@@ -4490,6 +4490,11 @@ spec:
                               type: object
                             pageSize:
                               type: string
+                            timeout:
+                              description: |-
+                                Timeout for the render, e.g. "10m". When unset the facet server's own
+                                render timeout applies.
+                              type: string
                             timestampUrl:
                               type: string
                             url:

--- a/config/crds/mission-control.flanksource.com_views.yaml
+++ b/config/crds/mission-control.flanksource.com_views.yaml
@@ -634,6 +634,11 @@ spec:
                     type: object
                   pageSize:
                     type: string
+                  timeout:
+                    description: |-
+                      Timeout for the render, e.g. "10m". When unset the facet server's own
+                      render timeout applies.
+                    type: string
                   timestampUrl:
                     type: string
                   url:

--- a/config/schemas/playbook-spec.schema.json
+++ b/config/schemas/playbook-spec.schema.json
@@ -592,6 +592,10 @@
         "url": {
           "type": "string"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout for the render, e.g. \"10m\". When unset the facet server's own\nrender timeout applies."
+        },
         "pageSize": {
           "type": "string"
         },

--- a/config/schemas/playbook.schema.json
+++ b/config/schemas/playbook.schema.json
@@ -623,6 +623,10 @@
         "url": {
           "type": "string"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout for the render, e.g. \"10m\". When unset the facet server's own\nrender timeout applies."
+        },
         "pageSize": {
           "type": "string"
         },

--- a/config/schemas/view.schema.json
+++ b/config/schemas/view.schema.json
@@ -373,6 +373,10 @@
         "url": {
           "type": "string"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout for the render, e.g. \"10m\". When unset the facet server's own\nrender timeout applies."
+        },
         "pageSize": {
           "type": "string"
         },

--- a/playbook/actions/report.go
+++ b/playbook/actions/report.go
@@ -210,9 +210,9 @@ func (r *Report) renderCatalogFacet(ctx context.Context, action v1.ReportAction,
 	}
 
 	if server.Configured() {
-		r.logf(ctx, "rendering %s via facet service %s", facetFormat, server.BaseURL)
+		r.logf(ctx, "rendering %s via facet service %s%s", facetFormat, server.BaseURL, timeoutSuffix(server.Timeout))
 	} else {
-		r.logf(ctx, "rendering %s via local facet binary", facetFormat)
+		r.logf(ctx, "rendering %s via local facet binary%s", facetFormat, timeoutSuffix(server.Timeout))
 	}
 
 	result, err := report.RenderWith(ctx, data, facetFormat, entryFile, srcDir, server)
@@ -220,6 +220,15 @@ func (r *Report) renderCatalogFacet(ctx context.Context, action v1.ReportAction,
 		return nil, err
 	}
 	return result.Data, nil
+}
+
+// timeoutSuffix names the render timeout for progress logs. Renders with no
+// configured timeout are bounded by the facet server, so there is nothing to say.
+func timeoutSuffix(timeout time.Duration) string {
+	if timeout <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (timeout %s)", timeout)
 }
 
 // catalogOptions builds the catalog report options from the action. When no

--- a/report/facet.go
+++ b/report/facet.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	gocontext "context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -14,11 +16,16 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	commonshttp "github.com/flanksource/commons/http"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/context"
 )
+
+// clientTimeoutGrace is how much longer the HTTP client waits than the render
+// timeout it asks the facet server for, so the server's timeout response wins.
+const clientTimeoutGrace = 30 * time.Second
 
 // RenderResult contains the rendered output and metadata about the render.
 type RenderResult struct {
@@ -31,7 +38,7 @@ type RenderResult struct {
 // RenderCLI renders data to the given format using the local facet CLI binary.
 // With -v (log level 1): prints the facet command and tees stdout/stderr.
 // With -vv (log level 2): also keeps the data file and report dir for re-rendering.
-func RenderCLI(data any, format, entryFile string) (*RenderResult, error) {
+func RenderCLI(ctx context.Context, data any, format, entryFile string, timeout time.Duration) (*RenderResult, error) {
 	srcDir, err := SrcDir()
 	if err != nil {
 		return nil, fmt.Errorf("prepare facet src dir: %w", err)
@@ -39,13 +46,15 @@ func RenderCLI(data any, format, entryFile string) (*RenderResult, error) {
 	if _, override := ResolveSource(); override != "" {
 		entryFile = override
 	}
-	return RenderCLIFromDir(data, format, srcDir, entryFile)
+	return RenderCLIFromDir(ctx, data, format, srcDir, entryFile, timeout)
 }
 
 // RenderCLIFromDir renders data using the facet CLI binary against an explicit
 // source directory and entry file. The directory must contain the report
 // scaffold (package.json, components, etc.) needed to compile the entry file.
-func RenderCLIFromDir(data any, format, srcDir, entryFile string) (*RenderResult, error) {
+// The facet process is killed when it exceeds timeout; a zero timeout lets it
+// run to completion.
+func RenderCLIFromDir(ctx context.Context, data any, format, srcDir, entryFile string, timeout time.Duration) (*RenderResult, error) {
 	verbose := logger.IsLevelEnabled(1)
 	keepFiles := logger.IsLevelEnabled(2)
 
@@ -79,8 +88,15 @@ func RenderCLIFromDir(data any, format, srcDir, entryFile string) (*RenderResult
 	outFile.Close()
 	defer os.Remove(outFile.Name())
 
+	renderCtx := gocontext.Context(ctx)
+	if timeout > 0 {
+		var cancel gocontext.CancelFunc
+		renderCtx, cancel = gocontext.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command(facetBin, format, entryFile, "-d", dataFile.Name(), "-o", outFile.Name())
+	cmd := exec.CommandContext(renderCtx, facetBin, format, entryFile, "-d", dataFile.Name(), "-o", outFile.Name())
 	cmd.Dir = srcDir
 
 	fmt.Fprintf(os.Stderr, "$ cd %s\n", srcDir)
@@ -93,6 +109,9 @@ func RenderCLIFromDir(data any, format, srcDir, entryFile string) (*RenderResult
 	}
 
 	if err = cmd.Run(); err != nil {
+		if errors.Is(renderCtx.Err(), gocontext.DeadlineExceeded) {
+			return nil, fmt.Errorf("facet %s timed out after %s", format, timeout)
+		}
 		return nil, facetCommandError(format, err, stdout.String(), stderr.String())
 	}
 
@@ -125,6 +144,11 @@ func facetCommandError(format string, err error, stdout string, stderr string) e
 
 type RenderHTTPOptions struct {
 	TimestampURL string
+
+	// Timeout bounds the render on the facet server. The HTTP client waits
+	// longer than the server so a server-side timeout is reported as such.
+	// Zero leaves the render bounded by the server's own timeout.
+	Timeout time.Duration
 }
 
 // RenderHTTP renders data via a remote facet rendering service using the
@@ -153,12 +177,19 @@ func renderHTTPWithArchive(ctx context.Context, baseURL, token string, archive [
 		return nil, fmt.Errorf("marshal data: %w", err)
 	}
 
+	var timeout time.Duration
 	renderOpts := map[string]any{
 		"format":    format,
 		"entryFile": entryFile,
 	}
-	if len(opts) > 0 && opts[0].TimestampURL != "" {
-		renderOpts["timestampUrl"] = opts[0].TimestampURL
+	if len(opts) > 0 {
+		if opts[0].TimestampURL != "" {
+			renderOpts["timestampUrl"] = opts[0].TimestampURL
+		}
+		if opts[0].Timeout > 0 {
+			timeout = opts[0].Timeout
+			renderOpts["timeout"] = timeout.Milliseconds()
+		}
 	}
 	optionsJSON, err := json.Marshal(renderOpts)
 	if err != nil {
@@ -189,6 +220,13 @@ func renderHTTPWithArchive(ctx context.Context, baseURL, token string, archive [
 	}
 
 	client := commonshttp.NewClient().BaseURL(baseURL)
+	if timeout > 0 {
+		client = client.Timeout(timeout + clientTimeoutGrace)
+	} else {
+		// The facet server bounds the render, so the client must not give up
+		// first — its own default is 2 minutes.
+		client = client.Timeout(0)
+	}
 	if token != "" {
 		client = client.Header("X-API-Key", token)
 	}

--- a/report/resolve.go
+++ b/report/resolve.go
@@ -3,6 +3,9 @@
 package report
 
 import (
+	"time"
+
+	"github.com/flanksource/commons/duration"
 	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/connection"
 	"github.com/flanksource/duty/context"
@@ -27,6 +30,10 @@ type Server struct {
 	BaseURL      string
 	Token        string
 	TimestampURL string
+
+	// Timeout bounds the render. Zero leaves the render bounded by the facet
+	// server's own timeout.
+	Timeout time.Duration
 }
 
 func (s Server) Configured() bool { return s.BaseURL != "" }
@@ -34,6 +41,38 @@ func (s Server) Configured() bool { return s.BaseURL != "" }
 // ResolveServer resolves the facet rendering server, preferring the report
 // options and falling back to the facet.url and facet.connection properties.
 func ResolveServer(ctx context.Context, opts *v1.FacetOptions) (Server, error) {
+	server, err := resolveServer(ctx, opts)
+	if err != nil {
+		return Server{}, err
+	}
+
+	server.Timeout, err = resolveTimeout(opts)
+	if err != nil {
+		return Server{}, err
+	}
+
+	return server, nil
+}
+
+// resolveTimeout parses the render timeout from the options. An unset timeout
+// resolves to zero, leaving the render bounded by the facet server.
+func resolveTimeout(opts *v1.FacetOptions) (time.Duration, error) {
+	if opts == nil || opts.Timeout == "" {
+		return 0, nil
+	}
+
+	parsed, err := duration.ParseDuration(opts.Timeout)
+	if err != nil {
+		return 0, dutyAPI.Errorf(dutyAPI.EINVALID, "invalid facet timeout %q: %v", opts.Timeout, err)
+	}
+	if parsed <= 0 {
+		return 0, dutyAPI.Errorf(dutyAPI.EINVALID, "invalid facet timeout %q: must be positive", opts.Timeout)
+	}
+
+	return time.Duration(parsed), nil
+}
+
+func resolveServer(ctx context.Context, opts *v1.FacetOptions) (Server, error) {
 	var timestampURL string
 	if opts != nil {
 		timestampURL = opts.TimestampURL
@@ -113,7 +152,7 @@ func RenderWith(ctx context.Context, data any, format, entryFile, srcDir string,
 	}
 
 	if server.Configured() {
-		httpOpts := RenderHTTPOptions{TimestampURL: server.TimestampURL}
+		httpOpts := RenderHTTPOptions{TimestampURL: server.TimestampURL, Timeout: server.Timeout}
 
 		var rendered []byte
 		var err error
@@ -129,7 +168,7 @@ func RenderWith(ctx context.Context, data any, format, entryFile, srcDir string,
 	}
 
 	if srcDir == "" {
-		return RenderCLI(data, format, entryFile)
+		return RenderCLI(ctx, data, format, entryFile, server.Timeout)
 	}
-	return RenderCLIFromDir(data, format, srcDir, entryFile)
+	return RenderCLIFromDir(ctx, data, format, srcDir, entryFile, server.Timeout)
 }

--- a/report/resolve_test.go
+++ b/report/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/flanksource/commons/properties"
 	"github.com/flanksource/duty/context"
@@ -72,20 +73,40 @@ var _ = ginkgo.Describe("ResolveServer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(server.TimestampURL).To(Equal("http://tsa.local"))
 	})
+
+	ginkgo.It("parses the render timeout from the options", func() {
+		server, err := ResolveServer(ctx, &v1.FacetOptions{URL: "http://facet.local", Timeout: "5m"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(server.Timeout).To(Equal(5 * time.Minute))
+	})
+
+	ginkgo.It("leaves the render timeout to the facet server when the options don't set one", func() {
+		server, err := ResolveServer(ctx, &v1.FacetOptions{URL: "http://facet.local"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(server.Timeout).To(BeZero())
+	})
+
+	ginkgo.It("fails on an invalid render timeout", func() {
+		_, err := ResolveServer(ctx, &v1.FacetOptions{URL: "http://facet.local", Timeout: "soon"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("soon"))
+	})
 })
 
 var _ = ginkgo.Describe("Render", func() {
 	var (
-		ctx       context.Context
-		server    *httptest.Server
-		gotAPIKey string
-		rendered  = []byte("<html><body>Rendered</body></html>")
+		ctx        context.Context
+		server     *httptest.Server
+		gotAPIKey  string
+		gotOptions map[string]any
+		rendered   = []byte("<html><body>Rendered</body></html>")
 	)
 
 	ginkgo.BeforeEach(func() {
 		ctx = context.New()
 		ctx.ClearCache()
 		gotAPIKey = ""
+		gotOptions = nil
 
 		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotAPIKey = r.Header.Get("X-API-Key")
@@ -94,6 +115,7 @@ var _ = ginkgo.Describe("Render", func() {
 			var options map[string]any
 			Expect(json.Unmarshal([]byte(r.FormValue("options")), &options)).To(Succeed())
 			Expect(options["entryFile"]).To(Equal("CatalogReport.tsx"))
+			gotOptions = options
 
 			w.Header().Set("Content-Type", "text/html")
 			_, err := w.Write(rendered)
@@ -130,5 +152,19 @@ var _ = ginkgo.Describe("Render", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.Data).To(Equal(rendered))
 		Expect(gotAPIKey).To(BeEmpty())
+	})
+
+	ginkgo.It("sends the render timeout in milliseconds", func() {
+		_, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
+			Server{BaseURL: server.URL, Timeout: 90 * time.Second})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotOptions["timeout"]).To(BeEquivalentTo(90_000))
+	})
+
+	ginkgo.It("sends no render timeout when none is configured", func() {
+		_, err := RenderWith(ctx, map[string]string{"key": "value"}, "html", "CatalogReport.tsx", "",
+			Server{BaseURL: server.URL})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotOptions).ToNot(HaveKey("timeout"))
 	})
 })


### PR DESCRIPTION
Fixes: #3389 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configurable timeouts for report facet and PDF rendering.
  * Supports duration values with server-default behavior when no timeout is specified.
  * Rendering progress now displays the configured timeout when applicable.

* **Bug Fixes**
  * Improved timeout handling and error reporting for local and remote rendering.
  * Invalid timeout values are now rejected with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->