### PR TITLE
fix: stabilize email report playbook E2E test

### DIFF
--- a/tests/e2e/playbooks_test.go
+++ b/tests/e2e/playbooks_test.go
@@ -106,11 +106,6 @@ var _ = ginkgo.Describe("Playbooks", ginkgo.Ordered, func() {
 		panic(fmt.Sprintf("failed to glob playbook fixtures: %v", err))
 	}
 
-	// Fixtures that are flaky in CI and need multiple attempts.
-	flakyFixtures := map[string]int{
-		// "email-report": 5,
-	}
-
 	for _, fixturePath := range fixtures {
 		setup := peekFixtureSetup(fixturePath)
 		name := strings.TrimSuffix(filepath.Base(fixturePath), ".yaml")
@@ -122,14 +117,10 @@ var _ = ginkgo.Describe("Playbooks", ginkgo.Ordered, func() {
 			}
 		}
 
-		if attempts, ok := flakyFixtures[name]; ok {
-			decorators = append(decorators, ginkgo.FlakeAttempts(attempts))
-		}
-
 		// facet-pdf-report uses an older view-report path that is still incompatible
 		// with the Facet test container. Catalog report rendering is covered by the
 		// multi-root HTML fixture.
-		if name == "email-report" || name == "facet-pdf-report" {
+		if name == "facet-pdf-report" {
 			decorators = append(decorators, ginkgo.Pending)
 		}
 

--- a/tests/e2e/testdata/playbooks/email-report.yaml
+++ b/tests/e2e/testdata/playbooks/email-report.yaml
@@ -20,21 +20,23 @@ playbook:
       label: SMTP URL
   actions:
     - name: generate-report
+      timeout: 30s
       report:
         view: $(.params.view)
         format: html
-    - name: generate-pdf
+    - name: generate-attachment
+      timeout: 30s
       report:
         view: $(.params.view)
-        format: pdf
+        format: html
     - name: send-email
       notification:
         url: $(.params.smtp_url)
         title: Pod Report
         message: '{{(getAction "generate-report").result.format}}'
         attachments:
-          - content: artifact://generate-pdf/*.pdf
-            filename: report.pdf
+          - content: artifact://generate-attachment/*.html
+            filename: report.html
 
 output:
   run:
@@ -46,17 +48,17 @@ output:
         format: html
       artifacts:
         - content_type: text/html
-    - name: generate-pdf
+    - name: generate-attachment
       status: completed
       result:
-        format: pdf
+        format: html
       artifacts:
-        - content_type: application/pdf
+        - content_type: text/html
     - name: send-email
       status: completed
 
 assertions:
   - size(emails) >= 1
   - emails[0].body.contains('Pod Report')
-  - emails[0].body.contains('report.pdf')
-  - emails[0].body.contains('application/pdf')
+  - emails[0].body.contains('report.html')
+  - emails[0].body.contains('text/html')


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2943

The fixture rendered a view as `format: pdf`. That format doesn't route to the facet container - only `facet-pdf` does - so it fell through to clicky, which produces PDFs by writing HTML to a temp file and launching headless Chrome to print it. This step can fail if chrome isn't installed or the CDN takes a long time to respond.

The fix swaps the PDF step for a second HTML report, which clicky builds in-process with no browser and no network, and adds a 30s action timeout as a backstop. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email report testing to use HTML attachments and validate the correct content type and filename.
  * Removed an unused flaky-test retry configuration.
  * Restored coverage for the email report scenario; only the PDF report scenario remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->