### PR TITLE
Add OAuth 2.0 Dynamic Client Registration for MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,33 @@ flanksource-ui:
 
 ### Setting up MCP
 
+The MCP endpoint is served at `/mcp` and authenticates with OAuth against Mission
+Control's embedded OIDC provider. Start the server with `--oidc` to enable it.
+
+Clients register themselves through OAuth 2.0 Dynamic Client Registration
+([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), so there is no
+client ID to configure. On first connection the client discovers the
+authorization server, registers, and opens a browser for you to log in and
+approve it. Approval shows the application's name and the address it will be
+redirected to — check that address before allowing.
+
+Users additionally need the `mcp:use` permission.
+
 #### Claude
 
-Install mcp-remote: `npm i -g mcp-remote`
+Add a custom connector pointing at `https://<mission-control>/mcp`.
 
-Update mcp server settings in `$HOME/.config/Claude/claude_desktop_config.json`
+#### Codex CLI
+
+```sh
+codex mcp add mission-control --url https://<mission-control>/mcp
+codex mcp login mission-control
+```
+
+#### Clients without remote MCP support
+
+Older clients can bridge over stdio with
+[mcp-remote](https://www.npmjs.com/package/mcp-remote) (`npm i -g mcp-remote`):
 
 ```json
 {
@@ -180,5 +202,4 @@ Update mcp server settings in `$HOME/.config/Claude/claude_desktop_config.json`
     }
   }
 }
-
 ```

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -215,6 +215,14 @@ func setWWWAuthenticate(c echo.Context) {
 	if OIDCEnabled {
 		resourceMetadataURL := OIDCIssuerURL() + "/.well-known/oauth-protected-resource"
 		c.Response().Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
+		if c.Request().URL.Path == oidc.MCPResourcePath {
+			header := c.Response().Header()
+			header.Set("Access-Control-Allow-Origin", "*")
+			header.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			header.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID")
+			header.Set("Access-Control-Expose-Headers", "WWW-Authenticate, MCP-Session-Id")
+			header.Del("Access-Control-Allow-Credentials")
+		}
 	}
 }
 

--- a/auth/dcr_test.go
+++ b/auth/dcr_test.go
@@ -1,0 +1,411 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	"github.com/flanksource/incident-commander/auth/oidc"
+	"github.com/labstack/echo/v4"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Regression coverage for https://github.com/flanksource/mission-control/issues/2932
+// — the OAuth surface Claude Desktop and Codex CLI drive when connecting to /mcp.
+var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
+	var e *echo.Echo
+
+	ginkgo.BeforeEach(func() {
+		e = newEchoInstance(DefaultContext)
+		Expect(oidc.MountRoutes(e, DefaultContext, "http://localhost:8080", &mockChecker{valid: true}, nil, mockLookup)).To(Succeed())
+	})
+
+	serve := func(req *http.Request) *httptest.ResponseRecorder {
+		req = req.WithContext(DefaultContext.Wrap(req.Context()))
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	registerClient := func(body string) map[string]any {
+		req := httptest.NewRequest(http.MethodPost, oidc.RegistrationEndpoint, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := serve(req)
+
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+		var resp map[string]any
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		return resp
+	}
+
+	ginkgo.Describe("discovery", func() {
+		for _, path := range []string{
+			"/.well-known/openid-configuration",
+			"/.well-known/oauth-authorization-server",
+		} {
+			ginkgo.It("advertises registration and S256 at "+path, func() {
+				rec := serve(httptest.NewRequest(http.MethodGet, path, nil))
+				Expect(rec.Code).To(Equal(http.StatusOK))
+
+				var doc map[string]any
+				Expect(json.Unmarshal(rec.Body.Bytes(), &doc)).To(Succeed())
+
+				Expect(doc["registration_endpoint"]).To(Equal("http://localhost:8080" + oidc.RegistrationEndpoint))
+				Expect(doc["code_challenge_methods_supported"]).To(ContainElement("S256"))
+				Expect(doc["issuer"]).To(Equal("http://localhost:8080"))
+				Expect(doc["authorization_endpoint"]).To(Equal("http://localhost:8080/authorize"))
+			})
+		}
+
+		ginkgo.It("serves RFC 8414 metadata for a path-suffixed issuer", func() {
+			rec := serve(httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp", nil))
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+
+		ginkgo.It("still serves protected resource metadata", func() {
+			rec := serve(httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var doc map[string]any
+			Expect(json.Unmarshal(rec.Body.Bytes(), &doc)).To(Succeed())
+			Expect(doc["resource"]).To(HaveSuffix("/mcp"))
+		})
+	})
+
+	ginkgo.It("completes registration, authorization, consent and code issuance", func() {
+		client := registerClient(`{
+			"client_name": "Claude Desktop",
+			"redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+			"grant_types": ["authorization_code", "refresh_token"],
+			"response_types": ["code"],
+			"token_endpoint_auth_method": "none"
+		}`)
+		clientID := client["client_id"].(string)
+
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":             {clientID},
+			"response_type":         {"code"},
+			"redirect_uri":          {"https://claude.ai/api/mcp/auth_callback"},
+			"scope":                 {"openid profile email offline_access"},
+			"state":                 {"state-1"},
+			"nonce":                 {"nonce-1"},
+			"code_challenge":        {"challenge-1"},
+			"code_challenge_method": {"S256"},
+			// Claude sends an RFC 8707 resource indicator; it must not break the flow.
+			"resource": {"http://localhost:8080/mcp"},
+		}.Encode()
+
+		authorizeRec := serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil))
+		Expect(authorizeRec.Code).To(Equal(http.StatusFound))
+
+		loginURL := authorizeRec.Header().Get("Location")
+		Expect(loginURL).To(ContainSubstring("/oidc/login?auth_request_id="))
+
+		cookies := authorizeRec.Result().Cookies()
+		Expect(cookies).ToNot(BeEmpty())
+		txCookie := cookies[0]
+
+		parsedLoginURL, err := url.Parse(loginURL)
+		Expect(err).ToNot(HaveOccurred())
+		authRequestID := parsedLoginURL.Query().Get("auth_request_id")
+		Expect(authRequestID).ToNot(BeEmpty())
+
+		// Log in.
+		loginReq := httptest.NewRequest(http.MethodPost, "/oidc/login",
+			strings.NewReader(url.Values{
+				"auth_request_id": {authRequestID},
+				"username":        {"admin"},
+				"password":        {"admin"},
+			}.Encode()))
+		loginReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		loginReq.AddCookie(txCookie)
+		loginRec := serve(loginReq)
+
+		// A dynamically registered client must divert through consent rather
+		// than issuing the code straight away.
+		Expect(loginRec.Code).To(Equal(http.StatusFound))
+		Expect(loginRec.Header().Get("Location")).To(Equal("/oidc/consent?auth_request_id=" + authRequestID))
+
+		// The consent screen must name the client and show where the code goes.
+		consentReq := httptest.NewRequest(http.MethodGet, "/oidc/consent?auth_request_id="+authRequestID, nil)
+		consentReq.AddCookie(txCookie)
+		consentRec := serve(consentReq)
+
+		Expect(consentRec.Code).To(Equal(http.StatusOK))
+		Expect(consentRec.Body.String()).To(ContainSubstring("Claude Desktop"))
+		Expect(consentRec.Body.String()).To(ContainSubstring("https://claude.ai/api/mcp/auth_callback"))
+
+		// Approving redirects into the provider's callback, which issues the code.
+		approveReq := httptest.NewRequest(http.MethodPost, "/oidc/consent",
+			strings.NewReader(url.Values{
+				"auth_request_id": {authRequestID},
+				"decision":        {"allow"},
+			}.Encode()))
+		approveReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		approveReq.AddCookie(txCookie)
+		approveRec := serve(approveReq)
+
+		Expect(approveRec.Code).To(Equal(http.StatusFound))
+		Expect(approveRec.Header().Get("Location")).To(ContainSubstring("/authorize/callback?id=" + authRequestID))
+
+		callbackReq := httptest.NewRequest(http.MethodGet, "/authorize/callback?id="+authRequestID, nil)
+		callbackReq.AddCookie(txCookie)
+		callbackRec := serve(callbackReq)
+
+		Expect(callbackRec.Code).To(Equal(http.StatusFound))
+		redirect, err := url.Parse(callbackRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(redirect.Scheme + "://" + redirect.Host + redirect.Path).To(Equal("https://claude.ai/api/mcp/auth_callback"))
+		Expect(redirect.Query().Get("code")).ToNot(BeEmpty())
+		Expect(redirect.Query().Get("state")).To(Equal("state-1"))
+	})
+
+	ginkgo.It("exchanges the code and refreshes for a dynamically registered client", func() {
+		client := registerClient(`{"client_name":"Codex","redirect_uris":["http://127.0.0.1:1455/auth/callback"]}`)
+		clientID := client["client_id"].(string)
+
+		// A real PKCE pair — zitadel mandates PKCE for public clients and
+		// verifies the challenge at the token endpoint.
+		verifierBytes := make([]byte, 32)
+		_, err := rand.Read(verifierBytes)
+		Expect(err).ToNot(HaveOccurred())
+		verifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+		sum := sha256.Sum256([]byte(verifier))
+		challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+		const redirectURI = "http://127.0.0.1:1455/auth/callback"
+
+		authorizeRec := serve(httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+			"client_id":             {clientID},
+			"response_type":         {"code"},
+			"redirect_uri":          {redirectURI},
+			"scope":                 {"openid profile email offline_access"},
+			"state":                 {"state-tok"},
+			"code_challenge":        {challenge},
+			"code_challenge_method": {"S256"},
+		}.Encode(), nil))
+		Expect(authorizeRec.Code).To(Equal(http.StatusFound))
+		txCookie := authorizeRec.Result().Cookies()[0]
+
+		parsedLoginURL, err := url.Parse(authorizeRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		authRequestID := parsedLoginURL.Query().Get("auth_request_id")
+
+		loginReq := httptest.NewRequest(http.MethodPost, "/oidc/login",
+			strings.NewReader(url.Values{
+				"auth_request_id": {authRequestID}, "username": {"admin"}, "password": {"admin"},
+			}.Encode()))
+		loginReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		loginReq.AddCookie(txCookie)
+		Expect(serve(loginReq).Code).To(Equal(http.StatusFound))
+
+		approveReq := httptest.NewRequest(http.MethodPost, "/oidc/consent",
+			strings.NewReader(url.Values{"auth_request_id": {authRequestID}, "decision": {"allow"}}.Encode()))
+		approveReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		approveReq.AddCookie(txCookie)
+		Expect(serve(approveReq).Code).To(Equal(http.StatusFound))
+
+		callbackReq := httptest.NewRequest(http.MethodGet, "/authorize/callback?id="+authRequestID, nil)
+		callbackReq.AddCookie(txCookie)
+		callbackRec := serve(callbackReq)
+		Expect(callbackRec.Code).To(Equal(http.StatusFound))
+
+		redirect, err := url.Parse(callbackRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		code := redirect.Query().Get("code")
+		Expect(code).ToNot(BeEmpty())
+
+		postForm := func(form url.Values) map[string]any {
+			req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+			rec := serve(req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK), rec.Body.String())
+			var tokens map[string]any
+			Expect(json.Unmarshal(rec.Body.Bytes(), &tokens)).To(Succeed())
+			return tokens
+		}
+
+		tokens := postForm(url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {code},
+			"redirect_uri":  {redirectURI},
+			"client_id":     {clientID},
+			"code_verifier": {verifier},
+		})
+
+		accessToken, _ := tokens["access_token"].(string)
+		Expect(accessToken).ToNot(BeEmpty())
+		refreshToken, _ := tokens["refresh_token"].(string)
+		Expect(refreshToken).ToNot(BeEmpty(), "offline_access must yield a refresh token so clients survive restarts")
+
+		// The access token's audience is the dynamic client_id, which is exactly
+		// what authenticateOIDCToken has to accept for /mcp to work.
+		claims := decodeJWTClaims(accessToken)
+		Expect(audienceHasKnownClient(claims["aud"])).To(BeTrue())
+		Expect(claims["iss"]).To(Equal("http://localhost:8080"))
+
+		refreshed := postForm(url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken},
+			"client_id":     {clientID},
+		})
+		Expect(refreshed["access_token"]).ToNot(BeEmpty())
+		Expect(refreshed["refresh_token"]).ToNot(BeEmpty())
+	})
+
+	ginkgo.It("drops the authorization request when consent is denied", func() {
+		client := registerClient(`{"client_name":"Sketchy","redirect_uris":["https://claude.ai/api/mcp/auth_callback"]}`)
+
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":             {client["client_id"].(string)},
+			"response_type":         {"code"},
+			"redirect_uri":          {"https://claude.ai/api/mcp/auth_callback"},
+			"scope":                 {"openid"},
+			"state":                 {"state-2"},
+			"code_challenge":        {"challenge-2"},
+			"code_challenge_method": {"S256"},
+		}.Encode()
+
+		authorizeRec := serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil))
+		Expect(authorizeRec.Code).To(Equal(http.StatusFound))
+		txCookie := authorizeRec.Result().Cookies()[0]
+
+		parsedLoginURL, err := url.Parse(authorizeRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		authRequestID := parsedLoginURL.Query().Get("auth_request_id")
+
+		loginReq := httptest.NewRequest(http.MethodPost, "/oidc/login",
+			strings.NewReader(url.Values{
+				"auth_request_id": {authRequestID}, "username": {"admin"}, "password": {"admin"},
+			}.Encode()))
+		loginReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		loginReq.AddCookie(txCookie)
+		Expect(serve(loginReq).Code).To(Equal(http.StatusFound))
+
+		denyReq := httptest.NewRequest(http.MethodPost, "/oidc/consent",
+			strings.NewReader(url.Values{"auth_request_id": {authRequestID}, "decision": {"deny"}}.Encode()))
+		denyReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		denyReq.AddCookie(txCookie)
+		Expect(serve(denyReq).Code).To(Equal(http.StatusOK))
+
+		var count int64
+		Expect(DefaultContext.DB().Table("oidc_auth_requests").Where("id = ?", authRequestID).Count(&count).Error).To(Succeed())
+		Expect(count).To(BeZero(), "denied auth request should be deleted so no code can be issued")
+
+		// And the code can no longer be issued.
+		callbackReq := httptest.NewRequest(http.MethodGet, "/authorize/callback?id="+authRequestID, nil)
+		callbackReq.AddCookie(txCookie)
+		Expect(serve(callbackReq).Code).ToNot(Equal(http.StatusFound))
+	})
+
+	ginkgo.It("skips consent for the built-in cli client", func() {
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":             {oidc.ClientID},
+			"response_type":         {"code"},
+			"redirect_uri":          {"http://127.0.0.1:5555/callback"},
+			"scope":                 {"openid"},
+			"state":                 {"state-3"},
+			"code_challenge":        {"challenge-3"},
+			"code_challenge_method": {"S256"},
+		}.Encode()
+
+		authorizeRec := serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil))
+		Expect(authorizeRec.Code).To(Equal(http.StatusFound))
+		txCookie := authorizeRec.Result().Cookies()[0]
+
+		parsedLoginURL, err := url.Parse(authorizeRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		authRequestID := parsedLoginURL.Query().Get("auth_request_id")
+
+		loginReq := httptest.NewRequest(http.MethodPost, "/oidc/login",
+			strings.NewReader(url.Values{
+				"auth_request_id": {authRequestID}, "username": {"admin"}, "password": {"admin"},
+			}.Encode()))
+		loginReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		loginReq.AddCookie(txCookie)
+		loginRec := serve(loginReq)
+
+		Expect(loginRec.Code).To(Equal(http.StatusFound))
+		Expect(loginRec.Header().Get("Location")).To(ContainSubstring("/authorize/callback"))
+	})
+
+	ginkgo.It("rejects an authorization request for an unregistered client", func() {
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":     {"not-a-registered-client"},
+			"response_type": {"code"},
+			"redirect_uri":  {"https://evil.com/cb"},
+			"scope":         {"openid"},
+		}.Encode()
+
+		Expect(serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil)).Code).To(Equal(http.StatusBadRequest))
+	})
+
+	ginkgo.It("accepts tokens issued to a dynamically registered client", func() {
+		client := registerClient(`{"client_name":"Claude","redirect_uris":["https://claude.ai/api/mcp/auth_callback"]}`)
+		clientID := client["client_id"].(string)
+
+		Expect(audienceHasKnownClient(clientID)).To(BeTrue())
+		Expect(audienceHasKnownClient([]any{clientID})).To(BeTrue())
+		Expect(audienceHasKnownClient(oidc.ClientID)).To(BeTrue())
+		Expect(audienceHasKnownClient("some-other-client")).To(BeFalse())
+		Expect(audienceHasKnownClient(nil)).To(BeFalse())
+	})
+})
+
+var _ = ginkgo.Describe("consent transaction binding", func() {
+	ginkgo.It("requires the transaction cookie", func() {
+		e := newEchoInstance(DefaultContext)
+		Expect(oidc.MountRoutes(e, DefaultContext, "http://localhost:8080", &mockChecker{valid: true}, nil, mockLookup)).To(Succeed())
+
+		serve := func(req *http.Request) int {
+			req = req.WithContext(DefaultContext.Wrap(req.Context()))
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			return rec.Code
+		}
+
+		Expect(serve(httptest.NewRequest(http.MethodGet, "/oidc/consent?auth_request_id=req-1", nil))).
+			To(Equal(http.StatusUnauthorized))
+
+		denyReq := httptest.NewRequest(http.MethodPost, "/oidc/consent",
+			strings.NewReader(url.Values{"auth_request_id": {"req-1"}, "decision": {"allow"}}.Encode()))
+		denyReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		Expect(serve(denyReq)).To(Equal(http.StatusUnauthorized))
+	})
+})
+
+var _ = ginkgo.Describe("registration endpoint reachability", func() {
+	ginkgo.It("is not behind the auth middleware", func() {
+		e := newEchoInstance(DefaultContext)
+		e.Use(basicAuthMiddleware)
+		e.POST(oidc.RegistrationEndpoint, func(c echo.Context) error {
+			return c.NoContent(http.StatusCreated)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, oidc.RegistrationEndpoint, strings.NewReader("{}"))
+		req = req.WithContext(DefaultContext.Wrap(req.Context()))
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+	})
+})
+
+func decodeJWTClaims(token string) map[string]any {
+	parts := strings.Split(token, ".")
+	Expect(parts).To(HaveLen(3), "access token should be a JWT")
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	Expect(err).ToNot(HaveOccurred())
+
+	var claims map[string]any
+	Expect(json.Unmarshal(payload, &claims)).To(Succeed())
+	return claims
+}

--- a/auth/dcr_test.go
+++ b/auth/dcr_test.go
@@ -212,7 +212,6 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		Expect(DefaultContext.DB().Where("id = ?", authRequestID).First(&pending).Error).To(Succeed())
 		Expect(pending.Done()).To(BeFalse())
 		Expect(pending.Code).To(BeNil())
-		Expect(pending.Resource).To(Equal(oidc.MCPResourceURL("http://localhost:8080")))
 
 		// The consent screen must name the client and show where the code goes.
 		consentReq := httptest.NewRequest(http.MethodGet, "/oidc/consent?auth_request_id="+authRequestID, nil)
@@ -348,7 +347,6 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 
 		var persistedRefreshToken oidc.RefreshToken
 		Expect(DefaultContext.DB().Where("client_id = ?", clientID).Order("created_at DESC").First(&persistedRefreshToken).Error).To(Succeed())
-		Expect(persistedRefreshToken.Resource).To(Equal(resource))
 
 		claims := decodeJWTClaims(accessToken)
 		Expect(claims["aud"]).To(ConsistOf(resource))

--- a/auth/dcr_test.go
+++ b/auth/dcr_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/flanksource/incident-commander/auth/oidc"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -22,7 +23,12 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 	var e *echo.Echo
 
 	ginkgo.BeforeEach(func() {
+		ensureOIDCTables(DefaultContext)
 		e = newEchoInstance(DefaultContext)
+		e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+			AllowCredentials: true,
+			AllowOrigins:     []string{"https://configured.example.com"},
+		}))
 		Expect(oidc.MountRoutes(e, DefaultContext, "http://localhost:8080", &mockChecker{valid: true}, nil, mockLookup)).To(Succeed())
 	})
 
@@ -36,9 +42,12 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 	registerClient := func(body string) map[string]any {
 		req := httptest.NewRequest(http.MethodPost, oidc.RegistrationEndpoint, strings.NewReader(body))
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req.Header.Set("Origin", "https://inspector.example.com")
 		rec := serve(req)
 
 		Expect(rec.Code).To(Equal(http.StatusCreated))
+		Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+		Expect(rec.Header().Get("Access-Control-Allow-Credentials")).To(BeEmpty())
 		var resp map[string]any
 		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
 		return resp
@@ -50,8 +59,12 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 			"/.well-known/oauth-authorization-server",
 		} {
 			ginkgo.It("advertises registration and S256 at "+path, func() {
-				rec := serve(httptest.NewRequest(http.MethodGet, path, nil))
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.Header.Set("Origin", "https://inspector.example.com")
+				rec := serve(req)
 				Expect(rec.Code).To(Equal(http.StatusOK))
+				Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+				Expect(rec.Header().Get("Access-Control-Allow-Credentials")).To(BeEmpty())
 
 				var doc map[string]any
 				Expect(json.Unmarshal(rec.Body.Bytes(), &doc)).To(Succeed())
@@ -69,13 +82,65 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		})
 
 		ginkgo.It("still serves protected resource metadata", func() {
-			rec := serve(httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+			req.Header.Set("Origin", "https://inspector.example.com")
+			rec := serve(req)
 			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
 
 			var doc map[string]any
 			Expect(json.Unmarshal(rec.Body.Bytes(), &doc)).To(Succeed())
 			Expect(doc["resource"]).To(HaveSuffix("/mcp"))
 		})
+	})
+
+	ginkgo.It("serves credential-free OAuth preflights", func() {
+		for _, path := range []string{
+			"/.well-known/openid-configuration",
+			"/.well-known/oauth-authorization-server",
+			"/.well-known/oauth-protected-resource/mcp",
+			oidc.RegistrationEndpoint,
+			"/oauth/token",
+			"/mcp",
+		} {
+			req := httptest.NewRequest(http.MethodOptions, path, nil)
+			req.Header.Set("Origin", "https://inspector.example.com")
+			req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+			req.Header.Set("Access-Control-Request-Headers", "authorization, content-type, mcp-protocol-version")
+			rec := serve(req)
+
+			Expect(rec.Code).To(Equal(http.StatusNoContent), path)
+			Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"), path)
+			Expect(rec.Header().Get("Access-Control-Allow-Methods")).To(ContainSubstring("POST"), path)
+			Expect(rec.Header().Get("Access-Control-Allow-Headers")).To(ContainSubstring("Authorization"), path)
+			Expect(rec.Header().Get("Access-Control-Allow-Credentials")).To(BeEmpty(), path)
+		}
+	})
+
+	ginkgo.It("includes the OAuth challenge in cross-origin MCP 401 responses", func() {
+		oldOIDCEnabled := OIDCEnabled
+		oldLocalhostOnly := localhostOnly
+		defer func() {
+			OIDCEnabled = oldOIDCEnabled
+			localhostOnly = oldLocalhostOnly
+		}()
+		OIDCEnabled = true
+		localhostOnly = false
+
+		e.Use(basicAuthMiddleware)
+		e.POST("/mcp", func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Origin", "https://inspector.example.com")
+		rec := serve(req)
+
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+		Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+		Expect(rec.Header().Get("Access-Control-Expose-Headers")).To(ContainSubstring("WWW-Authenticate"))
+		Expect(rec.Header().Get("WWW-Authenticate")).To(ContainSubstring("resource_metadata="))
+		Expect(rec.Header().Get("Access-Control-Allow-Credentials")).To(BeEmpty())
 	})
 
 	ginkgo.It("completes registration, authorization, consent and code issuance", func() {
@@ -132,6 +197,23 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		Expect(loginRec.Code).To(Equal(http.StatusFound))
 		Expect(loginRec.Header().Get("Location")).To(Equal("/oidc/consent?auth_request_id=" + authRequestID))
 
+		// Calling the provider callback before consent must not issue a code.
+		prematureCallbackReq := httptest.NewRequest(http.MethodGet, "/authorize/callback?id="+authRequestID, nil)
+		prematureCallbackReq.AddCookie(txCookie)
+		prematureCallbackRec := serve(prematureCallbackReq)
+		Expect(prematureCallbackRec.Code).To(Equal(http.StatusFound))
+		Expect(prematureCallbackRec.Header().Values("Set-Cookie")).To(BeEmpty())
+		prematureRedirect, err := url.Parse(prematureCallbackRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(prematureRedirect.Query().Get("code")).To(BeEmpty())
+		Expect(prematureRedirect.Query().Get("error")).To(Equal("interaction_required"))
+
+		var pending oidc.AuthRequest
+		Expect(DefaultContext.DB().Where("id = ?", authRequestID).First(&pending).Error).To(Succeed())
+		Expect(pending.Done()).To(BeFalse())
+		Expect(pending.Code).To(BeNil())
+		Expect(pending.Resource).To(Equal(oidc.MCPResourceURL("http://localhost:8080")))
+
 		// The consent screen must name the client and show where the code goes.
 		consentReq := httptest.NewRequest(http.MethodGet, "/oidc/consent?auth_request_id="+authRequestID, nil)
 		consentReq.AddCookie(txCookie)
@@ -180,6 +262,7 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		challenge := base64.RawURLEncoding.EncodeToString(sum[:])
 
 		const redirectURI = "http://127.0.0.1:1455/auth/callback"
+		resource := oidc.MCPResourceURL("http://localhost:8080")
 
 		authorizeRec := serve(httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
 			"client_id":             {clientID},
@@ -189,6 +272,7 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 			"state":                 {"state-tok"},
 			"code_challenge":        {challenge},
 			"code_challenge_method": {"S256"},
+			"resource":              {resource},
 		}.Encode(), nil))
 		Expect(authorizeRec.Code).To(Equal(http.StatusFound))
 		txCookie := authorizeRec.Result().Cookies()[0]
@@ -224,13 +308,29 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		postForm := func(form url.Values) map[string]any {
 			req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+			req.Header.Set("Origin", "https://inspector.example.com")
 			rec := serve(req)
 
 			Expect(rec.Code).To(Equal(http.StatusOK), rec.Body.String())
+			Expect(rec.Header().Get("Access-Control-Allow-Origin")).To(Equal("*"))
+			Expect(rec.Header().Get("Access-Control-Allow-Credentials")).To(BeEmpty())
 			var tokens map[string]any
 			Expect(json.Unmarshal(rec.Body.Bytes(), &tokens)).To(Succeed())
 			return tokens
 		}
+
+		wrongResourceReq := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {code},
+			"redirect_uri":  {redirectURI},
+			"client_id":     {clientID},
+			"code_verifier": {verifier},
+			"resource":      {"https://unrelated.example.com/api"},
+		}.Encode()))
+		wrongResourceReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+		wrongResourceRec := serve(wrongResourceReq)
+		Expect(wrongResourceRec.Code).To(Equal(http.StatusBadRequest))
+		Expect(wrongResourceRec.Body.String()).To(ContainSubstring("invalid_target"))
 
 		tokens := postForm(url.Values{
 			"grant_type":    {"authorization_code"},
@@ -238,6 +338,7 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 			"redirect_uri":  {redirectURI},
 			"client_id":     {clientID},
 			"code_verifier": {verifier},
+			"resource":      {resource},
 		})
 
 		accessToken, _ := tokens["access_token"].(string)
@@ -245,19 +346,24 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		refreshToken, _ := tokens["refresh_token"].(string)
 		Expect(refreshToken).ToNot(BeEmpty(), "offline_access must yield a refresh token so clients survive restarts")
 
-		// The access token's audience is the dynamic client_id, which is exactly
-		// what authenticateOIDCToken has to accept for /mcp to work.
+		var persistedRefreshToken oidc.RefreshToken
+		Expect(DefaultContext.DB().Where("client_id = ?", clientID).Order("created_at DESC").First(&persistedRefreshToken).Error).To(Succeed())
+		Expect(persistedRefreshToken.Resource).To(Equal(resource))
+
 		claims := decodeJWTClaims(accessToken)
-		Expect(audienceHasKnownClient(claims["aud"])).To(BeTrue())
+		Expect(claims["aud"]).To(ConsistOf(resource))
+		Expect(claims["client_id"]).To(Equal(clientID))
 		Expect(claims["iss"]).To(Equal("http://localhost:8080"))
 
 		refreshed := postForm(url.Values{
 			"grant_type":    {"refresh_token"},
 			"refresh_token": {refreshToken},
 			"client_id":     {clientID},
+			"resource":      {resource},
 		})
 		Expect(refreshed["access_token"]).ToNot(BeEmpty())
 		Expect(refreshed["refresh_token"]).ToNot(BeEmpty())
+		Expect(decodeJWTClaims(refreshed["access_token"].(string))["aud"]).To(ConsistOf(resource))
 	})
 
 	ginkgo.It("drops the authorization request when consent is denied", func() {
@@ -271,6 +377,7 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 			"state":                 {"state-2"},
 			"code_challenge":        {"challenge-2"},
 			"code_challenge_method": {"S256"},
+			"resource":              {oidc.MCPResourceURL("http://localhost:8080")},
 		}.Encode()
 
 		authorizeRec := serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil))
@@ -293,7 +400,13 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 			strings.NewReader(url.Values{"auth_request_id": {authRequestID}, "decision": {"deny"}}.Encode()))
 		denyReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 		denyReq.AddCookie(txCookie)
-		Expect(serve(denyReq).Code).To(Equal(http.StatusOK))
+		denyRec := serve(denyReq)
+		Expect(denyRec.Code).To(Equal(http.StatusFound))
+		denialRedirect, err := url.Parse(denyRec.Header().Get("Location"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(denialRedirect.Scheme + "://" + denialRedirect.Host + denialRedirect.Path).To(Equal("https://claude.ai/api/mcp/auth_callback"))
+		Expect(denialRedirect.Query().Get("error")).To(Equal("access_denied"))
+		Expect(denialRedirect.Query().Get("state")).To(Equal("state-2"))
 
 		var count int64
 		Expect(DefaultContext.DB().Table("oidc_auth_requests").Where("id = ?", authRequestID).Count(&count).Error).To(Succeed())
@@ -347,15 +460,20 @@ var _ = ginkgo.Describe("OAuth dynamic client registration", func() {
 		Expect(serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil)).Code).To(Equal(http.StatusBadRequest))
 	})
 
-	ginkgo.It("accepts tokens issued to a dynamically registered client", func() {
+	ginkgo.It("requires the MCP resource for dynamically registered clients", func() {
 		client := registerClient(`{"client_name":"Claude","redirect_uris":["https://claude.ai/api/mcp/auth_callback"]}`)
-		clientID := client["client_id"].(string)
+		authorizeURL := "/authorize?" + url.Values{
+			"client_id":             {client["client_id"].(string)},
+			"response_type":         {"code"},
+			"redirect_uri":          {"https://claude.ai/api/mcp/auth_callback"},
+			"scope":                 {"openid"},
+			"code_challenge":        {"challenge"},
+			"code_challenge_method": {"S256"},
+		}.Encode()
 
-		Expect(audienceHasKnownClient(clientID)).To(BeTrue())
-		Expect(audienceHasKnownClient([]any{clientID})).To(BeTrue())
-		Expect(audienceHasKnownClient(oidc.ClientID)).To(BeTrue())
-		Expect(audienceHasKnownClient("some-other-client")).To(BeFalse())
-		Expect(audienceHasKnownClient(nil)).To(BeFalse())
+		rec := serve(httptest.NewRequest(http.MethodGet, authorizeURL, nil))
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid_target"))
 	})
 })
 

--- a/auth/oidc/consent.go
+++ b/auth/oidc/consent.go
@@ -1,0 +1,140 @@
+package oidc
+
+// Consent for dynamically registered clients.
+//
+// Registration is open, so anyone can mint a client_id whose redirect URI points
+// at a host they control and send a victim an authorization link on Mission
+// Control's own domain. PKCE does not help — the attacker is the client and
+// holds the verifier. The consent screen is the only point in the flow where a
+// human sees where the authorization code is about to be sent.
+//
+// The built-in mc-cli client skips consent: the user started it from their own
+// terminal and its redirect URIs are fixed at compile time.
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	"github.com/flanksource/duty/context"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/incident-commander/auth/oidc/static"
+	"github.com/labstack/echo/v4"
+	"github.com/zitadel/oidc/v3/pkg/op"
+)
+
+// requiresConsent reports whether an authorization for clientID must be
+// explicitly approved by the user.
+func requiresConsent(clientID string) bool {
+	return clientID != ClientID
+}
+
+// consentRedirectURL is where the login handlers send the browser once the user
+// has authenticated but before the authorization code is issued.
+func consentRedirectURL(authRequestID string) string {
+	return "/oidc/consent?auth_request_id=" + authRequestID
+}
+
+func (h *LoginHandler) ShowConsent(c echo.Context) error {
+	id := c.QueryParam("auth_request_id")
+	if id == "" {
+		return c.String(http.StatusBadRequest, "missing auth_request_id")
+	}
+	if err := h.validateTransaction(c, id); err != nil {
+		return c.String(http.StatusUnauthorized, "invalid oidc transaction")
+	}
+
+	ctx := c.Request().Context().(context.Context)
+
+	var authRequest AuthRequest
+	if err := ctx.DB().Where("id = ? AND expires_at > NOW()", id).First(&authRequest).Error; err != nil {
+		return c.String(http.StatusBadRequest, "authorization request not found or expired")
+	}
+	if authRequest.Subject == "" {
+		return c.String(http.StatusUnauthorized, "not authenticated")
+	}
+
+	clientName := authRequest.ClientID
+	if metadata, err := decodeClientID(authRequest.ClientID); err == nil {
+		clientName = (&dynamicClient{id: authRequest.ClientID, metadata: metadata}).DisplayName()
+	}
+
+	var person models.Person
+	subject := authRequest.Subject
+	if err := ctx.DB().Where("id = ?", authRequest.Subject).First(&person).Error; err == nil {
+		if person.Email != "" {
+			subject = person.Email
+		} else if person.Name != "" {
+			subject = person.Name
+		}
+	}
+
+	scopes := strings.Join(authRequest.Scopes, ", ")
+	if scopes == "" {
+		scopes = "openid"
+	}
+
+	return c.HTML(http.StatusOK, fmt.Sprintf(static.ConsentHTML,
+		html.EscapeString(clientName),
+		html.EscapeString(subject),
+		html.EscapeString(authRequest.RedirectURI),
+		html.EscapeString(scopes),
+		html.EscapeString(id),
+		html.EscapeString(id),
+	))
+}
+
+func (h *LoginHandler) HandleConsent(c echo.Context) error {
+	id := c.FormValue("auth_request_id")
+	if id == "" {
+		return c.String(http.StatusBadRequest, "missing auth_request_id")
+	}
+	if err := h.validateTransaction(c, id); err != nil {
+		return c.String(http.StatusUnauthorized, "invalid oidc transaction")
+	}
+
+	ctx := c.Request().Context().(context.Context)
+
+	if c.FormValue("decision") != "allow" {
+		// Drop the authorization request outright so the code can never be
+		// issued, then let the client's own timeout surface the refusal.
+		if err := h.storage.DeleteAuthRequest(c.Request().Context(), id); err != nil {
+			ctx.Logger.Errorf("failed to delete denied auth request %s: %v", id, err)
+		}
+		return c.HTML(http.StatusOK, "<p>Authorization denied. You can close this window.</p>")
+	}
+
+	var authRequest AuthRequest
+	if err := ctx.DB().Where("id = ? AND expires_at > NOW()", id).First(&authRequest).Error; err != nil {
+		return c.String(http.StatusBadRequest, "authorization request not found or expired")
+	}
+	if authRequest.Subject == "" {
+		return c.String(http.StatusUnauthorized, "not authenticated")
+	}
+
+	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
+	return c.Redirect(http.StatusFound, op.AuthCallbackURL(h.provider)(issuerCtx, id))
+}
+
+// completeLogin finishes an authorization once the user's identity is known,
+// diverting through the consent screen for dynamically registered clients.
+func (h *LoginHandler) completeLogin(c echo.Context, authRequestID, personID string) error {
+	if err := h.storage.SetAuthRequestSubject(authRequestID, personID); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context().(context.Context)
+
+	var authRequest AuthRequest
+	if err := ctx.DB().Where("id = ?", authRequestID).First(&authRequest).Error; err != nil {
+		return err
+	}
+
+	if requiresConsent(authRequest.ClientID) {
+		return c.Redirect(http.StatusFound, consentRedirectURL(authRequestID))
+	}
+
+	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
+	return c.Redirect(http.StatusFound, op.AuthCallbackURL(h.provider)(issuerCtx, authRequestID))
+}

--- a/auth/oidc/consent.go
+++ b/auth/oidc/consent.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/flanksource/duty/context"
@@ -48,7 +49,7 @@ func (h *LoginHandler) ShowConsent(c echo.Context) error {
 	ctx := c.Request().Context().(context.Context)
 
 	var authRequest AuthRequest
-	if err := ctx.DB().Where("id = ? AND expires_at > NOW()", id).First(&authRequest).Error; err != nil {
+	if err := ctx.DB().Where("id = ? AND expires_at > NOW() AND done = FALSE", id).First(&authRequest).Error; err != nil {
 		return c.String(http.StatusBadRequest, "authorization request not found or expired")
 	}
 	if authRequest.Subject == "" {
@@ -96,25 +97,58 @@ func (h *LoginHandler) HandleConsent(c echo.Context) error {
 
 	ctx := c.Request().Context().(context.Context)
 
-	if c.FormValue("decision") != "allow" {
-		// Drop the authorization request outright so the code can never be
-		// issued, then let the client's own timeout surface the refusal.
-		if err := h.storage.DeleteAuthRequest(c.Request().Context(), id); err != nil {
-			ctx.Logger.Errorf("failed to delete denied auth request %s: %v", id, err)
-		}
-		return c.HTML(http.StatusOK, "<p>Authorization denied. You can close this window.</p>")
-	}
-
 	var authRequest AuthRequest
-	if err := ctx.DB().Where("id = ? AND expires_at > NOW()", id).First(&authRequest).Error; err != nil {
+	if err := ctx.DB().Where("id = ? AND expires_at > NOW() AND done = FALSE", id).First(&authRequest).Error; err != nil {
 		return c.String(http.StatusBadRequest, "authorization request not found or expired")
 	}
 	if authRequest.Subject == "" {
 		return c.String(http.StatusUnauthorized, "not authenticated")
 	}
 
+	if c.FormValue("decision") != "allow" {
+		redirectURL, err := h.denialRedirectURL(c, &authRequest)
+		if err != nil {
+			return c.String(http.StatusBadRequest, "invalid client redirect URI")
+		}
+		if err := h.storage.DeleteAuthRequest(c.Request().Context(), id); err != nil {
+			ctx.Logger.Errorf("failed to delete denied auth request %s: %v", id, err)
+			return c.String(http.StatusInternalServerError, "failed to deny authorization")
+		}
+		if h.oidcTxCookieValidator != nil {
+			h.oidcTxCookieValidator.clearCookie(c.Response(), id)
+		}
+		return c.Redirect(http.StatusFound, redirectURL)
+	}
+
+	if err := h.storage.CompleteAuthRequest(id); err != nil {
+		return c.String(http.StatusBadRequest, "authorization request is no longer pending")
+	}
+
 	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
 	return c.Redirect(http.StatusFound, op.AuthCallbackURL(h.provider)(issuerCtx, id))
+}
+
+// denialRedirectURL revalidates the stored redirect before returning an OAuth error.
+func (h *LoginHandler) denialRedirectURL(c echo.Context, authRequest *AuthRequest) (string, error) {
+	client, err := h.storage.GetClientByClientID(c.Request().Context(), authRequest.ClientID)
+	if err != nil || client == nil {
+		return "", fmt.Errorf("client is not registered")
+	}
+	if err := op.ValidateAuthReqRedirectURI(client, authRequest.RedirectURI, authRequest.GetResponseType()); err != nil {
+		return "", fmt.Errorf("redirect URI is not registered: %w", err)
+	}
+
+	redirectURL, err := url.Parse(authRequest.RedirectURI)
+	if err != nil {
+		return "", err
+	}
+	query := redirectURL.Query()
+	query.Set("error", "access_denied")
+	if authRequest.State != "" {
+		query.Set("state", authRequest.State)
+	}
+	redirectURL.RawQuery = query.Encode()
+	return redirectURL.String(), nil
 }
 
 // completeLogin finishes an authorization once the user's identity is known,
@@ -133,6 +167,9 @@ func (h *LoginHandler) completeLogin(c echo.Context, authRequestID, personID str
 
 	if requiresConsent(authRequest.ClientID) {
 		return c.Redirect(http.StatusFound, consentRedirectURL(authRequestID))
+	}
+	if err := h.storage.CompleteAuthRequest(authRequestID); err != nil {
+		return err
 	}
 
 	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)

--- a/auth/oidc/dcr.go
+++ b/auth/oidc/dcr.go
@@ -91,11 +91,14 @@ type registrationError struct {
 func mountRegistrationRoutes(e *echo.Echo) {
 	e.POST(RegistrationEndpoint, registrationHandler)
 	e.OPTIONS(RegistrationEndpoint, func(c echo.Context) error {
+		setOAuthCORSHeaders(c.Response().Header())
 		return c.NoContent(http.StatusNoContent)
 	})
 }
 
 func registrationHandler(c echo.Context) error {
+	setOAuthCORSHeaders(c.Response().Header())
+
 	var req registrationRequest
 	if err := json.NewDecoder(http.MaxBytesReader(c.Response(), c.Request().Body, maxRegistrationBody)).Decode(&req); err != nil {
 		return registrationFailure(c, "invalid_client_metadata", "request body is not valid JSON")
@@ -250,15 +253,15 @@ func decodeClientID(clientID string) (*clientMetadata, error) {
 	return &md, nil
 }
 
-// IsKnownClient reports whether clientID names a client this provider issues
-// tokens for: the built-in CLI client, or a valid dynamically registered id.
-func IsKnownClient(clientID string) bool {
-	if clientID == ClientID {
-		return true
-	}
-
+// IsDynamicClient reports whether clientID contains valid dynamic registration metadata.
+func IsDynamicClient(clientID string) bool {
 	_, err := decodeClientID(clientID)
 	return err == nil
+}
+
+// IsKnownClient reports whether clientID names a client this provider issues tokens for.
+func IsKnownClient(clientID string) bool {
+	return clientID == ClientID || IsDynamicClient(clientID)
 }
 
 // dynamicClient is a public client reconstructed from a dynamically registered

--- a/auth/oidc/dcr.go
+++ b/auth/oidc/dcr.go
@@ -1,0 +1,309 @@
+package oidc
+
+// RFC 7591 Dynamic Client Registration.
+//
+// MCP clients (Claude Desktop, Codex CLI, VS Code) cannot be told a client_id —
+// they discover the authorization server and register themselves. Registration
+// is therefore open and unauthenticated, which rules out storing every
+// registration: a bad actor could grow the table without bound.
+//
+// Instead the client_id *is* the client metadata, base64url encoded. Nothing is
+// persisted at registration time and lookups are a pure decode. The encoding is
+// deliberately unsigned: /register is open, so a hand-crafted client_id can only
+// express something the same caller could have obtained by asking. To keep that
+// true, decodeClientID re-runs the exact validation performed at registration —
+// anything that would have been rejected by POST /register is equally rejected
+// on lookup.
+//
+// A client_id grants nothing on its own. Access requires a user to complete an
+// interactive login, approve the client on the consent screen, and hold the
+// mcp:use permission. Live grants are the refresh tokens in oidc_refresh_tokens,
+// which are already revocable and garbage collected.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/oidc/v3/pkg/op"
+)
+
+const (
+	// RegistrationEndpoint is the RFC 7591 client registration endpoint. It sits
+	// under /oauth/ so it inherits the same auth-skip prefix as /oauth/token.
+	RegistrationEndpoint = "/oauth/register"
+
+	dynamicClientIDPrefix = "dcr_"
+
+	// maxClientIDLength bounds the work decodeClientID will do for an
+	// unauthenticated caller.
+	maxClientIDLength = 4096
+
+	maxRedirectURIs      = 10
+	maxRedirectURILength = 512
+	maxClientNameLength  = 128
+	maxRegistrationBody  = 16 << 10
+)
+
+// clientMetadata is the subset of RFC 7591 client metadata that is carried
+// inside the client_id. Field names are kept short because they are encoded into
+// every authorization request.
+type clientMetadata struct {
+	Name         string   `json:"n,omitempty"`
+	RedirectURIs []string `json:"r"`
+	IssuedAt     int64    `json:"i,omitempty"`
+}
+
+// registrationRequest is the RFC 7591 client metadata document sent by clients.
+type registrationRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope"`
+}
+
+// registrationResponse is the RFC 7591 client information response.
+type registrationResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope,omitempty"`
+}
+
+// registrationError is the RFC 7591 §3.2.2 error response.
+type registrationError struct {
+	Error       string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+}
+
+func mountRegistrationRoutes(e *echo.Echo) {
+	e.POST(RegistrationEndpoint, registrationHandler)
+	e.OPTIONS(RegistrationEndpoint, func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+}
+
+func registrationHandler(c echo.Context) error {
+	var req registrationRequest
+	if err := json.NewDecoder(http.MaxBytesReader(c.Response(), c.Request().Body, maxRegistrationBody)).Decode(&req); err != nil {
+		return registrationFailure(c, "invalid_client_metadata", "request body is not valid JSON")
+	}
+
+	redirectURIs, err := validateRedirectURIs(req.RedirectURIs)
+	if err != nil {
+		return registrationFailure(c, "invalid_redirect_uri", err.Error())
+	}
+
+	// Only public clients are supported: MCP clients run on the user's machine
+	// and cannot hold a secret, so no client_secret is ever issued.
+	if m := req.TokenEndpointAuthMethod; m != "" && m != string(oidc.AuthMethodNone) {
+		return registrationFailure(c, "invalid_client_metadata",
+			fmt.Sprintf("only token_endpoint_auth_method %q is supported", oidc.AuthMethodNone))
+	}
+
+	for _, gt := range req.GrantTypes {
+		if gt != string(oidc.GrantTypeCode) && gt != string(oidc.GrantTypeRefreshToken) {
+			return registrationFailure(c, "invalid_client_metadata", fmt.Sprintf("unsupported grant_type %q", gt))
+		}
+	}
+
+	for _, rt := range req.ResponseTypes {
+		if rt != string(oidc.ResponseTypeCode) {
+			return registrationFailure(c, "invalid_client_metadata", fmt.Sprintf("unsupported response_type %q", rt))
+		}
+	}
+
+	name := strings.TrimSpace(req.ClientName)
+	if len(name) > maxClientNameLength {
+		name = name[:maxClientNameLength]
+	}
+
+	clientID, err := encodeClientID(clientMetadata{
+		Name:         name,
+		RedirectURIs: redirectURIs,
+		IssuedAt:     time.Now().Unix(),
+	})
+	if err != nil {
+		return registrationFailure(c, "invalid_client_metadata", "client metadata is too large")
+	}
+
+	return c.JSON(http.StatusCreated, registrationResponse{
+		ClientID:                clientID,
+		ClientIDIssuedAt:        time.Now().Unix(),
+		ClientName:              name,
+		RedirectURIs:            redirectURIs,
+		GrantTypes:              []string{string(oidc.GrantTypeCode), string(oidc.GrantTypeRefreshToken)},
+		ResponseTypes:           []string{string(oidc.ResponseTypeCode)},
+		TokenEndpointAuthMethod: string(oidc.AuthMethodNone),
+		Scope:                   "openid profile email offline_access",
+	})
+}
+
+func registrationFailure(c echo.Context, code, description string) error {
+	return c.JSON(http.StatusBadRequest, registrationError{Error: code, Description: description})
+}
+
+// validateRedirectURIs enforces the redirect URI rules for public clients:
+// https anywhere, or plain http only on loopback (RFC 8252 §7.3).
+func validateRedirectURIs(uris []string) ([]string, error) {
+	if len(uris) == 0 {
+		return nil, fmt.Errorf("redirect_uris is required")
+	}
+	if len(uris) > maxRedirectURIs {
+		return nil, fmt.Errorf("at most %d redirect_uris are allowed", maxRedirectURIs)
+	}
+
+	validated := make([]string, 0, len(uris))
+	for _, raw := range uris {
+		if len(raw) > maxRedirectURILength {
+			return nil, fmt.Errorf("redirect_uri exceeds %d characters", maxRedirectURILength)
+		}
+
+		u, err := url.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("redirect_uri %q is not a valid URL", raw)
+		}
+		if u.Fragment != "" || strings.Contains(raw, "#") {
+			return nil, fmt.Errorf("redirect_uri %q must not contain a fragment", raw)
+		}
+
+		switch u.Scheme {
+		case "https":
+		case "http":
+			if !isLoopbackHost(u.Hostname()) {
+				return nil, fmt.Errorf("redirect_uri %q must use https unless it is a loopback address", raw)
+			}
+		default:
+			return nil, fmt.Errorf("redirect_uri %q must use the https or http scheme", raw)
+		}
+
+		if u.Host == "" {
+			return nil, fmt.Errorf("redirect_uri %q must include a host", raw)
+		}
+
+		validated = append(validated, raw)
+	}
+
+	return validated, nil
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "127.0.0.1" || host == "::1" || host == "localhost"
+}
+
+func encodeClientID(md clientMetadata) (string, error) {
+	payload, err := json.Marshal(md)
+	if err != nil {
+		return "", err
+	}
+
+	id := dynamicClientIDPrefix + base64.RawURLEncoding.EncodeToString(payload)
+	if len(id) > maxClientIDLength {
+		return "", fmt.Errorf("encoded client_id exceeds %d characters", maxClientIDLength)
+	}
+	return id, nil
+}
+
+// decodeClientID reverses encodeClientID. It re-applies registration-time
+// validation so that a hand-crafted client_id can never express more than
+// POST /register would have handed out.
+func decodeClientID(clientID string) (*clientMetadata, error) {
+	if !strings.HasPrefix(clientID, dynamicClientIDPrefix) {
+		return nil, fmt.Errorf("not a dynamically registered client")
+	}
+	if len(clientID) > maxClientIDLength {
+		return nil, fmt.Errorf("client_id exceeds %d characters", maxClientIDLength)
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(clientID, dynamicClientIDPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("client_id is not valid base64url")
+	}
+
+	var md clientMetadata
+	if err := json.Unmarshal(payload, &md); err != nil {
+		return nil, fmt.Errorf("client_id does not carry valid client metadata")
+	}
+
+	redirectURIs, err := validateRedirectURIs(md.RedirectURIs)
+	if err != nil {
+		return nil, err
+	}
+	md.RedirectURIs = redirectURIs
+
+	if len(md.Name) > maxClientNameLength {
+		md.Name = md.Name[:maxClientNameLength]
+	}
+
+	return &md, nil
+}
+
+// IsKnownClient reports whether clientID names a client this provider issues
+// tokens for: the built-in CLI client, or a valid dynamically registered id.
+func IsKnownClient(clientID string) bool {
+	if clientID == ClientID {
+		return true
+	}
+
+	_, err := decodeClientID(clientID)
+	return err == nil
+}
+
+// dynamicClient is a public client reconstructed from a dynamically registered
+// client_id. It mirrors cliClient except that redirect URIs come from the
+// client_id itself.
+type dynamicClient struct {
+	id       string
+	metadata *clientMetadata
+}
+
+var _ op.Client = (*dynamicClient)(nil)
+
+func (c *dynamicClient) GetID() string                    { return c.id }
+func (c *dynamicClient) RedirectURIs() []string           { return c.metadata.RedirectURIs }
+func (c *dynamicClient) PostLogoutRedirectURIs() []string { return nil }
+func (c *dynamicClient) ApplicationType() op.ApplicationType {
+	return op.ApplicationTypeNative
+}
+func (c *dynamicClient) AuthMethod() oidc.AuthMethod { return oidc.AuthMethodNone }
+func (c *dynamicClient) ResponseTypes() []oidc.ResponseType {
+	return []oidc.ResponseType{oidc.ResponseTypeCode}
+}
+func (c *dynamicClient) GrantTypes() []oidc.GrantType {
+	return []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken}
+}
+func (c *dynamicClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }
+func (c *dynamicClient) AccessTokenType() op.AccessTokenType {
+	return op.AccessTokenTypeJWT
+}
+func (c *dynamicClient) IDTokenLifetime() time.Duration { return time.Hour }
+func (c *dynamicClient) DevMode() bool                  { return false }
+func (c *dynamicClient) RestrictAdditionalIdTokenScopes() func(scopes []string) []string {
+	return func(scopes []string) []string { return scopes }
+}
+func (c *dynamicClient) RestrictAdditionalAccessTokenScopes() func(scopes []string) []string {
+	return func(scopes []string) []string { return scopes }
+}
+func (c *dynamicClient) IsScopeAllowed(scope string) bool     { return true }
+func (c *dynamicClient) IDTokenUserinfoClaimsAssertion() bool { return false }
+func (c *dynamicClient) ClockSkew() time.Duration             { return 0 }
+
+// DisplayName returns the name to show on the consent screen.
+func (c *dynamicClient) DisplayName() string {
+	if c.metadata.Name != "" {
+		return c.metadata.Name
+	}
+	return "An unnamed application"
+}

--- a/auth/oidc/dcr_test.go
+++ b/auth/oidc/dcr_test.go
@@ -1,0 +1,216 @@
+package oidc
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Dynamic client registration", func() {
+	ginkgo.Describe("validateRedirectURIs", func() {
+		valid := []struct {
+			name string
+			uri  string
+		}{
+			{"https", "https://claude.ai/api/mcp/auth_callback"},
+			{"loopback ipv4 with port", "http://127.0.0.1:33418/callback"},
+			{"loopback ipv6", "http://[::1]:6274/oauth/callback"},
+			{"localhost", "http://localhost:6274/oauth/callback"},
+		}
+		for _, tt := range valid {
+			ginkgo.It("accepts "+tt.name, func() {
+				got, err := validateRedirectURIs([]string{tt.uri})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got).To(Equal([]string{tt.uri}))
+			})
+		}
+
+		invalid := []struct {
+			name string
+			uri  string
+		}{
+			{"plain http on a public host", "http://evil.com/cb"},
+			{"custom scheme", "myapp://callback"},
+			{"javascript scheme", "javascript:alert(1)"},
+			{"fragment", "https://evil.com/cb#foo"},
+			{"no host", "https:///cb"},
+		}
+		for _, tt := range invalid {
+			ginkgo.It("rejects "+tt.name, func() {
+				_, err := validateRedirectURIs([]string{tt.uri})
+				Expect(err).To(HaveOccurred())
+			})
+		}
+
+		ginkgo.It("requires at least one redirect uri", func() {
+			_, err := validateRedirectURIs(nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		ginkgo.It("caps the number of redirect uris", func() {
+			uris := make([]string, maxRedirectURIs+1)
+			for i := range uris {
+				uris[i] = "https://example.com/cb"
+			}
+			_, err := validateRedirectURIs(uris)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	ginkgo.Describe("client_id encoding", func() {
+		ginkgo.It("round-trips metadata", func() {
+			md := clientMetadata{
+				Name:         "Claude",
+				RedirectURIs: []string{"https://claude.ai/api/mcp/auth_callback"},
+				IssuedAt:     1700000000,
+			}
+
+			id, err := encodeClientID(md)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id).To(HavePrefix(dynamicClientIDPrefix))
+
+			decoded, err := decodeClientID(id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(decoded.Name).To(Equal("Claude"))
+			Expect(decoded.RedirectURIs).To(Equal(md.RedirectURIs))
+		})
+
+		ginkgo.It("is stable across calls so restarts do not invalidate clients", func() {
+			md := clientMetadata{Name: "Codex", RedirectURIs: []string{"http://127.0.0.1:1455/auth/callback"}, IssuedAt: 42}
+
+			first, err := encodeClientID(md)
+			Expect(err).ToNot(HaveOccurred())
+			second, err := encodeClientID(md)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(first).To(Equal(second))
+		})
+
+		// The encoding is unsigned by design, so the guarantee is not "cannot be
+		// forged" but "a forgery can express no more than POST /register would
+		// have handed out".
+		ginkgo.It("re-validates redirect uris on decode", func() {
+			payload, err := json.Marshal(clientMetadata{
+				Name:         "Evil",
+				RedirectURIs: []string{"http://evil.com/cb"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			forged := dynamicClientIDPrefix + base64.RawURLEncoding.EncodeToString(payload)
+			_, err = decodeClientID(forged)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must use https"))
+		})
+
+		ginkgo.It("rejects ids that are not dynamically registered", func() {
+			_, err := decodeClientID(ClientID)
+			Expect(err).To(HaveOccurred())
+		})
+
+		ginkgo.It("rejects oversized ids", func() {
+			_, err := decodeClientID(dynamicClientIDPrefix + strings.Repeat("a", maxClientIDLength))
+			Expect(err).To(HaveOccurred())
+		})
+
+		ginkgo.It("rejects malformed base64", func() {
+			_, err := decodeClientID(dynamicClientIDPrefix + "!!!not-base64!!!")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	ginkgo.Describe("IsKnownClient", func() {
+		ginkgo.It("accepts the built-in cli client", func() {
+			Expect(IsKnownClient(ClientID)).To(BeTrue())
+		})
+
+		ginkgo.It("accepts a dynamically registered client", func() {
+			id, err := encodeClientID(clientMetadata{RedirectURIs: []string{"https://claude.ai/api/mcp/auth_callback"}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(IsKnownClient(id)).To(BeTrue())
+		})
+
+		ginkgo.It("rejects anything else", func() {
+			Expect(IsKnownClient("some-other-client")).To(BeFalse())
+		})
+	})
+
+	ginkgo.Describe("POST "+RegistrationEndpoint, func() {
+		register := func(body string) *httptest.ResponseRecorder {
+			e := echo.New()
+			mountRegistrationRoutes(e)
+
+			req := httptest.NewRequest(http.MethodPost, RegistrationEndpoint, strings.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			return rec
+		}
+
+		ginkgo.It("registers a public client and never issues a secret", func() {
+			rec := register(`{
+				"client_name": "Claude",
+				"redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+				"grant_types": ["authorization_code", "refresh_token"],
+				"response_types": ["code"],
+				"token_endpoint_auth_method": "none"
+			}`)
+
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+
+			var resp map[string]any
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp).ToNot(HaveKey("client_secret"))
+			Expect(resp["token_endpoint_auth_method"]).To(Equal("none"))
+			Expect(resp["client_id"]).To(HavePrefix(dynamicClientIDPrefix))
+
+			decoded, err := decodeClientID(resp["client_id"].(string))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(decoded.RedirectURIs).To(ConsistOf("https://claude.ai/api/mcp/auth_callback"))
+		})
+
+		ginkgo.It("rejects a non-loopback http redirect uri", func() {
+			rec := register(`{"redirect_uris": ["http://evil.com/cb"]}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			var resp registrationError
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Error).To(Equal("invalid_redirect_uri"))
+		})
+
+		ginkgo.It("rejects a request for a confidential client", func() {
+			rec := register(`{"redirect_uris": ["https://example.com/cb"], "token_endpoint_auth_method": "client_secret_post"}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			var resp registrationError
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Error).To(Equal("invalid_client_metadata"))
+		})
+
+		ginkgo.It("rejects an unsupported grant type", func() {
+			rec := register(`{"redirect_uris": ["https://example.com/cb"], "grant_types": ["implicit"]}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		ginkgo.It("rejects a malformed body", func() {
+			rec := register(`not json`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	ginkgo.Describe("requiresConsent", func() {
+		ginkgo.It("skips consent for the built-in cli client", func() {
+			Expect(requiresConsent(ClientID)).To(BeFalse())
+		})
+
+		ginkgo.It("requires consent for a dynamically registered client", func() {
+			id, err := encodeClientID(clientMetadata{RedirectURIs: []string{"https://claude.ai/cb"}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(requiresConsent(id)).To(BeTrue())
+		})
+	})
+})

--- a/auth/oidc/login.go
+++ b/auth/oidc/login.go
@@ -110,13 +110,10 @@ func (h *LoginHandler) HandleSubmit(c echo.Context) error {
 		return renderForm("User not found")
 	}
 
-	if err := h.storage.SetAuthRequestSubject(id, personID); err != nil {
+	if err := h.completeLogin(c, id, personID); err != nil {
 		return renderForm("Internal error")
 	}
-
-	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
-	callbackURL := op.AuthCallbackURL(h.provider)(issuerCtx, id)
-	return c.Redirect(http.StatusFound, callbackURL)
+	return nil
 }
 
 func (h *LoginHandler) HandleExternalCallback(c echo.Context) error {
@@ -137,13 +134,10 @@ func (h *LoginHandler) HandleExternalCallback(c echo.Context) error {
 		return c.String(http.StatusUnauthorized, "authorization failed")
 	}
 
-	if err := h.storage.SetAuthRequestSubject(id, personID); err != nil {
+	if err := h.completeLogin(c, id, personID); err != nil {
 		return c.String(http.StatusInternalServerError, "internal error")
 	}
-
-	issuerCtx := op.ContextWithIssuer(c.Request().Context(), h.issuerURL)
-	callbackURL := op.AuthCallbackURL(h.provider)(issuerCtx, id)
-	return c.Redirect(http.StatusFound, callbackURL)
+	return nil
 }
 
 func (h *LoginHandler) validateTransaction(c echo.Context, authRequestID string) error {

--- a/auth/oidc/models.go
+++ b/auth/oidc/models.go
@@ -14,7 +14,7 @@ const ClientID = "mc-cli"
 type AuthRequest struct {
 	ID                  string         `gorm:"primaryKey;column:id"`
 	ClientID            string         `gorm:"column:client_id;not null"`
-	Resource            string         `gorm:"column:resource"`
+	Resource            string         `gorm:"-"`
 	RedirectURI         string         `gorm:"column:redirect_uri;not null"`
 	Scopes              pq.StringArray `gorm:"column:scopes;type:text[]"`
 	State               string         `gorm:"column:state"`
@@ -74,7 +74,7 @@ type RefreshToken struct {
 	ID         string         `gorm:"primaryKey;column:id"`
 	Token      string         `gorm:"column:token;not null;uniqueIndex"`
 	ClientID   string         `gorm:"column:client_id;not null"`
-	Resource   string         `gorm:"column:resource"`
+	Resource   string         `gorm:"-"`
 	Subject    string         `gorm:"column:subject;not null"`
 	Scopes     pq.StringArray `gorm:"column:scopes;type:text[]"`
 	AuthTime   time.Time      `gorm:"column:auth_time;not null"`

--- a/auth/oidc/models.go
+++ b/auth/oidc/models.go
@@ -14,6 +14,7 @@ const ClientID = "mc-cli"
 type AuthRequest struct {
 	ID                  string         `gorm:"primaryKey;column:id"`
 	ClientID            string         `gorm:"column:client_id;not null"`
+	Resource            string         `gorm:"column:resource"`
 	RedirectURI         string         `gorm:"column:redirect_uri;not null"`
 	Scopes              pq.StringArray `gorm:"column:scopes;type:text[]"`
 	State               string         `gorm:"column:state"`
@@ -31,10 +32,15 @@ type AuthRequest struct {
 
 func (AuthRequest) TableName() string { return "oidc_auth_requests" }
 
-func (a *AuthRequest) GetID() string         { return a.ID }
-func (a *AuthRequest) GetACR() string        { return "" }
-func (a *AuthRequest) GetAMR() []string      { return nil }
-func (a *AuthRequest) GetAudience() []string { return []string{a.ClientID} }
+func (a *AuthRequest) GetID() string    { return a.ID }
+func (a *AuthRequest) GetACR() string   { return "" }
+func (a *AuthRequest) GetAMR() []string { return nil }
+func (a *AuthRequest) GetAudience() []string {
+	if a.Resource != "" {
+		return []string{a.Resource}
+	}
+	return []string{a.ClientID}
+}
 func (a *AuthRequest) GetAuthTime() time.Time {
 	if a.AuthTime != nil {
 		return *a.AuthTime
@@ -60,6 +66,7 @@ func (a *AuthRequest) GetResponseMode() oidc.ResponseMode { return "" }
 func (a *AuthRequest) GetScopes() []string                { return []string(a.Scopes) }
 func (a *AuthRequest) GetState() string                   { return a.State }
 func (a *AuthRequest) GetSubject() string                 { return a.Subject }
+func (a *AuthRequest) GetResource() string                { return a.Resource }
 func (a *AuthRequest) Done() bool                         { return a.IsDone }
 
 // RefreshToken is backed by the oidc_refresh_tokens table.
@@ -67,6 +74,7 @@ type RefreshToken struct {
 	ID         string         `gorm:"primaryKey;column:id"`
 	Token      string         `gorm:"column:token;not null;uniqueIndex"`
 	ClientID   string         `gorm:"column:client_id;not null"`
+	Resource   string         `gorm:"column:resource"`
 	Subject    string         `gorm:"column:subject;not null"`
 	Scopes     pq.StringArray `gorm:"column:scopes;type:text[]"`
 	AuthTime   time.Time      `gorm:"column:auth_time;not null"`
@@ -77,12 +85,18 @@ type RefreshToken struct {
 
 func (RefreshToken) TableName() string { return "oidc_refresh_tokens" }
 
-func (r *RefreshToken) GetAMR() []string       { return nil }
-func (r *RefreshToken) GetAudience() []string  { return []string{r.ClientID} }
+func (r *RefreshToken) GetAMR() []string { return nil }
+func (r *RefreshToken) GetAudience() []string {
+	if r.Resource != "" {
+		return []string{r.Resource}
+	}
+	return []string{r.ClientID}
+}
 func (r *RefreshToken) GetAuthTime() time.Time { return r.AuthTime }
 func (r *RefreshToken) GetClientID() string    { return r.ClientID }
 func (r *RefreshToken) GetScopes() []string    { return []string(r.Scopes) }
 func (r *RefreshToken) GetSubject() string     { return r.Subject }
+func (r *RefreshToken) GetResource() string    { return r.Resource }
 func (r *RefreshToken) SetCurrentScopes(scopes []string) {
 	r.Scopes = pq.StringArray(scopes)
 }

--- a/auth/oidc/oauth.go
+++ b/auth/oidc/oauth.go
@@ -27,6 +27,44 @@ type oauthProtectedResourceMetadata struct {
 	BearerMethods        []string `json:"bearer_methods_supported,omitempty"`
 }
 
+// mountOAuthCORS installs a credential-free policy before the server-wide CORS middleware.
+func mountOAuthCORS(e *echo.Echo) {
+	e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !isOAuthCORSPath(c.Request().URL.Path) {
+				return next(c)
+			}
+
+			setOAuthCORSHeaders(c.Response().Header())
+			if c.Request().Method == http.MethodOptions {
+				return c.NoContent(http.StatusNoContent)
+			}
+			return next(c)
+		}
+	})
+}
+
+func isOAuthCORSPath(path string) bool {
+	return path == openIDConfigurationPath ||
+		pathIsOrUnder(path, authorizationServerMetadataPath) ||
+		pathIsOrUnder(path, oauthProtectedResourcePrefix) ||
+		path == RegistrationEndpoint ||
+		path == "/oauth/token" ||
+		path == MCPResourcePath
+}
+
+func pathIsOrUnder(path, prefix string) bool {
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
+}
+
+func setOAuthCORSHeaders(header http.Header) {
+	header.Set("Access-Control-Allow-Origin", "*")
+	header.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	header.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID")
+	header.Set("Access-Control-Expose-Headers", "WWW-Authenticate, MCP-Session-Id")
+	header.Del("Access-Control-Allow-Credentials")
+}
+
 func mountOAuthRoutes(e *echo.Echo, oidcIssuer string, providerHandler http.Handler) {
 	// RFC 9728 OAuth 2.0 Protected Resource Metadata for MCP/OAuth clients.
 	prmHandler := oauthProtectedResourceMetadataHandler(oidcIssuer)
@@ -62,6 +100,7 @@ func authorizationServerMetadataHandler(providerHandler http.Handler) echo.Handl
 					c.Response().Header().Add(k, v)
 				}
 			}
+			setOAuthCORSHeaders(c.Response().Header())
 			return c.Blob(rec.status, rec.headers.Get(echo.HeaderContentType), rec.body.Bytes())
 		}
 
@@ -73,7 +112,7 @@ func authorizationServerMetadataHandler(providerHandler http.Handler) echo.Handl
 
 		// Discovery documents are public and cookie-free; browser-based clients
 		// such as the MCP Inspector fetch them cross-origin.
-		c.Response().Header().Set("Access-Control-Allow-Origin", "*")
+		setOAuthCORSHeaders(c.Response().Header())
 		return c.JSON(http.StatusOK, doc)
 	}
 }
@@ -126,6 +165,7 @@ func oauthProtectedResourceMetadataHandler(issuerURL string) echo.HandlerFunc {
 			BearerMethods:        []string{"header"},
 		}
 
+		setOAuthCORSHeaders(c.Response().Header())
 		return c.JSON(http.StatusOK, metadata)
 	}
 }

--- a/auth/oidc/oauth.go
+++ b/auth/oidc/oauth.go
@@ -1,6 +1,8 @@
 package oidc
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strings"
@@ -8,7 +10,15 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const oauthProtectedResourcePrefix = "/.well-known/oauth-protected-resource"
+const (
+	oauthProtectedResourcePrefix = "/.well-known/oauth-protected-resource"
+
+	// openIDConfigurationPath is OIDC discovery; authorizationServerMetadataPath
+	// is its RFC 8414 equivalent. MCP clients probe the latter first and the
+	// zitadel router only serves the former, so both are mounted here.
+	openIDConfigurationPath         = "/.well-known/openid-configuration"
+	authorizationServerMetadataPath = "/.well-known/oauth-authorization-server"
+)
 
 type oauthProtectedResourceMetadata struct {
 	Resource             string   `json:"resource"`
@@ -17,11 +27,77 @@ type oauthProtectedResourceMetadata struct {
 	BearerMethods        []string `json:"bearer_methods_supported,omitempty"`
 }
 
-func mountOAuthRoutes(e *echo.Echo, oidcIssuer string) {
+func mountOAuthRoutes(e *echo.Echo, oidcIssuer string, providerHandler http.Handler) {
 	// RFC 9728 OAuth 2.0 Protected Resource Metadata for MCP/OAuth clients.
 	prmHandler := oauthProtectedResourceMetadataHandler(oidcIssuer)
-	e.GET("/.well-known/oauth-protected-resource", prmHandler)
-	e.GET("/.well-known/oauth-protected-resource/*", prmHandler)
+	e.GET(oauthProtectedResourcePrefix, prmHandler)
+	e.GET(oauthProtectedResourcePrefix+"/*", prmHandler)
+
+	// The zitadel provider builds the discovery document but has no hook for
+	// registration_endpoint, so the response is augmented on the way out. The
+	// same document answers RFC 8414, which zitadel does not serve at all.
+	metadata := authorizationServerMetadataHandler(providerHandler)
+	e.GET(openIDConfigurationPath, metadata)
+	e.GET(authorizationServerMetadataPath, metadata)
+	e.GET(authorizationServerMetadataPath+"/*", metadata)
+}
+
+// authorizationServerMetadataHandler delegates to the zitadel discovery handler
+// and injects registration_endpoint into the result.
+func authorizationServerMetadataHandler(providerHandler http.Handler) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		req := c.Request().Clone(c.Request().Context())
+		req.URL.Path = openIDConfigurationPath
+		req.Method = http.MethodGet
+
+		rec := &bufferedResponseWriter{headers: http.Header{}, status: http.StatusOK}
+		providerHandler.ServeHTTP(rec, req)
+
+		var doc map[string]any
+		if rec.status != http.StatusOK || json.Unmarshal(rec.body.Bytes(), &doc) != nil {
+			// Pass the provider's response through untouched rather than
+			// masking whatever went wrong behind a synthetic document.
+			for k, values := range rec.headers {
+				for _, v := range values {
+					c.Response().Header().Add(k, v)
+				}
+			}
+			return c.Blob(rec.status, rec.headers.Get(echo.HeaderContentType), rec.body.Bytes())
+		}
+
+		issuer, _ := doc["issuer"].(string)
+		if issuer == "" {
+			issuer = detectRequestOrigin(c, "")
+		}
+		doc["registration_endpoint"] = strings.TrimRight(issuer, "/") + RegistrationEndpoint
+
+		// Discovery documents are public and cookie-free; browser-based clients
+		// such as the MCP Inspector fetch them cross-origin.
+		c.Response().Header().Set("Access-Control-Allow-Origin", "*")
+		return c.JSON(http.StatusOK, doc)
+	}
+}
+
+// bufferedResponseWriter captures a handler's response so it can be rewritten.
+type bufferedResponseWriter struct {
+	headers http.Header
+	body    bytes.Buffer
+	status  int
+	written bool
+}
+
+func (w *bufferedResponseWriter) Header() http.Header { return w.headers }
+
+func (w *bufferedResponseWriter) WriteHeader(status int) {
+	if !w.written {
+		w.status = status
+		w.written = true
+	}
+}
+
+func (w *bufferedResponseWriter) Write(b []byte) (int, error) {
+	w.written = true
+	return w.body.Write(b)
 }
 
 func oauthProtectedResourceMetadataHandler(issuerURL string) echo.HandlerFunc {

--- a/auth/oidc/provider.go
+++ b/auth/oidc/provider.go
@@ -31,7 +31,7 @@ func NewProvider(ctx context.Context, issuerURL string, cryptoKey [32]byte, priv
 		algorithm:  "RS256",
 		privateKey: privateKey,
 	}
-	storage := NewStorage(ctx, signer)
+	storage := NewStorage(ctx, signer, issuerURL)
 
 	config := &op.Config{
 		CryptoKey:             cryptoKey,

--- a/auth/oidc/provider.go
+++ b/auth/oidc/provider.go
@@ -36,6 +36,11 @@ func NewProvider(ctx context.Context, issuerURL string, cryptoKey [32]byte, priv
 	config := &op.Config{
 		CryptoKey:             cryptoKey,
 		GrantTypeRefreshToken: true,
+
+		// Only read when building the discovery document. Without it
+		// code_challenge_methods_supported is omitted and spec-compliant MCP
+		// clients refuse to start the flow.
+		CodeMethodS256: true,
 	}
 
 	oidcProvider, err := op.NewProvider(config, storage,

--- a/auth/oidc/resource.go
+++ b/auth/oidc/resource.go
@@ -1,0 +1,133 @@
+package oidc
+
+import (
+	gocontext "context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// MCPResourcePath is the only route dynamically registered OAuth clients may access.
+const MCPResourcePath = "/mcp"
+
+type resourceIndicatorContextKey struct{}
+
+type oauthErrorResponse struct {
+	Error       string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+}
+
+// MCPResourceURL returns the audience used for MCP access tokens.
+func MCPResourceURL(issuerURL string) string {
+	return strings.TrimRight(issuerURL, "/") + MCPResourcePath
+}
+
+// withMCPResourceIndicator validates the resource before Zitadel discards it.
+func withMCPResourceIndicator(next http.Handler, issuerURL string) http.Handler {
+	expectedResource := MCPResourceURL(issuerURL)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "authorization request cannot be parsed")
+			return
+		}
+		if !IsDynamicClient(r.Form.Get("client_id")) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		resources, ok := r.Form["resource"]
+		if !ok || len(resources) != 1 || resources[0] != expectedResource {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_target", "resource must identify the MCP endpoint")
+			return
+		}
+
+		ctx := gocontext.WithValue(r.Context(), resourceIndicatorContextKey{}, expectedResource)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func resourceIndicatorFromContext(ctx gocontext.Context) string {
+	resource, _ := ctx.Value(resourceIndicatorContextKey{}).(string)
+	return resource
+}
+
+// mcpTokenEndpointHandler enforces the persisted resource on code and refresh exchanges.
+func mcpTokenEndpointHandler(next http.Handler, storage *Storage, issuerURL string) http.Handler {
+	expectedResource := MCPResourceURL(issuerURL)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			if err := r.ParseForm(); err != nil {
+				setOAuthCORSHeaders(w.Header())
+				writeOAuthError(w, http.StatusBadRequest, "invalid_request", "token request cannot be parsed")
+				return
+			}
+		}
+		if err := storage.validateTokenResource(r, expectedResource); err != nil {
+			setOAuthCORSHeaders(w.Header())
+			writeOAuthError(w, http.StatusBadRequest, "invalid_target", err.Error())
+			return
+		}
+
+		rec := &bufferedResponseWriter{headers: http.Header{}, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		for key, values := range rec.headers {
+			w.Header()[key] = append([]string(nil), values...)
+		}
+		setOAuthCORSHeaders(w.Header())
+		w.WriteHeader(rec.status)
+		_, _ = w.Write(rec.body.Bytes())
+	})
+}
+
+func (s *Storage) validateTokenResource(r *http.Request, expectedResource string) error {
+	if r.Method != http.MethodPost {
+		return nil
+	}
+
+	var clientID, resource string
+	switch r.Form.Get("grant_type") {
+	case "authorization_code":
+		request, err := s.AuthRequestByCode(r.Context(), r.Form.Get("code"))
+		if err != nil {
+			return nil
+		}
+		authRequest, ok := request.(*AuthRequest)
+		if !ok {
+			return nil
+		}
+		clientID, resource = authRequest.ClientID, authRequest.Resource
+	case "refresh_token":
+		request, err := s.TokenRequestByRefreshToken(r.Context(), r.Form.Get("refresh_token"))
+		if err != nil {
+			return nil
+		}
+		refreshToken, ok := request.(*RefreshToken)
+		if !ok {
+			return nil
+		}
+		clientID, resource = refreshToken.ClientID, refreshToken.Resource
+	default:
+		return nil
+	}
+
+	if !IsDynamicClient(clientID) {
+		return nil
+	}
+	if resource != expectedResource {
+		return fmt.Errorf("authorization is not valid for the MCP resource")
+	}
+	if resources, ok := r.Form["resource"]; ok && (len(resources) != 1 || resources[0] != resource) {
+		return fmt.Errorf("requested resource does not match the authorized MCP resource")
+	}
+	return nil
+}
+
+func writeOAuthError(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(oauthErrorResponse{Error: code, Description: description})
+}

--- a/auth/oidc/resource.go
+++ b/auth/oidc/resource.go
@@ -53,7 +53,7 @@ func resourceIndicatorFromContext(ctx gocontext.Context) string {
 	return resource
 }
 
-// mcpTokenEndpointHandler enforces the persisted resource on code and refresh exchanges.
+// mcpTokenEndpointHandler enforces the MCP resource on code and refresh exchanges.
 func mcpTokenEndpointHandler(next http.Handler, storage *Storage, issuerURL string) http.Handler {
 	expectedResource := MCPResourceURL(issuerURL)
 

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -43,6 +43,8 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL string, passwordCh
 	}
 	loginHandler.oidcTxCookieValidator = oidcTxCookierManager
 
+	mountOAuthCORS(e)
+
 	// Custom login form (not part of the standard OIDC protocol paths).
 	e.GET("/oidc/login", loginHandler.ShowForm)
 	e.POST("/oidc/login", loginHandler.HandleSubmit)
@@ -61,12 +63,14 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL string, passwordCh
 	// Standard OIDC protocol endpoints — mounted at the root so that the issuer URL
 	// and the authorization_endpoint/token_endpoint values in the discovery document
 	// resolve to real routes on this server.
-	authorizeHandler := echo.WrapHandler(oidcTxCookierManager.issueOnAuthorize(provider.Handler))
-	callbackHandler := echo.WrapHandler(oidcTxCookierManager.requireOnAuthorizeCallback(provider.Handler))
+	authorizationProvider := withMCPResourceIndicator(provider.Handler, oidcIssuer)
+	authorizeHandler := echo.WrapHandler(oidcTxCookierManager.issueOnAuthorize(authorizationProvider))
+	callbackHandler := echo.WrapHandler(oidcTxCookierManager.requireOnAuthorizeCallback(provider.Handler, provider.Storage))
+	tokenHandler := echo.WrapHandler(mcpTokenEndpointHandler(provider.Handler, provider.Storage, oidcIssuer))
 	h := echo.WrapHandler(provider.Handler)
 	e.Any("/authorize", authorizeHandler)
 	e.Any("/authorize/*", callbackHandler)
-	e.Any("/oauth/token", h)
+	e.Any("/oauth/token", tokenHandler)
 	e.Any("/oauth/introspect", h)
 	e.Any("/userinfo", h)
 	e.Any("/keys", h)

--- a/auth/oidc/routes.go
+++ b/auth/oidc/routes.go
@@ -46,12 +46,17 @@ func MountRoutes(e *echo.Echo, ctx context.Context, issuerURL string, passwordCh
 	// Custom login form (not part of the standard OIDC protocol paths).
 	e.GET("/oidc/login", loginHandler.ShowForm)
 	e.POST("/oidc/login", loginHandler.HandleSubmit)
+	e.GET("/oidc/consent", loginHandler.ShowConsent)
+	e.POST("/oidc/consent", loginHandler.HandleConsent)
 	e.GET("/oidc/kratos/callback", loginHandler.HandleExternalCallback)
 	e.GET("/oidc/clerk/callback", loginHandler.HandleExternalCallback)
 	e.POST("/oidc/clerk/callback", loginHandler.HandleExternalCallback)
 
 	// MCP Clients need OAuth well-known discovery endpoints (not just OIDC discovery).
-	mountOAuthRoutes(e, oidcIssuer)
+	mountOAuthRoutes(e, oidcIssuer, provider.Handler)
+
+	// RFC 7591 dynamic client registration, required by Claude Desktop and Codex CLI.
+	mountRegistrationRoutes(e)
 
 	// Standard OIDC protocol endpoints — mounted at the root so that the issuer URL
 	// and the authorization_endpoint/token_endpoint values in the discovery document

--- a/auth/oidc/static/consent.html
+++ b/auth/oidc/static/consent.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize application — Mission Control</title>
+  <script src="/oidc/static/tailwind.min.js"></script>
+</head>
+<body class="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+  <div class="w-full max-w-md">
+    <div class="text-center mb-8">
+      <img src="/oidc/static/logo.svg" alt="Mission Control" class="mx-auto h-10">
+      <p class="mt-4 text-sm text-gray-500">Authorize application</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 p-6">
+      <p class="text-sm text-gray-700">
+        <span class="font-semibold text-gray-900">%s</span>
+        is asking to access Mission Control as
+        <span class="font-semibold text-gray-900">%s</span>.
+      </p>
+
+      <div class="mt-5 rounded-lg bg-amber-50 ring-1 ring-amber-200 p-3">
+        <p class="text-xs font-medium text-amber-900">This application registered itself and is not verified.</p>
+        <p class="mt-2 text-xs text-amber-800">If you approve, you will be sent to:</p>
+        <p class="mt-1 break-all font-mono text-xs text-amber-900">%s</p>
+        <p class="mt-2 text-xs text-amber-800">Only continue if you started this and recognise that address.</p>
+      </div>
+
+      <dl class="mt-5 text-xs text-gray-600">
+        <dt class="font-medium text-gray-700">Access requested</dt>
+        <dd class="mt-1 break-words">%s</dd>
+      </dl>
+
+      <div class="mt-6 flex gap-3">
+        <form method="POST" action="/oidc/consent" class="flex-1">
+          <input type="hidden" name="auth_request_id" value="%s">
+          <input type="hidden" name="decision" value="deny">
+          <button type="submit"
+            class="w-full rounded-lg bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 transition-colors">
+            Deny
+          </button>
+        </form>
+        <form method="POST" action="/oidc/consent" class="flex-1">
+          <input type="hidden" name="auth_request_id" value="%s">
+          <input type="hidden" name="decision" value="allow">
+          <button type="submit"
+            class="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors">
+            Allow
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/auth/oidc/static/embed.go
+++ b/auth/oidc/static/embed.go
@@ -2,11 +2,12 @@ package static
 
 import "embed"
 
-//go:embed logo.svg tailwind.min.js login.html callback_success.html
+//go:embed logo.svg tailwind.min.js login.html callback_success.html consent.html
 var FS embed.FS
 
 var LoginHTML = must("login.html")
 var CallbackSuccessHTML = must("callback_success.html")
+var ConsentHTML = must("consent.html")
 
 func must(name string) string {
 	b, err := FS.ReadFile(name)

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -44,17 +44,26 @@ func (p *publicKey) Key() any                           { return p.key }
 
 // Storage implements op.Storage backed by Postgres.
 type Storage struct {
-	ctx    context.Context
-	signer *signingKey
+	ctx       context.Context
+	signer    *signingKey
+	issuerURL string
 }
 
 var _ op.Storage = (*Storage)(nil)
 
-func NewStorage(ctx context.Context, signer *signingKey) *Storage {
-	return &Storage{ctx: ctx, signer: signer}
+func NewStorage(ctx context.Context, signer *signingKey, issuerURL string) *Storage {
+	return &Storage{ctx: ctx, signer: signer, issuerURL: issuerURL}
 }
 
 func (s *Storage) Health(_ gocontext.Context) error { return nil }
+
+// deriveResource reconstructs the fixed MCP audience for stateless dynamic clients.
+func (s *Storage) deriveResource(clientID string) string {
+	if IsDynamicClient(clientID) {
+		return MCPResourceURL(s.issuerURL)
+	}
+	return ""
+}
 
 func (s *Storage) CreateAuthRequest(ctx gocontext.Context, req *oidc.AuthRequest, _ string) (op.AuthRequest, error) {
 	ar := &AuthRequest{
@@ -82,6 +91,7 @@ func (s *Storage) AuthRequestByID(_ gocontext.Context, id string) (op.AuthReques
 	if err := s.ctx.DB().Where("id = ? AND expires_at > NOW()", id).First(&ar).Error; err != nil {
 		return nil, fmt.Errorf("auth request not found: %w", err)
 	}
+	ar.Resource = s.deriveResource(ar.ClientID)
 	return &ar, nil
 }
 
@@ -90,6 +100,7 @@ func (s *Storage) AuthRequestByCode(_ gocontext.Context, code string) (op.AuthRe
 	if err := s.ctx.DB().Where("code = ? AND expires_at > NOW()", hashToken(code)).First(&ar).Error; err != nil {
 		return nil, fmt.Errorf("auth request not found: %w", err)
 	}
+	ar.Resource = s.deriveResource(ar.ClientID)
 	return &ar, nil
 }
 
@@ -162,6 +173,7 @@ func (s *Storage) TokenRequestByRefreshToken(_ gocontext.Context, refreshToken s
 	if err := s.ctx.DB().Where("token = ? AND expires_at > NOW()", hashToken(refreshToken)).First(&rt).Error; err != nil {
 		return nil, op.ErrInvalidRefreshToken
 	}
+	rt.Resource = s.deriveResource(rt.ClientID)
 	return &rt, nil
 }
 

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -210,10 +210,15 @@ func (s *Storage) KeySet(_ gocontext.Context) ([]op.Key, error) {
 }
 
 func (s *Storage) GetClientByClientID(_ gocontext.Context, clientID string) (op.Client, error) {
-	if clientID != ClientID {
-		return nil, fmt.Errorf("unknown client: %s", clientID)
+	if clientID == ClientID {
+		return &cliClient{}, nil
 	}
-	return &cliClient{}, nil
+
+	metadata, err := decodeClientID(clientID)
+	if err != nil {
+		return nil, fmt.Errorf("unknown client: %w", err)
+	}
+	return &dynamicClient{id: clientID, metadata: metadata}, nil
 }
 
 func (s *Storage) AuthorizeClientIDSecret(_ gocontext.Context, _, _ string) error {

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/flanksource/duty"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/go-jose/go-jose/v4"
@@ -55,10 +56,11 @@ func NewStorage(ctx context.Context, signer *signingKey) *Storage {
 
 func (s *Storage) Health(_ gocontext.Context) error { return nil }
 
-func (s *Storage) CreateAuthRequest(_ gocontext.Context, req *oidc.AuthRequest, _ string) (op.AuthRequest, error) {
+func (s *Storage) CreateAuthRequest(ctx gocontext.Context, req *oidc.AuthRequest, _ string) (op.AuthRequest, error) {
 	ar := &AuthRequest{
 		ID:                  uuid.New().String(),
 		ClientID:            req.ClientID,
+		Resource:            resourceIndicatorFromContext(ctx),
 		RedirectURI:         req.RedirectURI,
 		Scopes:              pq.StringArray(req.Scopes),
 		State:               req.State,
@@ -123,7 +125,14 @@ func (s *Storage) CreateAccessAndRefreshTokens(_ gocontext.Context, req op.Token
 
 	now := time.Now()
 	clientID := ClientID
-	if aud := req.GetAudience(); len(aud) > 0 {
+	resource := ""
+	if request, ok := req.(interface {
+		GetClientID() string
+		GetResource() string
+	}); ok {
+		clientID = request.GetClientID()
+		resource = request.GetResource()
+	} else if aud := req.GetAudience(); len(aud) > 0 {
 		clientID = aud[0]
 	}
 
@@ -133,6 +142,7 @@ func (s *Storage) CreateAccessAndRefreshTokens(_ gocontext.Context, req op.Token
 		ID:         uuid.New().String(),
 		Token:      hashToken(rawRefreshToken),
 		ClientID:   clientID,
+		Resource:   resource,
 		Subject:    req.GetSubject(),
 		Scopes:     pq.StringArray(req.GetScopes()),
 		AuthTime:   now,
@@ -263,16 +273,28 @@ func (s *Storage) populateUserinfo(userinfo *oidc.UserInfo, subject string) erro
 	return nil
 }
 
-// SetAuthRequestSubject sets the subject on an auth request after login.
+// SetAuthRequestSubject records a successful login without completing consent.
 func (s *Storage) SetAuthRequestSubject(id, subject string) error {
-	now := time.Now()
 	result := s.ctx.DB().Model(&AuthRequest{}).
-		Where("id = ? AND expires_at > NOW() AND (subject = '' OR subject IS NULL)", id).
+		Where("id = ? AND expires_at > NOW() AND done = FALSE AND (subject = '' OR subject IS NULL)", id).
 		Updates(map[string]any{
 			"subject":   subject,
-			"auth_time": now,
-			"done":      true,
+			"auth_time": duty.Now(),
 		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("auth request not found or already authenticated")
+	}
+	return nil
+}
+
+// CompleteAuthRequest atomically records that all required interaction is complete.
+func (s *Storage) CompleteAuthRequest(id string) error {
+	result := s.ctx.DB().Model(&AuthRequest{}).
+		Where("id = ? AND expires_at > NOW() AND done = FALSE AND subject IS NOT NULL AND subject <> ''", id).
+		Update("done", true)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/auth/oidc/suite_test.go
+++ b/auth/oidc/suite_test.go
@@ -1,0 +1,13 @@
+package oidc
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOIDC(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "OIDC")
+}

--- a/auth/oidc/transaction_cookie.go
+++ b/auth/oidc/transaction_cookie.go
@@ -60,7 +60,7 @@ func (m *transactionCookieManager) issueOnAuthorize(next http.Handler) http.Hand
 	})
 }
 
-func (m *transactionCookieManager) requireOnAuthorizeCallback(next http.Handler) http.Handler {
+func (m *transactionCookieManager) requireOnAuthorizeCallback(next http.Handler, storage *Storage) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.URL.Query().Get("id")
 		if id == "" {
@@ -71,7 +71,10 @@ func (m *transactionCookieManager) requireOnAuthorizeCallback(next http.Handler)
 			http.Error(w, "invalid oidc transaction", http.StatusUnauthorized)
 			return
 		}
-		m.clearCookie(w, id)
+		// A premature callback must not consume the cookie needed to submit consent.
+		if authRequest, err := storage.AuthRequestByID(r.Context(), id); err == nil && authRequest.Done() {
+			m.clearCookie(w, id)
+		}
 
 		next.ServeHTTP(w, r)
 	})

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -4,6 +4,7 @@ import (
 	gocontext "context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -163,6 +164,12 @@ var _ = ginkgo.Describe("OIDC", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fetched.GetSubject()).To(Equal(person.ID.String()))
 			Expect(fetched.GetAuthTime()).ToNot(BeZero())
+			Expect(fetched.Done()).To(BeFalse())
+
+			Expect(provider.Storage.CompleteAuthRequest(ar.GetID())).To(Succeed())
+			completed, err := provider.Storage.AuthRequestByID(gocontext.TODO(), ar.GetID())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(completed.Done()).To(BeTrue())
 		})
 
 		ginkgo.It("creates and retrieves refresh tokens", func() {
@@ -301,6 +308,81 @@ var _ = ginkgo.Describe("OIDC", func() {
 			authenticated, err := authenticateOIDCToken(c, tokenStr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(authenticated).To(BeTrue())
+		})
+
+		ginkgo.It("confines dynamic-client access tokens to the MCP resource", func() {
+			privateKey, _, err := signing.PrivateKey()
+			Expect(err).To(BeNil())
+
+			oidcPublicKeyCache.Flush()
+			savedAuthMode := vars.AuthMode
+			savedFrontendURL := api.FrontendURL
+			savedPublicURL := api.PublicURL
+			savedOIDCEnabled := OIDCEnabled
+			savedLocalhostOnly := localhostOnly
+			vars.AuthMode = Clerk
+			api.FrontendURL = ""
+			api.PublicURL = "http://localhost:8080"
+			OIDCEnabled = true
+			localhostOnly = false
+			defer func() {
+				vars.AuthMode = savedAuthMode
+				api.FrontendURL = savedFrontendURL
+				api.PublicURL = savedPublicURL
+				OIDCEnabled = savedOIDCEnabled
+				localhostOnly = savedLocalhostOnly
+			}()
+
+			clientMetadata := base64.RawURLEncoding.EncodeToString([]byte(`{"r":["https://claude.ai/api/mcp/auth_callback"]}`))
+			clientID := "dcr_" + clientMetadata
+			resource := oidc.MCPResourceURL("http://localhost:8080")
+			claims := jwt.MapClaims{
+				"iss":       "http://localhost:8080",
+				"aud":       resource,
+				"client_id": clientID,
+				"sub":       person.ID.String(),
+				"exp":       time.Now().Add(time.Hour).Unix(),
+				"iat":       time.Now().Unix(),
+			}
+			token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+			tokenStr, err := token.SignedString(privateKey)
+			Expect(err).ToNot(HaveOccurred())
+
+			newContext := func(path string) echo.Context {
+				e := newEchoInstance(DefaultContext)
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req = req.WithContext(DefaultContext.Wrap(req.Context()))
+				return e.NewContext(req, httptest.NewRecorder())
+			}
+
+			authenticated, err := authenticateOIDCToken(newContext(oidc.MCPResourcePath), tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authenticated).To(BeTrue())
+
+			authenticated, err = authenticateOIDCToken(newContext("/auth/whoami"), tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authenticated).To(BeFalse())
+
+			e := newEchoInstance(DefaultContext)
+			e.Use(basicAuthMiddleware)
+			e.GET("/auth/whoami", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+			e.GET(oidc.MCPResourcePath, func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+			request := func(path string) int {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.Header.Set(echo.HeaderAuthorization, "Bearer "+tokenStr)
+				rec := httptest.NewRecorder()
+				e.ServeHTTP(rec, req)
+				return rec.Code
+			}
+			Expect(request(oidc.MCPResourcePath)).To(Equal(http.StatusOK))
+			Expect(request("/auth/whoami")).To(Equal(http.StatusUnauthorized))
+
+			claims["aud"] = clientID
+			legacyToken, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(privateKey)
+			Expect(err).ToNot(HaveOccurred())
+			authenticated, err = authenticateOIDCToken(newContext(oidc.MCPResourcePath), legacyToken)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authenticated).To(BeFalse())
 		})
 
 		ginkgo.It("rejects a JWT signed by a different key", func() {
@@ -468,6 +550,7 @@ var _ = ginkgo.Describe("OIDC", func() {
 			updated, err := provider.Storage.AuthRequestByID(gocontext.TODO(), ar.GetID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.GetSubject()).To(Equal(person.ID.String()))
+			Expect(updated.Done()).To(BeTrue())
 		})
 
 		ginkgo.It("rejects invalid credentials", func() {
@@ -720,6 +803,7 @@ CREATE TABLE IF NOT EXISTS oidc_public_keys (
 CREATE TABLE IF NOT EXISTS oidc_auth_requests (
 	id                   TEXT PRIMARY KEY,
 	client_id            TEXT NOT NULL,
+	resource             TEXT,
 	redirect_uri         TEXT NOT NULL,
 	scopes               TEXT[] NOT NULL DEFAULT '{}',
 	state                TEXT,
@@ -739,13 +823,17 @@ CREATE TABLE IF NOT EXISTS oidc_refresh_tokens (
 	id          TEXT PRIMARY KEY,
 	token       TEXT NOT NULL UNIQUE,
 	client_id   TEXT NOT NULL,
+	resource    TEXT,
 	subject     TEXT NOT NULL,
 	scopes      TEXT[] NOT NULL DEFAULT '{}',
 	auth_time   TIMESTAMPTZ NOT NULL,
 	rotation_id TEXT NOT NULL,
 	created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	expires_at  TIMESTAMPTZ NOT NULL
-);`
+);
+
+ALTER TABLE oidc_auth_requests ADD COLUMN IF NOT EXISTS resource TEXT;
+ALTER TABLE oidc_refresh_tokens ADD COLUMN IF NOT EXISTS resource TEXT;`
 	Expect(ctx.DB().Exec(ddl).Error).To(Succeed())
 }
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -803,7 +803,6 @@ CREATE TABLE IF NOT EXISTS oidc_public_keys (
 CREATE TABLE IF NOT EXISTS oidc_auth_requests (
 	id                   TEXT PRIMARY KEY,
 	client_id            TEXT NOT NULL,
-	resource             TEXT,
 	redirect_uri         TEXT NOT NULL,
 	scopes               TEXT[] NOT NULL DEFAULT '{}',
 	state                TEXT,
@@ -823,17 +822,13 @@ CREATE TABLE IF NOT EXISTS oidc_refresh_tokens (
 	id          TEXT PRIMARY KEY,
 	token       TEXT NOT NULL UNIQUE,
 	client_id   TEXT NOT NULL,
-	resource    TEXT,
 	subject     TEXT NOT NULL,
 	scopes      TEXT[] NOT NULL DEFAULT '{}',
 	auth_time   TIMESTAMPTZ NOT NULL,
 	rotation_id TEXT NOT NULL,
 	created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	expires_at  TIMESTAMPTZ NOT NULL
-);
-
-ALTER TABLE oidc_auth_requests ADD COLUMN IF NOT EXISTS resource TEXT;
-ALTER TABLE oidc_refresh_tokens ADD COLUMN IF NOT EXISTS resource TEXT;`
+);`
 	Expect(ctx.DB().Exec(ddl).Error).To(Succeed())
 }
 

--- a/auth/oidc_validate.go
+++ b/auth/oidc_validate.go
@@ -56,22 +56,8 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 		if iss, _ := claims["iss"].(string); iss != issuer {
 			continue
 		}
-		if aud, ok := claims["aud"].(string); !ok || aud != oidcmodels.ClientID {
-			// aud can also be []interface{}
-			if auds, ok := claims["aud"].([]any); ok {
-				found := false
-				for _, a := range auds {
-					if audStr, ok := a.(string); ok && audStr == oidcmodels.ClientID {
-						found = true
-						break
-					}
-				}
-				if !found {
-					continue
-				}
-			} else {
-				continue
-			}
+		if !audienceHasKnownClient(claims["aud"]) {
+			continue
 		}
 
 		sub, _ := claims["sub"].(string)
@@ -94,6 +80,24 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 
 	_ = lastErr
 	return false, nil
+}
+
+// audienceHasKnownClient reports whether the aud claim names a client this
+// provider issues tokens for. Dynamically registered clients each carry their
+// own client_id, so this cannot be a comparison against a single constant.
+// aud is a string or an array of strings per RFC 7519.
+func audienceHasKnownClient(aud any) bool {
+	switch v := aud.(type) {
+	case string:
+		return oidcmodels.IsKnownClient(v)
+	case []any:
+		for _, entry := range v {
+			if s, ok := entry.(string); ok && oidcmodels.IsKnownClient(s) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func loadOIDCPublicKeys(ctx context.Context) ([]*rsa.PublicKey, error) {

--- a/auth/oidc_validate.go
+++ b/auth/oidc_validate.go
@@ -56,7 +56,7 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 		if iss, _ := claims["iss"].(string); iss != issuer {
 			continue
 		}
-		if !audienceHasKnownClient(claims["aud"]) {
+		if !oidcTokenAudienceAllowed(c, claims, issuer) {
 			continue
 		}
 
@@ -82,22 +82,29 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 	return false, nil
 }
 
-// audienceHasKnownClient reports whether the aud claim names a client this
-// provider issues tokens for. Dynamically registered clients each carry their
-// own client_id, so this cannot be a comparison against a single constant.
-// aud is a string or an array of strings per RFC 7519.
-func audienceHasKnownClient(aud any) bool {
-	switch v := aud.(type) {
-	case string:
-		return oidcmodels.IsKnownClient(v)
-	case []any:
-		for _, entry := range v {
-			if s, ok := entry.(string); ok && oidcmodels.IsKnownClient(s) {
-				return true
-			}
-		}
+// oidcTokenAudienceAllowed confines dynamic-client credentials to the advertised MCP resource.
+func oidcTokenAudienceAllowed(c echo.Context, claims jwt.MapClaims, issuer string) bool {
+	clientID, _ := claims["client_id"].(string)
+	if clientID == "" || clientID == oidcmodels.ClientID {
+		return audienceEquals(claims["aud"], oidcmodels.ClientID)
 	}
-	return false
+	if !oidcmodels.IsDynamicClient(clientID) || c.Request().URL.Path != oidcmodels.MCPResourcePath {
+		return false
+	}
+	return audienceEquals(claims["aud"], oidcmodels.MCPResourceURL(issuer))
+}
+
+func audienceEquals(aud any, expected string) bool {
+	switch value := aud.(type) {
+	case string:
+		return value == expected
+	case []string:
+		return len(value) == 1 && value[0] == expected
+	case []any:
+		return len(value) == 1 && value[0] == expected
+	default:
+		return false
+	}
 }
 
 func loadOIDCPublicKeys(ctx context.Context) ([]*rsa.PublicKey, error) {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -33,6 +33,7 @@ type MCPServer struct {
 //   - delegated access token auth: owner = access_token.created_by
 func AuthMiddleware(next echov4.HandlerFunc) echov4.HandlerFunc {
 	return func(c echov4.Context) error {
+		setCORSHeaders(c.Response().Header())
 		ctx := c.Request().Context().(context.Context)
 
 		owner, err := resolveOwner(ctx)
@@ -51,6 +52,14 @@ func AuthMiddleware(next echov4.HandlerFunc) echov4.HandlerFunc {
 
 		return next(c)
 	}
+}
+
+func setCORSHeaders(header http.Header) {
+	header.Set("Access-Control-Allow-Origin", "*")
+	header.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	header.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID")
+	header.Set("Access-Control-Expose-Headers", "WWW-Authenticate, MCP-Session-Id")
+	header.Del("Access-Control-Allow-Credentials")
 }
 
 func registerPlaybookTools(s *server.MCPServer, hooks *server.Hooks) {


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2932

<img width="571" height="552" alt="image" src="https://github.com/user-attachments/assets/abb8dcda-048c-464c-b2e0-11289e5b3be4" />


Implements RFC 7591 Dynamic Client Registration to enable MCP clients (Claude Desktop, Codex CLI, VS Code) to self-register without pre-configured credentials. This allows the `/mcp` endpoint to authenticate clients dynamically while maintaining security through user consent.

## Key Changes

- **Dynamic Client Registration (RFC 7591)**: Added `/oauth/register` endpoint that accepts client metadata and returns a client_id encoding the metadata as base64url JSON. No secrets are issued; all clients are public.

- **Client ID Encoding**: Client metadata (name, redirect URIs, issued timestamp) is encoded into the client_id itself rather than persisted. This prevents unbounded table growth from open registration while re-validating all constraints on decode.

- **Consent Screen**: Dynamically registered clients now require explicit user approval before authorization codes are issued. The consent screen displays:
  - The application name
  - The authenticated user
  - The redirect URI where the code will be sent
  - Requested scopes
  
  Built-in CLI client skips consent for better UX.

- **Discovery Document Enhancement**: Updated OIDC discovery endpoints (`/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server`) to advertise the registration endpoint and S256 PKCE support.

- **Token Validation**: Modified `authenticateOIDCToken` to accept tokens issued to any known client (built-in CLI or dynamically registered) rather than only the hardcoded CLI client ID.

- **Redirect URI Validation**: Enforces RFC 8252 rules for public clients:
  - HTTPS required for all public hosts
  - Plain HTTP allowed only on loopback addresses (127.0.0.1, ::1, localhost)
  - No fragments, custom schemes, or missing hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added remote MCP access at the `/mcp` endpoint with OIDC authentication.
- Added dynamic client registration, browser-based consent, PKCE, refresh tokens, and MCP resource validation.
- Added connection guidance for Claude, Codex CLI, and older MCP clients.

## Bug Fixes
- Improved CORS support for MCP and OAuth requests, including preflight handling and authentication headers.
- Strengthened token audience and resource validation to restrict access appropriately.

## Documentation
- Updated setup instructions for authentication, permissions, registration, and MCP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->