### PR TITLE
feat(faro): add related config traversal to catalog change search

### DIFF
--- a/faro/catalog_change.go
+++ b/faro/catalog_change.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,16 +10,36 @@ import (
 	"github.com/flanksource/duty/query"
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/incident-commander/clientcmd"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
-var changeSearchLimit int
+var (
+	changeSearchConfig  string
+	changeSearchDepth   int
+	changeSearchLimit   int
+	changeSearchRelated string
+	changeSearchSoft    bool
+)
+
+type catalogChangeSearchOptions struct {
+	ConfigID   string
+	Depth      int
+	DepthSet   bool
+	Limit      int
+	Related    query.ChangeRelationDirection
+	RelatedSet bool
+	Soft       bool
+	SoftSet    bool
+}
 
 type catalogChangeSearchHit struct {
 	ID         string     `json:"id"`
+	ConfigID   string     `json:"config_id,omitempty"`
 	Agent      string     `json:"agent,omitempty"`
 	Name       string     `json:"name,omitempty"`
 	Namespace  string     `json:"namespace,omitempty"`
+	ConfigType string     `json:"config_type,omitempty"`
 	ChangeType string     `json:"change_type,omitempty"`
 	CreatedAt  *time.Time `json:"created_at,omitempty"`
 }
@@ -30,23 +51,85 @@ var CatalogChange = &cobra.Command{
 }
 
 var CatalogChangeSearch = &cobra.Command{
-	Use:   "search <QUERY>",
-	Short: "Search catalog changes using the PEG search grammar",
-	Long: `Search catalog changes using the PEG search grammar used by the web UI.
+	Use:   "search [QUERY]",
+	Short: "Search global or config-scoped catalog changes",
+	Long: `Search catalog changes globally using the PEG search grammar, or fetch
+changes for a catalog config and its related configs.
 
 Examples:
   catalog change search change_type=diff
   catalog change search "change_type=diff type=deployment"
-  catalog change search "severity=critical source=kubernetes" --limit 50`,
-	Args: cobra.MinimumNArgs(1),
+  catalog change search --config <config-id>
+  catalog change search --config <config-id> --related downstream --soft --depth 5`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return validateCatalogChangeSearch(strings.Join(args, " "), catalogChangeSearchOptions{
+			ConfigID:   changeSearchConfig,
+			Depth:      changeSearchDepth,
+			DepthSet:   cmd.Flags().Changed("depth"),
+			Limit:      changeSearchLimit,
+			Related:    query.ChangeRelationDirection(changeSearchRelated),
+			RelatedSet: cmd.Flags().Changed("related"),
+			Soft:       changeSearchSoft,
+			SoftSet:    cmd.Flags().Changed("soft"),
+		})
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		results, err := remoteSearchChanges(strings.Join(args, " "), changeSearchLimit)
+		var results []catalogChangeSearchHit
+		var err error
+		if strings.TrimSpace(changeSearchConfig) != "" {
+			results, err = remoteSearchRelatedChanges(catalogChangeSearchOptions{
+				ConfigID: strings.TrimSpace(changeSearchConfig),
+				Depth:    changeSearchDepth,
+				Limit:    changeSearchLimit,
+				Related:  query.ChangeRelationDirection(changeSearchRelated),
+				Soft:     changeSearchSoft,
+			})
+		} else {
+			results, err = remoteSearchChanges(strings.Join(args, " "), changeSearchLimit)
+		}
 		if err != nil {
 			return err
 		}
 		clicky.MustPrint(results, clicky.Flags.FormatOptions)
 		return nil
 	},
+}
+
+func validateCatalogChangeSearch(searchQuery string, opts catalogChangeSearchOptions) error {
+	hasQuery := strings.TrimSpace(searchQuery) != ""
+	hasConfig := strings.TrimSpace(opts.ConfigID) != ""
+
+	if !hasConfig && (opts.RelatedSet || opts.SoftSet || opts.DepthSet) {
+		return fmt.Errorf("--related, --soft, and --depth require --config")
+	}
+	if !hasQuery && !hasConfig {
+		return fmt.Errorf("a search query or --config is required")
+	}
+	if hasQuery && hasConfig {
+		return fmt.Errorf("search query and --config cannot be used together")
+	}
+	if !hasConfig {
+		return nil
+	}
+	if _, err := uuid.Parse(opts.ConfigID); err != nil {
+		return fmt.Errorf("invalid --config UUID: %w", err)
+	}
+
+	switch opts.Related {
+	case query.CatalogChangeRecursiveNone,
+		query.CatalogChangeRecursiveDownstream,
+		query.CatalogChangeRecursiveUpstream,
+		query.CatalogChangeRecursiveAll:
+	default:
+		return fmt.Errorf("--related must be one of none, downstream, upstream, or all")
+	}
+	if opts.Depth <= 0 {
+		return fmt.Errorf("--depth must be greater than zero")
+	}
+	if opts.Related == query.CatalogChangeRecursiveNone && (opts.SoftSet || opts.DepthSet) {
+		return fmt.Errorf("--soft and --depth require --related to be downstream, upstream, or all")
+	}
+	return nil
 }
 
 var CatalogChangeGet = &cobra.Command{
@@ -98,6 +181,46 @@ func remoteSearchChanges(searchQuery string, limit int) ([]catalogChangeSearchHi
 	return out, nil
 }
 
+func remoteSearchRelatedChanges(opts catalogChangeSearchOptions) ([]catalogChangeSearchHit, error) {
+	client, err := clientcmd.RemoteClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+
+	resp, err := client.SearchCatalogChanges(context.Background(), query.CatalogChangesSearchRequest{
+		BaseCatalogSearch: query.BaseCatalogSearch{
+			CatalogID: opts.ConfigID,
+			Depth:     opts.Depth,
+			PageSize:  opts.Limit,
+			Recursive: opts.Related,
+			Soft:      opts.Soft,
+			SortBy:    "-created_at",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]catalogChangeSearchHit, 0, len(resp.Changes))
+	for _, change := range resp.Changes {
+		out = append(out, catalogChangeSearchHit{
+			ID:         change.ID,
+			ConfigID:   change.ConfigID,
+			Agent:      change.AgentID,
+			Name:       change.ConfigName,
+			Namespace:  change.Tags["namespace"],
+			ConfigType: change.ConfigType,
+			ChangeType: change.ChangeType,
+			CreatedAt:  change.CreatedAt,
+		})
+	}
+	return out, nil
+}
+
 func remoteGetChange(id string) (any, error) {
 	client, err := clientcmd.RemoteClient()
 	if err != nil {
@@ -107,7 +230,11 @@ func remoteGetChange(id string) (any, error) {
 }
 
 func init() {
+	CatalogChangeSearch.Flags().StringVar(&changeSearchConfig, "config", "", "Catalog config UUID to scope changes")
+	CatalogChangeSearch.Flags().IntVar(&changeSearchDepth, "depth", 5, "Maximum relationship traversal depth")
 	CatalogChangeSearch.Flags().IntVar(&changeSearchLimit, "limit", 100, "Maximum number of results")
+	CatalogChangeSearch.Flags().StringVar(&changeSearchRelated, "related", string(query.CatalogChangeRecursiveNone), "Related config direction: none, downstream, upstream, or all")
+	CatalogChangeSearch.Flags().BoolVar(&changeSearchSoft, "soft", false, "Include soft relationships")
 	CatalogChange.AddCommand(CatalogChangeSearch, CatalogChangeGet)
 	clicky.RegisterSubCommand("catalog", CatalogChange)
 }

--- a/faro/catalog_change_test.go
+++ b/faro/catalog_change_test.go
@@ -63,6 +63,109 @@ var _ = ginkgo.Describe("faro catalog change", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	ginkgo.It("fetches config-scoped downstream changes including soft relationships", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/catalog/changes"))
+
+			var got query.CatalogChangesSearchRequest
+			Expect(json.NewDecoder(r.Body).Decode(&got)).To(Succeed())
+			Expect(got.CatalogID).To(Equal("03e294e4-a297-5047-5325-3041303b1ce0"))
+			Expect(got.Recursive).To(Equal(query.CatalogChangeRecursiveDownstream))
+			Expect(got.Depth).To(Equal(5))
+			Expect(got.Soft).To(BeTrue())
+			Expect(got.PageSize).To(Equal(25))
+			Expect(got.SortBy).To(Equal("-created_at"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"total":1,"changes":[{"id":"0274d556-6257-426a-b651-0a9bc35c26d8","config_id":"21e7586d-31fb-453c-a205-d73dc6b58eaa","agent_id":"00000000-0000-0000-0000-000000000000","name":"api","type":"Kubernetes::Deployment","tags":{"namespace":"production"},"change_type":"diff","created_at":"2026-06-24T16:41:38Z"}]}`))
+		}))
+		defer server.Close()
+		storeRemoteContext(server.URL)
+
+		items, err := remoteSearchRelatedChanges(catalogChangeSearchOptions{
+			ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0",
+			Related:  query.CatalogChangeRecursiveDownstream,
+			Depth:    5,
+			Soft:     true,
+			Limit:    25,
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(items).To(HaveLen(1))
+		Expect(items[0].ConfigID).To(Equal("21e7586d-31fb-453c-a205-d73dc6b58eaa"))
+		Expect(items[0].Name).To(Equal("api"))
+		Expect(items[0].Namespace).To(Equal("production"))
+		Expect(items[0].ConfigType).To(Equal("Kubernetes::Deployment"))
+		Expect(items[0].ChangeType).To(Equal("diff"))
+	})
+
+	validationTests := []struct {
+		name        string
+		searchQuery string
+		opts        catalogChangeSearchOptions
+		errorText   string
+	}{
+		{name: "requires a query or config", errorText: "query or --config is required"},
+		{
+			name:        "rejects query with config",
+			searchQuery: "change_type=diff",
+			opts:        catalogChangeSearchOptions{ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0", Depth: 5, Related: query.CatalogChangeRecursiveNone},
+			errorText:   "cannot be used together",
+		},
+		{
+			name:      "rejects relationship flags without config",
+			opts:      catalogChangeSearchOptions{Depth: 5, Related: query.CatalogChangeRecursiveDownstream, RelatedSet: true},
+			errorText: "require --config",
+		},
+		{
+			name:      "validates config UUID",
+			opts:      catalogChangeSearchOptions{ConfigID: "not-a-uuid", Depth: 5, Related: query.CatalogChangeRecursiveNone},
+			errorText: "invalid --config UUID",
+		},
+		{
+			name:      "validates related direction",
+			opts:      catalogChangeSearchOptions{ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0", Depth: 5, Related: "sideways"},
+			errorText: "--related must be one of",
+		},
+		{
+			name:      "validates depth",
+			opts:      catalogChangeSearchOptions{ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0", Related: query.CatalogChangeRecursiveDownstream},
+			errorText: "--depth must be greater than zero",
+		},
+		{
+			name:      "rejects soft with no relationship traversal",
+			opts:      catalogChangeSearchOptions{ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0", Depth: 5, Related: query.CatalogChangeRecursiveNone, Soft: true, SoftSet: true},
+			errorText: "require --related",
+		},
+		{
+			name:        "accepts a global query",
+			searchQuery: "change_type=diff",
+			opts:        catalogChangeSearchOptions{Depth: 5, Related: query.CatalogChangeRecursiveNone},
+		},
+		{
+			name: "accepts config relationship traversal",
+			opts: catalogChangeSearchOptions{
+				ConfigID: "03e294e4-a297-5047-5325-3041303b1ce0",
+				Depth:    5,
+				Related:  query.CatalogChangeRecursiveAll,
+				Soft:     true,
+				SoftSet:  true,
+			},
+		},
+	}
+
+	for _, tt := range validationTests {
+		ginkgo.It(tt.name, func() {
+			err := validateCatalogChangeSearch(tt.searchQuery, tt.opts)
+			if tt.errorText == "" {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(MatchError(ContainSubstring(tt.errorText)))
+			}
+		})
+	}
+
 	ginkgo.It("gets full change details from the PostgREST endpoint", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))

--- a/faro/catalog_help.go
+++ b/faro/catalog_help.go
@@ -103,15 +103,18 @@ Use "search" to find change IDs, then "get" to fetch the full change record.`
   faro catalog change get <change-id>`
 
 	if searchCmd := catalogSubcommand(changesCmd, "search"); searchCmd != nil {
-		searchCmd.Short = "Search catalog changes using the query language"
-		searchCmd.Long = `Search catalog change events using the catalog query language.
+		searchCmd.Short = "Search global or config-scoped catalog changes"
+		searchCmd.Long = `Search catalog change events globally using the query language, or scope the
+results to a catalog config and its related upstream or downstream configs.
 
-Use this to find historical changes by change type, catalog resource type,
-source, severity, name, tags, or other indexed fields. The result rows include
-change IDs that can be passed to "faro catalog change get".`
+Global searches accept change type, catalog resource type, source, severity,
+name, tags, and other indexed fields. Config-scoped searches accept relationship
+direction, depth, and soft relationship options. Result rows include change IDs
+that can be passed to "faro catalog change get".`
 		searchCmd.Example = `  faro catalog change search 'change_type=diff'
   faro catalog change search 'change_type=diff type=Kubernetes::Deployment'
-  faro catalog change search 'severity=critical source=kubernetes' --limit 50`
+  faro catalog change search --config <config-id>
+  faro catalog change search --config <config-id> --related downstream --soft --depth 5`
 	}
 
 	if getCmd := catalogSubcommand(changesCmd, "get"); getCmd != nil {

--- a/sdk/catalog.go
+++ b/sdk/catalog.go
@@ -112,6 +112,27 @@ func (c *Client) SearchCatalog(ctx context.Context, req query.SearchResourcesReq
 	return &out, nil
 }
 
+// SearchCatalogChanges returns config-scoped catalog changes, including changes
+// reached through the requested relationship direction.
+func (c *Client) SearchCatalogChanges(ctx context.Context, req query.CatalogChangesSearchRequest) (*query.CatalogChangesSearchResponse, error) {
+	r, err := c.R(ctx).Post(c.apiPath("/catalog/changes"), req)
+	if err != nil {
+		return nil, err
+	}
+	if !r.IsOK() {
+		body, _ := r.AsString()
+		if looksLikeHTML(r.Header.Get("Content-Type"), body) {
+			return nil, ErrHTMLResponse
+		}
+		return nil, fmt.Errorf("server returned %d: %s", r.StatusCode, strings.TrimSpace(body))
+	}
+	var out query.CatalogChangesSearchResponse
+	if err := decodeJSON(r, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // GetCatalogItem fetches a single catalog item by id (GET /resources/:id).
 func (c *Client) GetCatalogItem(ctx context.Context, id string) (*models.ConfigItem, error) {
 	r, err := c.R(ctx).Get(c.apiPath("/resources/" + id))

--- a/sdk/catalog_test.go
+++ b/sdk/catalog_test.go
@@ -34,6 +34,38 @@ var _ = ginkgo.Describe("catalog client", func() {
 		Expect(resp.Configs[0].Name).To(Equal("api"))
 	})
 
+	ginkgo.It("posts a config-scoped catalog changes request", func() {
+		var gotBody query.CatalogChangesSearchRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal(http.MethodPost))
+			Expect(r.URL.Path).To(Equal("/catalog/changes"))
+			Expect(json.NewDecoder(r.Body).Decode(&gotBody)).To(Succeed())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"total":1,"changes":[{"id":"change-1","config_id":"config-1","name":"api","type":"Kubernetes::Deployment","change_type":"diff"}]}`))
+		}))
+		defer server.Close()
+
+		resp, err := New(server.URL, "tok").SearchCatalogChanges(context.Background(), query.CatalogChangesSearchRequest{
+			BaseCatalogSearch: query.BaseCatalogSearch{
+				CatalogID: "config-1",
+				Recursive: query.CatalogChangeRecursiveDownstream,
+				Depth:     5,
+				Soft:      true,
+				PageSize:  25,
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotBody.CatalogID).To(Equal("config-1"))
+		Expect(gotBody.Recursive).To(Equal(query.CatalogChangeRecursiveDownstream))
+		Expect(gotBody.Depth).To(Equal(5))
+		Expect(gotBody.Soft).To(BeTrue())
+		Expect(gotBody.PageSize).To(Equal(25))
+		Expect(resp.Total).To(Equal(int64(1)))
+		Expect(resp.Changes).To(HaveLen(1))
+		Expect(resp.Changes[0].ConfigID).To(Equal("config-1"))
+	})
+
 	ginkgo.It("gets a single catalog item by id", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))


### PR DESCRIPTION
```sh
faro catalog changes search --config <config-id>

faro catalog changes search \
  --config <config-id> \
  --related downstream

faro catalog changes search \
  --config <config-id> \
  --related downstream \
  --soft \
  --depth 5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog change searches scoped to a configuration, with support for relationship direction, traversal depth, soft relationships, sorting, and pagination.
  * Added CLI options for configuration-scoped searches and UUID-based filtering.
  * Added SDK support for submitting catalog change search requests and receiving results.

* **Documentation**
  * Updated command help with supported filters, relationship options, and configuration-scoped search examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->