### PR TITLE
fix(faro): strip release binaries and remove action dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,18 +138,18 @@ windows:
 # requested matrix: linux amd64/arm64, darwin amd64/arm64, windows amd64/arm64.
 .PHONY: faro-linux
 faro-linux: $(TAILWIND_JS)
-	GOOS=linux GOARCH=amd64 go build -o ./.bin/faro_linux_amd64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=linux GOARCH=arm64 go build -o ./.bin/faro_linux_arm64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=linux GOARCH=amd64 go build -trimpath -o ./.bin/faro_linux_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=linux GOARCH=arm64 go build -trimpath -o ./.bin/faro_linux_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro-darwin
 faro-darwin: $(TAILWIND_JS)
-	GOOS=darwin GOARCH=amd64 go build -o ./.bin/faro_darwin_amd64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=darwin GOARCH=arm64 go build -o ./.bin/faro_darwin_arm64 -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=darwin GOARCH=amd64 go build -trimpath -o ./.bin/faro_darwin_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=darwin GOARCH=arm64 go build -trimpath -o ./.bin/faro_darwin_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro-windows
 faro-windows: $(TAILWIND_JS)
-	GOOS=windows GOARCH=amd64 go build -o ./.bin/faro_windows_amd64.exe -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=windows GOARCH=arm64 go build -o ./.bin/faro_windows_arm64.exe -ldflags "-X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=amd64 go build -trimpath -o ./.bin/faro_windows_amd64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=arm64 go build -trimpath -o ./.bin/faro_windows_arm64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro
 faro: faro-linux faro-darwin faro-windows

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -300,7 +300,7 @@ tasks:
     cmds:
       - mkdir -p {{.BIN_DIR}}
       - >-
-        go build -o {{.FARO_BINARY}} -ldflags "-X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
+        go build -trimpath -o {{.FARO_BINARY}} -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
     sources:
       - "**/*.go"
       - "{{.TAILWIND_JS}}"
@@ -316,7 +316,7 @@ tasks:
     desc: Build and install the faro client to the default go bin (go env GOBIN)
     cmds:
       - >-
-        go install -ldflags "-X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
+        go install -trimpath -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
 
   faro:run:
     desc: Build and run faro (pass args after --, e.g. `task faro:run -- whoami`)

--- a/api/playbook.go
+++ b/api/playbook.go
@@ -1,8 +1,16 @@
 package api
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/flanksource/artifacts"
+	"github.com/flanksource/clicky"
+	clickyapi "github.com/flanksource/clicky/api"
+	"github.com/flanksource/duty/models"
+	"github.com/flanksource/duty/shell"
 	"github.com/flanksource/duty/types"
 	"github.com/google/uuid"
 )
@@ -21,4 +29,148 @@ type PlaybookListItem struct {
 	CreatedAt   *time.Time `json:"created_at,omitempty"`
 	Parameters  types.JSON `json:"parameters,omitempty"`
 	Spec        types.JSON `json:"spec,omitempty"`
+}
+
+// PlaybookSQLResult is the result of a SQL playbook action.
+type PlaybookSQLResult struct {
+	Query   string           `json:"query,omitempty"`
+	Rows    []map[string]any `json:"rows,omitempty"`
+	Count   int              `json:"count"`
+	Columns []string         `json:"columns,omitempty"` // Used for maintaining order in UI
+}
+
+func (r PlaybookSQLResult) String() string   { return r.table().String() }
+func (r PlaybookSQLResult) ANSI() string     { return "\n" + r.table().ANSI() }
+func (r PlaybookSQLResult) HTML() string     { return r.table().HTML() }
+func (r PlaybookSQLResult) Markdown() string { return "\n" + r.table().Markdown() }
+
+func (r PlaybookSQLResult) table() clickyapi.TextTable {
+	headers := make([]clickyapi.Textable, len(r.Columns))
+	for i, col := range r.Columns {
+		headers[i] = clicky.Text(col, "font-bold")
+	}
+
+	rows := make([]clickyapi.TableRow, len(r.Rows))
+	for i, row := range r.Rows {
+		tr := make(clickyapi.TableRow)
+		for _, col := range r.Columns {
+			val := "NULL"
+			if v, exists := row[col]; exists && v != nil {
+				val = fmt.Sprint(v)
+			}
+			tr[col] = clickyapi.TypedValue{Textable: clicky.Text(val, "")}
+		}
+		rows[i] = tr
+	}
+
+	return clickyapi.TextTable{
+		Headers:    headers,
+		Rows:       rows,
+		FieldNames: r.Columns,
+	}
+}
+
+// PlaybookExecResult is the result of an exec playbook action.
+type PlaybookExecResult shell.ExecDetails
+
+func (r *PlaybookExecResult) GetArtifacts() []artifacts.Artifact {
+	if r == nil {
+		return nil
+	}
+	return r.Artifacts
+}
+
+func (r *PlaybookExecResult) GetStatus() models.PlaybookActionStatus {
+	if r.ExitCode != 0 {
+		return models.PlaybookActionStatusFailed
+	}
+	return models.PlaybookActionStatusCompleted
+}
+
+func (r PlaybookExecResult) String() string   { return r.plain(false) }
+func (r PlaybookExecResult) ANSI() string     { return r.plain(true) }
+func (r PlaybookExecResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
+func (r PlaybookExecResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
+
+func (r PlaybookExecResult) plain(colors bool) string {
+	var b strings.Builder
+
+	if r.Stdout != "" {
+		if colors {
+			b.WriteString(clicky.Text("Stdout:", "font-bold text-green-600").ANSI())
+		} else {
+			b.WriteString("Stdout:")
+		}
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(r.Stdout))
+		b.WriteString("\n")
+	}
+
+	if r.Stderr != "" {
+		if colors {
+			b.WriteString(clicky.Text("Stderr:", "font-bold text-red-600").ANSI())
+		} else {
+			b.WriteString("Stderr:")
+		}
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(r.Stderr))
+		b.WriteString("\n")
+	}
+
+	if r.ExitCode != 0 {
+		if colors {
+			b.WriteString(clicky.Text(fmt.Sprintf("Exit Code: %d", r.ExitCode), "text-red-600").ANSI())
+		} else {
+			fmt.Fprintf(&b, "Exit Code: %d", r.ExitCode)
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// PlaybookHTTPResult is the result of an HTTP playbook action.
+type PlaybookHTTPResult struct {
+	Content    string            `json:"content"`
+	Headers    map[string]string `json:"headers"`
+	StatusCode int               `json:"code"`
+}
+
+func (r PlaybookHTTPResult) String() string   { return r.plain(false) }
+func (r PlaybookHTTPResult) ANSI() string     { return r.plain(true) }
+func (r PlaybookHTTPResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
+func (r PlaybookHTTPResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
+
+func (r PlaybookHTTPResult) plain(colors bool) string {
+	var b strings.Builder
+
+	statusLabel := fmt.Sprintf("Status: %d", r.StatusCode)
+	if colors {
+		style := "text-green-600"
+		if r.StatusCode >= 400 {
+			style = "text-red-600"
+		}
+		b.WriteString(clicky.Text(statusLabel, "font-bold "+style).ANSI())
+	} else {
+		b.WriteString(statusLabel)
+	}
+	b.WriteString("\n")
+
+	if len(r.Headers) > 0 {
+		keys := make([]string, 0, len(r.Headers))
+		for k := range r.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&b, "  %s: %s\n", k, r.Headers[k])
+		}
+	}
+
+	if r.Content != "" {
+		b.WriteString("\n")
+		b.WriteString(r.Content)
+	}
+
+	return strings.TrimRight(b.String(), "\n")
 }

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/flanksource/clicky"
+	clickyapi "github.com/flanksource/clicky/api"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/flanksource/incident-commander/playbook/actions"
 	"github.com/flanksource/incident-commander/sdk"
 	"github.com/spf13/cobra"
 )
@@ -220,6 +222,140 @@ type PlaybookActionOutput struct {
 	Result any    `json:"result" yaml:"result"`
 }
 
+type sqlResult struct {
+	Query   string           `json:"query,omitempty"`
+	Rows    []map[string]any `json:"rows,omitempty"`
+	Count   int              `json:"count"`
+	Columns []string         `json:"columns,omitempty"`
+}
+
+func (r sqlResult) String() string   { return r.table().String() }
+func (r sqlResult) ANSI() string     { return "\n" + r.table().ANSI() }
+func (r sqlResult) HTML() string     { return r.table().HTML() }
+func (r sqlResult) Markdown() string { return "\n" + r.table().Markdown() }
+
+func (r sqlResult) table() clickyapi.TextTable {
+	headers := make([]clickyapi.Textable, len(r.Columns))
+	for i, col := range r.Columns {
+		headers[i] = clicky.Text(col, "font-bold")
+	}
+
+	rows := make([]clickyapi.TableRow, len(r.Rows))
+	for i, row := range r.Rows {
+		tr := make(clickyapi.TableRow)
+		for _, col := range r.Columns {
+			val := "NULL"
+			if v, exists := row[col]; exists && v != nil {
+				val = fmt.Sprint(v)
+			}
+			tr[col] = clickyapi.TypedValue{Textable: clicky.Text(val, "")}
+		}
+		rows[i] = tr
+	}
+
+	return clickyapi.TextTable{
+		Headers:    headers,
+		Rows:       rows,
+		FieldNames: r.Columns,
+	}
+}
+
+type execResult struct {
+	Stdout   string         `json:"stdout"`
+	Stderr   string         `json:"stderr"`
+	ExitCode int            `json:"exitCode"`
+	Path     string         `json:"path"`
+	Args     []string       `json:"args"`
+	Extra    map[string]any `json:"extra,omitempty"`
+}
+
+func (r execResult) String() string   { return r.plain(false) }
+func (r execResult) ANSI() string     { return r.plain(true) }
+func (r execResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
+func (r execResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
+
+func (r execResult) plain(colors bool) string {
+	var b strings.Builder
+
+	if r.Stdout != "" {
+		if colors {
+			b.WriteString(clicky.Text("Stdout:", "font-bold text-green-600").ANSI())
+		} else {
+			b.WriteString("Stdout:")
+		}
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(r.Stdout))
+		b.WriteString("\n")
+	}
+
+	if r.Stderr != "" {
+		if colors {
+			b.WriteString(clicky.Text("Stderr:", "font-bold text-red-600").ANSI())
+		} else {
+			b.WriteString("Stderr:")
+		}
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(r.Stderr))
+		b.WriteString("\n")
+	}
+
+	if r.ExitCode != 0 {
+		if colors {
+			b.WriteString(clicky.Text(fmt.Sprintf("Exit Code: %d", r.ExitCode), "text-red-600").ANSI())
+		} else {
+			fmt.Fprintf(&b, "Exit Code: %d", r.ExitCode)
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+type httpResult struct {
+	Content    string            `json:"content"`
+	Headers    map[string]string `json:"headers"`
+	StatusCode int               `json:"code"`
+}
+
+func (r httpResult) String() string   { return r.plain(false) }
+func (r httpResult) ANSI() string     { return r.plain(true) }
+func (r httpResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
+func (r httpResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
+
+func (r httpResult) plain(colors bool) string {
+	var b strings.Builder
+
+	statusLabel := fmt.Sprintf("Status: %d", r.StatusCode)
+	if colors {
+		style := "text-green-600"
+		if r.StatusCode >= 400 {
+			style = "text-red-600"
+		}
+		b.WriteString(clicky.Text(statusLabel, "font-bold "+style).ANSI())
+	} else {
+		b.WriteString(statusLabel)
+	}
+	b.WriteString("\n")
+
+	if len(r.Headers) > 0 {
+		keys := make([]string, 0, len(r.Headers))
+		for k := range r.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&b, "  %s: %s\n", k, r.Headers[k])
+		}
+	}
+
+	if r.Content != "" {
+		b.WriteString("\n")
+		b.WriteString(r.Content)
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
 func PlaybookActionResults(summary *sdk.PlaybookSummary) PlaybookRunOutput {
 	if summary == nil || len(summary.Actions) == 0 {
 		return PlaybookRunOutput{Result: map[string]any{}}
@@ -270,17 +406,17 @@ func resolveActionResult(actionType string, raw map[string]any) any {
 	}
 	switch actionType {
 	case "sql":
-		var r actions.SQLResult
+		var r sqlResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}
 	case "exec":
-		var r actions.ExecDetails
+		var r execResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}
 	case "http":
-		var r actions.HTTPResult
+		var r httpResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}

--- a/clientcmd/playbook.go
+++ b/clientcmd/playbook.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/flanksource/clicky"
-	clickyapi "github.com/flanksource/clicky/api"
 	"github.com/flanksource/commons/logger"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
@@ -222,140 +219,6 @@ type PlaybookActionOutput struct {
 	Result any    `json:"result" yaml:"result"`
 }
 
-type sqlResult struct {
-	Query   string           `json:"query,omitempty"`
-	Rows    []map[string]any `json:"rows,omitempty"`
-	Count   int              `json:"count"`
-	Columns []string         `json:"columns,omitempty"`
-}
-
-func (r sqlResult) String() string   { return r.table().String() }
-func (r sqlResult) ANSI() string     { return "\n" + r.table().ANSI() }
-func (r sqlResult) HTML() string     { return r.table().HTML() }
-func (r sqlResult) Markdown() string { return "\n" + r.table().Markdown() }
-
-func (r sqlResult) table() clickyapi.TextTable {
-	headers := make([]clickyapi.Textable, len(r.Columns))
-	for i, col := range r.Columns {
-		headers[i] = clicky.Text(col, "font-bold")
-	}
-
-	rows := make([]clickyapi.TableRow, len(r.Rows))
-	for i, row := range r.Rows {
-		tr := make(clickyapi.TableRow)
-		for _, col := range r.Columns {
-			val := "NULL"
-			if v, exists := row[col]; exists && v != nil {
-				val = fmt.Sprint(v)
-			}
-			tr[col] = clickyapi.TypedValue{Textable: clicky.Text(val, "")}
-		}
-		rows[i] = tr
-	}
-
-	return clickyapi.TextTable{
-		Headers:    headers,
-		Rows:       rows,
-		FieldNames: r.Columns,
-	}
-}
-
-type execResult struct {
-	Stdout   string         `json:"stdout"`
-	Stderr   string         `json:"stderr"`
-	ExitCode int            `json:"exitCode"`
-	Path     string         `json:"path"`
-	Args     []string       `json:"args"`
-	Extra    map[string]any `json:"extra,omitempty"`
-}
-
-func (r execResult) String() string   { return r.plain(false) }
-func (r execResult) ANSI() string     { return r.plain(true) }
-func (r execResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
-func (r execResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
-
-func (r execResult) plain(colors bool) string {
-	var b strings.Builder
-
-	if r.Stdout != "" {
-		if colors {
-			b.WriteString(clicky.Text("Stdout:", "font-bold text-green-600").ANSI())
-		} else {
-			b.WriteString("Stdout:")
-		}
-		b.WriteString("\n")
-		b.WriteString(strings.TrimSpace(r.Stdout))
-		b.WriteString("\n")
-	}
-
-	if r.Stderr != "" {
-		if colors {
-			b.WriteString(clicky.Text("Stderr:", "font-bold text-red-600").ANSI())
-		} else {
-			b.WriteString("Stderr:")
-		}
-		b.WriteString("\n")
-		b.WriteString(strings.TrimSpace(r.Stderr))
-		b.WriteString("\n")
-	}
-
-	if r.ExitCode != 0 {
-		if colors {
-			b.WriteString(clicky.Text(fmt.Sprintf("Exit Code: %d", r.ExitCode), "text-red-600").ANSI())
-		} else {
-			fmt.Fprintf(&b, "Exit Code: %d", r.ExitCode)
-		}
-		b.WriteString("\n")
-	}
-
-	return strings.TrimRight(b.String(), "\n")
-}
-
-type httpResult struct {
-	Content    string            `json:"content"`
-	Headers    map[string]string `json:"headers"`
-	StatusCode int               `json:"code"`
-}
-
-func (r httpResult) String() string   { return r.plain(false) }
-func (r httpResult) ANSI() string     { return r.plain(true) }
-func (r httpResult) HTML() string     { return "<pre>" + r.plain(false) + "</pre>" }
-func (r httpResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
-
-func (r httpResult) plain(colors bool) string {
-	var b strings.Builder
-
-	statusLabel := fmt.Sprintf("Status: %d", r.StatusCode)
-	if colors {
-		style := "text-green-600"
-		if r.StatusCode >= 400 {
-			style = "text-red-600"
-		}
-		b.WriteString(clicky.Text(statusLabel, "font-bold "+style).ANSI())
-	} else {
-		b.WriteString(statusLabel)
-	}
-	b.WriteString("\n")
-
-	if len(r.Headers) > 0 {
-		keys := make([]string, 0, len(r.Headers))
-		for k := range r.Headers {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(&b, "  %s: %s\n", k, r.Headers[k])
-		}
-	}
-
-	if r.Content != "" {
-		b.WriteString("\n")
-		b.WriteString(r.Content)
-	}
-
-	return strings.TrimRight(b.String(), "\n")
-}
-
 func PlaybookActionResults(summary *sdk.PlaybookSummary) PlaybookRunOutput {
 	if summary == nil || len(summary.Actions) == 0 {
 		return PlaybookRunOutput{Result: map[string]any{}}
@@ -406,17 +269,17 @@ func resolveActionResult(actionType string, raw map[string]any) any {
 	}
 	switch actionType {
 	case "sql":
-		var r sqlResult
+		var r api.PlaybookSQLResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}
 	case "exec":
-		var r execResult
+		var r api.PlaybookExecResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}
 	case "http":
-		var r httpResult
+		var r api.PlaybookHTTPResult
 		if err := json.Unmarshal(data, &r); err == nil {
 			return r
 		}

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 				"columns": []string{"name", "ready"},
 				"rows":    []map[string]any{{"name": "api", "ready": true}},
 			},
-			expectedType: sqlResult{},
+			expectedType: api.PlaybookSQLResult{},
 			expected:     []string{"api", "true"},
 		},
 		{
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 				"args":     []string{"-c", "echo ok"},
 				"extra":    map[string]any{"commit": "abc123"},
 			},
-			expectedType: execResult{},
+			expectedType: api.PlaybookExecResult{},
 			expected:     []string{"Stdout:", "ok", "Stderr:", "warning", "Exit Code: 2"},
 		},
 		{
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 				"headers": map[string]string{"Content-Type": "application/json"},
 				"content": `{"ready":true}`,
 			},
-			expectedType: httpResult{},
+			expectedType: api.PlaybookHTTPResult{},
 			expected:     []string{"Status: 200", "Content-Type: application/json", `{"ready":true}`},
 		},
 	}
@@ -172,7 +172,7 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 
 	ginkgo.It("preserves exec action metadata", func() {
 		result := resolveActionResult("exec", actionResults[1].result)
-		Expect(result).To(Equal(execResult{
+		Expect(result).To(Equal(api.PlaybookExecResult{
 			Stdout: "ok", Stderr: "warning", ExitCode: 2,
 			Path: "/bin/sh", Args: []string{"-c", "echo ok"}, Extra: map[string]any{"commit": "abc123"},
 		}))

--- a/clientcmd/playbook_test.go
+++ b/clientcmd/playbook_test.go
@@ -3,6 +3,7 @@ package clientcmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -113,6 +114,68 @@ var _ = ginkgo.Describe("playbook CLI helpers", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(summary.Run.Status).To(Equal(models.PlaybookRunStatusCompleted))
 		Expect(stderr.String()).To(BeEmpty())
+	})
+
+	actionResults := []struct {
+		name         string
+		actionType   string
+		result       map[string]any
+		expectedType any
+		expected     []string
+	}{
+		{
+			name:       "SQL",
+			actionType: "sql",
+			result: map[string]any{
+				"columns": []string{"name", "ready"},
+				"rows":    []map[string]any{{"name": "api", "ready": true}},
+			},
+			expectedType: sqlResult{},
+			expected:     []string{"api", "true"},
+		},
+		{
+			name:       "exec",
+			actionType: "exec",
+			result: map[string]any{
+				"stdout":   "ok",
+				"stderr":   "warning",
+				"exitCode": 2,
+				"path":     "/bin/sh",
+				"args":     []string{"-c", "echo ok"},
+				"extra":    map[string]any{"commit": "abc123"},
+			},
+			expectedType: execResult{},
+			expected:     []string{"Stdout:", "ok", "Stderr:", "warning", "Exit Code: 2"},
+		},
+		{
+			name:       "HTTP",
+			actionType: "http",
+			result: map[string]any{
+				"code":    200,
+				"headers": map[string]string{"Content-Type": "application/json"},
+				"content": `{"ready":true}`,
+			},
+			expectedType: httpResult{},
+			expected:     []string{"Status: 200", "Content-Type: application/json", `{"ready":true}`},
+		},
+	}
+	for _, tt := range actionResults {
+		ginkgo.It("preserves "+tt.name+" action result formatting", func() {
+			result := resolveActionResult(tt.actionType, tt.result)
+			Expect(result).To(BeAssignableToTypeOf(tt.expectedType))
+			formatted := fmt.Sprint(result)
+			for _, expected := range tt.expected {
+				Expect(formatted).To(ContainSubstring(expected))
+			}
+		})
+	}
+
+	ginkgo.It("preserves exec action metadata", func() {
+		result := resolveActionResult("exec", actionResults[1].result)
+		Expect(result).To(Equal(execResult{
+			Stdout: "ok", Stderr: "warning", ExitCode: 2,
+			Path: "/bin/sh", Args: []string{"-c", "echo ok"}, Extra: map[string]any{"commit": "abc123"},
+		}))
 	})
 
 	ginkgo.It("prints only the action result for playbook run summaries", func() {

--- a/playbook/actions/exec.go
+++ b/playbook/actions/exec.go
@@ -1,80 +1,18 @@
 package actions
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/flanksource/artifacts"
-	"github.com/flanksource/clicky"
 	"github.com/flanksource/duty/context"
-	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/shell"
+	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
 )
 
 type ExecAction struct {
 }
 
-type ExecDetails shell.ExecDetails
-
-func (e *ExecDetails) GetArtifacts() []artifacts.Artifact {
-	if e == nil {
-		return nil
-	}
-	return e.Artifacts
-}
-
-func (e *ExecDetails) GetStatus() models.PlaybookActionStatus {
-	if e.ExitCode != 0 {
-		return models.PlaybookActionStatusFailed
-	}
-
-	return models.PlaybookActionStatusCompleted
-}
+type ExecDetails = api.PlaybookExecResult
 
 func (c *ExecAction) Run(ctx context.Context, exec v1.ExecAction) (*ExecDetails, error) {
 	details, err := shell.Run(ctx, exec.ToShellExec())
 	return (*ExecDetails)(details), err
-}
-
-func (e ExecDetails) String() string  { return e.plain(false) }
-func (e ExecDetails) ANSI() string    { return e.plain(true) }
-func (e ExecDetails) HTML() string    { return "<pre>" + e.plain(false) + "</pre>" }
-func (e ExecDetails) Markdown() string { return "```\n" + e.plain(false) + "\n```" }
-
-func (e ExecDetails) plain(colors bool) string {
-	var b strings.Builder
-
-	if e.Stdout != "" {
-		if colors {
-			b.WriteString(clicky.Text("Stdout:", "font-bold text-green-600").ANSI())
-		} else {
-			b.WriteString("Stdout:")
-		}
-		b.WriteString("\n")
-		b.WriteString(strings.TrimSpace(e.Stdout))
-		b.WriteString("\n")
-	}
-
-	if e.Stderr != "" {
-		if colors {
-			b.WriteString(clicky.Text("Stderr:", "font-bold text-red-600").ANSI())
-		} else {
-			b.WriteString("Stderr:")
-		}
-		b.WriteString("\n")
-		b.WriteString(strings.TrimSpace(e.Stderr))
-		b.WriteString("\n")
-	}
-
-	if e.ExitCode != 0 {
-		if colors {
-			b.WriteString(clicky.Text(fmt.Sprintf("Exit Code: %d", e.ExitCode), "text-red-600").ANSI())
-		} else {
-			fmt.Fprintf(&b, "Exit Code: %d", e.ExitCode)
-		}
-		b.WriteString("\n")
-	}
-
-	return strings.TrimRight(b.String(), "\n")
 }

--- a/playbook/actions/http.go
+++ b/playbook/actions/http.go
@@ -2,21 +2,15 @@ package actions
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
-	"github.com/flanksource/clicky"
 	"github.com/flanksource/commons/http"
 	"github.com/flanksource/duty/connection"
 	"github.com/flanksource/duty/context"
+	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
 )
 
-type HTTPResult struct {
-	Content    string            `json:"content"`
-	Headers    map[string]string `json:"headers"`
-	StatusCode int               `json:"code"`
-}
+type HTTPResult = api.PlaybookHTTPResult
 
 type HTTP struct {
 }
@@ -64,45 +58,6 @@ func (c *HTTP) Run(ctx context.Context, action v1.HTTPAction) (*HTTPResult, erro
 	}
 
 	return result, nil
-}
-
-func (r HTTPResult) String() string  { return r.plain(false) }
-func (r HTTPResult) ANSI() string    { return r.plain(true) }
-func (r HTTPResult) HTML() string    { return "<pre>" + r.plain(false) + "</pre>" }
-func (r HTTPResult) Markdown() string { return "```\n" + r.plain(false) + "\n```" }
-
-func (r HTTPResult) plain(colors bool) string {
-	var b strings.Builder
-
-	statusLabel := fmt.Sprintf("Status: %d", r.StatusCode)
-	if colors {
-		style := "text-green-600"
-		if r.StatusCode >= 400 {
-			style = "text-red-600"
-		}
-		b.WriteString(clicky.Text(statusLabel, "font-bold "+style).ANSI())
-	} else {
-		b.WriteString(statusLabel)
-	}
-	b.WriteString("\n")
-
-	if len(r.Headers) > 0 {
-		keys := make([]string, 0, len(r.Headers))
-		for k := range r.Headers {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(&b, "  %s: %s\n", k, r.Headers[k])
-		}
-	}
-
-	if r.Content != "" {
-		b.WriteString("\n")
-		b.WriteString(r.Content)
-	}
-
-	return strings.TrimRight(b.String(), "\n")
 }
 
 func (c *HTTP) makeRequest(ctx context.Context, action v1.HTTPAction, client *http.Client) (*http.Response, error) {

--- a/playbook/actions/sql.go
+++ b/playbook/actions/sql.go
@@ -4,20 +4,14 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/flanksource/clicky"
-	"github.com/flanksource/clicky/api"
 	pkgConnection "github.com/flanksource/duty/connection"
 	"github.com/flanksource/duty/context"
 
+	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
 )
 
-type SQLResult struct {
-	Query   string           `json:"query,omitempty"`
-	Rows    []map[string]any `json:"rows,omitempty"`
-	Count   int              `json:"count"`
-	Columns []string         `json:"columns,omitempty"` // Used for maintaining order in UI
-}
+type SQLResult = api.PlaybookSQLResult
 
 type SQL struct{}
 
@@ -91,35 +85,4 @@ func querySQL(driver string, connection string, query string) (*SQLResult, error
 
 	result.Count = len(result.Rows)
 	return &result, nil
-}
-
-func (r SQLResult) String() string   { return r.table().String() }
-func (r SQLResult) ANSI() string     { return "\n" + r.table().ANSI() }
-func (r SQLResult) HTML() string     { return r.table().HTML() }
-func (r SQLResult) Markdown() string { return "\n" + r.table().Markdown() }
-
-func (r SQLResult) table() api.TextTable {
-	headers := make([]api.Textable, len(r.Columns))
-	for i, col := range r.Columns {
-		headers[i] = clicky.Text(col, "font-bold")
-	}
-
-	rows := make([]api.TableRow, len(r.Rows))
-	for i, row := range r.Rows {
-		tr := make(api.TableRow)
-		for _, col := range r.Columns {
-			val := "NULL"
-			if v, exists := row[col]; exists && v != nil {
-				val = fmt.Sprint(v)
-			}
-			tr[col] = api.TypedValue{Textable: clicky.Text(val, "")}
-		}
-		rows[i] = tr
-	}
-
-	return api.TextTable{
-		Headers:    headers,
-		Rows:       rows,
-		FieldNames: r.Columns,
-	}
 }


### PR DESCRIPTION
## Summary

- build every Faro release target with `-trimpath` and linker flags `-s -w`
- move the canonical SQL, exec, and HTTP playbook result types and their formatters into the existing `api` package
- keep aliases in `playbook/actions` for compatibility and consume the shared API types from `clientcmd`
- derive the shared exec result from `duty/shell.ExecDetails`, retaining its existing field source of truth

## Impact

For Linux amd64:

| Build | Size |
| --- | ---: |
| Current published UPX-packed binary | 124,057,252 bytes (118.3 MiB) |
| This branch, stripped and UPX-packed | 63,982,036 bytes (61.0 MiB) |

That is a 48.4% reduction from the current published artifact. On the same source/toolchain, removing the action dependency reduces the stripped+UPX result by another 3,501,644 bytes (5.2%).

The Faro dependency graph drops from 2,663 to 2,484 packages (179 removed), and no longer contains `playbook/actions`. Moving the definitions into `api` adds no packages back to the Faro graph.

This is a substantial first reduction, though further dependency work is still needed to approach the 5–10 MB goal.

## Verification

- `ginkgo --label-filter='!ignore_local' ./api ./clientcmd` — 24 API and 67 clientcmd specs passed
- `ginkgo --label-filter='!ignore_local && !slow' ./playbook/actions ./playbook/runner` — 70 action and 30 runner specs passed
- `ginkgo --label-filter='!ignore_local' ./faro` — 31 specs passed
- built and ran the stripped Linux amd64 binary; version output remains intact and size is unchanged after centralizing the types
- parsed `Taskfile.yml` with Task v3.45.4
- verified all six Makefile Faro targets include the stripping flags

Addresses #3415