### PR TITLE
fix(faro): exclude local connection tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,18 +138,18 @@ windows:
 # requested matrix: linux amd64/arm64, darwin amd64/arm64, windows amd64/arm64.
 .PHONY: faro-linux
 faro-linux: $(TAILWIND_JS)
-	GOOS=linux GOARCH=amd64 go build -trimpath -o ./.bin/faro_linux_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=linux GOARCH=arm64 go build -trimpath -o ./.bin/faro_linux_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=linux GOARCH=amd64 go build -tags=faro -trimpath -o ./.bin/faro_linux_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=linux GOARCH=arm64 go build -tags=faro -trimpath -o ./.bin/faro_linux_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro-darwin
 faro-darwin: $(TAILWIND_JS)
-	GOOS=darwin GOARCH=amd64 go build -trimpath -o ./.bin/faro_darwin_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=darwin GOARCH=arm64 go build -trimpath -o ./.bin/faro_darwin_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=darwin GOARCH=amd64 go build -tags=faro -trimpath -o ./.bin/faro_darwin_amd64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=darwin GOARCH=arm64 go build -tags=faro -trimpath -o ./.bin/faro_darwin_arm64 -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro-windows
 faro-windows: $(TAILWIND_JS)
-	GOOS=windows GOARCH=amd64 go build -trimpath -o ./.bin/faro_windows_amd64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
-	GOOS=windows GOARCH=arm64 go build -trimpath -o ./.bin/faro_windows_arm64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=amd64 go build -tags=faro -trimpath -o ./.bin/faro_windows_amd64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
+	GOOS=windows GOARCH=arm64 go build -tags=faro -trimpath -o ./.bin/faro_windows_arm64.exe -ldflags "-s -w -X \"main.version=$(VERSION_TAG)\"" ./faro
 
 .PHONY: faro
 faro: faro-linux faro-darwin faro-windows

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -300,7 +300,7 @@ tasks:
     cmds:
       - mkdir -p {{.BIN_DIR}}
       - >-
-        go build -trimpath -o {{.FARO_BINARY}} -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
+        go build -tags=faro -trimpath -o {{.FARO_BINARY}} -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
     sources:
       - "**/*.go"
       - "{{.TAILWIND_JS}}"
@@ -316,7 +316,7 @@ tasks:
     desc: Build and install the faro client to the default go bin (go env GOBIN)
     cmds:
       - >-
-        go install -trimpath -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
+        go install -tags=faro -trimpath -ldflags "-s -w -X \"main.version={{.VERSION}} built at {{.BUILD_DATE}}\"" ./faro
 
   faro:run:
     desc: Build and run faro (pass args after --, e.g. `task faro:run -- whoami`)

--- a/clientcmd/connection.go
+++ b/clientcmd/connection.go
@@ -363,13 +363,8 @@ func runConnectionAdd(flags *ConnectionFlags) error {
 		}
 	}
 
-	if flags.DryRun {
-		out, err := marshalDryRunOutput(flags)
-		if err != nil {
-			return fmt.Errorf("failed to marshal dry-run output: %w", err)
-		}
-		fmt.Print(string(out))
-		return nil
+	if handled, err := runConnectionDryRun(flags); handled || err != nil {
+		return err
 	}
 
 	if err := validateConnectionFlags(flags); err != nil {

--- a/clientcmd/connection_browser.go
+++ b/clientcmd/connection_browser.go
@@ -1,3 +1,5 @@
+//go:build !faro
+
 package clientcmd
 
 import (

--- a/clientcmd/connection_browser_teardown.go
+++ b/clientcmd/connection_browser_teardown.go
@@ -1,3 +1,5 @@
+//go:build !faro
+
 package clientcmd
 
 import (

--- a/clientcmd/connection_browser_unix.go
+++ b/clientcmd/connection_browser_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !faro
 
 package clientcmd
 

--- a/clientcmd/connection_browser_windows.go
+++ b/clientcmd/connection_browser_windows.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !faro
 
 package clientcmd
 

--- a/clientcmd/connection_crd.go
+++ b/clientcmd/connection_crd.go
@@ -1,3 +1,5 @@
+//go:build !faro
+
 package clientcmd
 
 import (

--- a/clientcmd/connection_crd_test.go
+++ b/clientcmd/connection_crd_test.go
@@ -1,3 +1,5 @@
+//go:build !faro
+
 package clientcmd
 
 import (

--- a/clientcmd/connection_dryrun.go
+++ b/clientcmd/connection_dryrun.go
@@ -1,0 +1,25 @@
+//go:build !faro
+
+package clientcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func addConnectionDryRunFlag(cmd *cobra.Command, flags *ConnectionFlags) {
+	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Output Kubernetes YAML instead of saving to database")
+}
+
+func runConnectionDryRun(flags *ConnectionFlags) (bool, error) {
+	if !flags.DryRun {
+		return false, nil
+	}
+	out, err := marshalDryRunOutput(flags)
+	if err != nil {
+		return true, fmt.Errorf("failed to marshal dry-run output: %w", err)
+	}
+	fmt.Print(string(out))
+	return true, nil
+}

--- a/clientcmd/connection_dryrun_faro.go
+++ b/clientcmd/connection_dryrun_faro.go
@@ -1,0 +1,9 @@
+//go:build faro
+
+package clientcmd
+
+import "github.com/spf13/cobra"
+
+func addConnectionDryRunFlag(_ *cobra.Command, _ *ConnectionFlags) {}
+
+func runConnectionDryRun(_ *ConnectionFlags) (bool, error) { return false, nil }

--- a/clientcmd/connection_flags.go
+++ b/clientcmd/connection_flags.go
@@ -238,7 +238,7 @@ func addCommonFlags(cmd *cobra.Command, flags *ConnectionFlags) {
 	cmd.Flags().StringVar(&flags.Name, "name", "", "Connection name (required)")
 	cmd.Flags().StringVar(&flags.Namespace, "namespace", "", "Connection namespace (required)")
 	cmd.Flags().BoolVar(&flags.Test, "test", false, "Test connection before saving")
-	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Output Kubernetes YAML instead of saving to database")
+	addConnectionDryRunFlag(cmd, flags)
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("namespace")
 }

--- a/faro/connection_test.go
+++ b/faro/connection_test.go
@@ -1,0 +1,34 @@
+//go:build faro
+
+package main
+
+import (
+	"github.com/flanksource/incident-commander/clientcmd"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = ginkgo.Describe("faro connections", func() {
+	ginkgo.It("registers remote operations without local browser or CRD commands", func() {
+		root := &cobra.Command{Use: "faro"}
+		clientcmd.RegisterClientCommands(root)
+
+		connection, _, err := root.Find([]string{"connection"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(connection).ToNot(BeNil())
+
+		add, _, err := root.Find([]string{"connection", "add", "http"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(add).ToNot(BeNil())
+		Expect(add.Flags().Lookup("dry-run")).To(BeNil())
+
+		test, _, err := root.Find([]string{"connection", "test"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(test).ToNot(BeNil())
+
+		for _, child := range connection.Commands() {
+			Expect(child.Name()).ToNot(Equal("login"))
+		}
+	})
+})


### PR DESCRIPTION
## Summary

- build Faro with a dedicated `faro` build tag
- exclude the browser automation and connection CRD/dry-run implementation from tagged Faro builds
- retain Faro's remote `connection add` and saved `connection test` operations
- leave the full mission-control connection surface unchanged, including browser login and CRD dry-run

Related to #3415.
Builds on the Faro stripping and action-dependency reduction merged in #3416.

## Size and dependency impact

Measured on Linux amd64 with Go 1.26.1 and UPX 3.96. Both `main` and this branch used #3416's stripped build flags; this branch additionally uses the `faro` tag introduced here:

```sh
# main after #3416
GOOS=linux GOARCH=amd64 go build -trimpath -o /tmp/faro-size/faro-parent -ldflags '-s -w -X "main.version=measurement"' ./faro
cp /tmp/faro-size/faro-parent /tmp/faro-size/faro-parent-upx
upx -1 /tmp/faro-size/faro-parent-upx
GOOS=linux GOARCH=amd64 go list -deps ./faro | sort > /tmp/faro-size/deps-parent.txt

# This PR
GOOS=linux GOARCH=amd64 go build -tags=faro -trimpath -o /tmp/faro-size/faro-final -ldflags '-s -w -X "main.version=measurement"' ./faro
cp /tmp/faro-size/faro-final /tmp/faro-size/faro-final-upx
upx -1 /tmp/faro-size/faro-final-upx
GOOS=linux GOARCH=amd64 go list -tags=faro -deps ./faro | sort > /tmp/faro-size/deps-final.txt
```

| Artifact | `main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Stripped raw | 174,657,801 bytes (166.57 MiB) | 172,278,025 bytes (164.30 MiB) | -2,379,776 bytes (-1.363%) |
| UPX `-1` | 63,982,020 bytes (61.02 MiB) | 62,966,972 bytes (60.05 MiB) | -1,015,048 bytes (-1.586%) |
| Dependency packages | 2,484 | 2,352 | -132 |

The removed graph includes all 55 `cdproto` packages, 3 `chromedp` packages plus `chromedp/sysutil`, the local `connection` package, 14 `go-scm` packages, and 16 `go-redis` packages. No packages were added.

## Verification

- `GOFLAGS='-tags=faro' ginkgo --label-filter='!ignore_local' ./faro` — 32 specs passed
- `ginkgo --label-filter='!ignore_local' ./clientcmd` — 67 specs passed
- `make dev` — full mission-control binary compiled successfully
- full binary help still registers `connection login`, `connection test`, and `connection add ... --dry-run`
- tagged Faro help registers `connection add` and `connection test`, with browser login and CRD dry-run absent
- tagged cross-builds succeeded for Windows amd64 and Darwin arm64
- `git diff --check` passed

## Caveat / next target

Faro intentionally no longer includes local Chromium login/session capture or local CRD dry-run generation; remote connection creation and saved-connection tests remain available. The remaining Kubernetes/API-v1 graph is still reachable through Faro playbook commands, making that playbook CRD boundary the next likely target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Faro-specific builds for Linux, macOS, and Windows.
  * Faro builds support connection creation and testing commands without local browser login or dry-run options.
  * Standard builds retain connection dry-run support, including YAML output.

* **Bug Fixes**
  * Improved dry-run handling and error propagation for connection commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->