### PR TITLE
feat(mcp): search changes for related configs

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -39,7 +39,7 @@
 | [`search_catalog_access_log`](#search_catalog_access_log) | read-only | Search historical sign-in and access activity logs for a specific infrastructure configuration item. |
 | [`search_catalog_access_mapping`](#search_catalog_access_mapping) | read-only | Search the current access state and RBAC mappings for infrastructure resources to audit who currently holds permissions. |
 | [`search_catalog_access_reviews`](#search_catalog_access_reviews) | read-only | Search historical access review and certification events to verify when user permissions were last audited or validated. |
-| [`search_catalog_changes`](#search_catalog_changes) | read-only | Search and find configuration change events across catalog items. |
+| [`search_catalog_changes`](#search_catalog_changes) | read-only | Search configuration change events globally or for a config and its related configs. |
 | [`search_health_checks`](#search_health_checks) | read-only | Search and find health checks returning JSON array with check metadata |
 | `{playbook}_{namespace}_{category}` | mutating | Dynamic per-session playbook tools. Parameters derived from playbook spec. |
 | `view_{name}_{namespace}` | read-only | Dynamic view tools synced hourly. Returns table rows by default with select/page/limit controls. |
@@ -323,7 +323,14 @@ Search historical access review and certification events to verify when user per
 
 ### `search_catalog_changes`
 
-Search and find configuration change events across catalog items.
+Search configuration change events globally or for a config and its related configs.
+	Related config changes:
+	- For a global search, provide query.
+	- To fetch changes for one config, omit query and provide config_id.
+	- Set related to downstream, upstream, or all to include related configs. The default is none.
+	- Set soft=true to include soft relationships during related traversal. The default is false.
+	- depth controls the maximum relationship traversal depth and defaults to 5.
+
 	IMPORTANT - Column Selection for Token Efficiency:
 	ALWAYS specify the "select" parameter with only the columns you need to minimize token usage.
 	Default columns (id,config_id,name,type,change_type,severity,summary,created_at,first_observed,count) provide essential change metadata.
@@ -331,12 +338,14 @@ Search and find configuration change events across catalog items.
 	Available columns for CatalogChange:
 	- Lightweight: id, config_id, name, type, change_type, severity, summary, created_at, first_observed, count, external_created_by, created_by, source, deleted_at, agent_id, tags
 	- Heavy (avoid unless needed): config, details, diff - these are large JSON fields containing full configuration data, change details, and diffs
+	- Config-scoped searches return lightweight columns only.
 
 	Examples:
 	- For basic change listing: "id,config_id,name,type,change_type,severity,created_at"
 	- For change analysis: "id,config_id,change_type,severity,summary,first_observed,count"
 	- For critical changes: "id,config_id,name,change_type,severity,summary,source"
 	- Only when full details needed: "id,config_id,change_type,severity,summary,details"
+	- For downstream changes including soft relationships: config_id=<uuid>, related=downstream, soft=true, depth=5
 
 **Hints:** read-only
 
@@ -344,9 +353,13 @@ Search and find configuration change events across catalog items.
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
+| `config_id` | string |  | Config UUID whose changes should be returned. |
+| `depth` | integer |  | Maximum related config traversal depth. |
 | `limit` | number |  | Number of results to return. |
-| `query` | string | Yes | Search query We can search all the catalog changes via query Use the tool: list_catalog_types to get all the types first to make inference is better (cache them for 15m) FORMAL PEG GRAMMAR: Query = AndQuery _ OrQuery* OrQuery = _ '\|' _ AndQuery AndQuery = _ FieldQuery _ FieldQuery* FieldQuery = _ '(' _ Query _ ')' _ / _ Field _ / _ '-' Word _ / _ (Word / Identifier) _ Field = Source _ Operator _ Value Source = Identifier ('.' Identifier)* Operator = "<=" / ">=" / "=" / ":" / "!=" / "<" / ">" Value = DateTime / ISODate / Time / Measure / Float / Integer / Identifier / String String = '"' [^"]* '"' ISODate = [0-9]{4} '-' [0-9]{2} '-' [0-9]{2} Time = [0-2][0-9] ':' [0-5][0-9] ':' [0-5][0-9] DateTime = "now" (("+" / "-") Integer DurationUnit)? / ISODate ? Time? DurationUnit = "s" / "m" / "h" / "d" / "w" / "mo" / "y" Word = String / '-'? [@a-zA-Z0-9-]+ Integer = [+-]?[0-9]+ ![a-zA-Z0-9_-] Float = [+-]? [0-9] '.' [0-9]+ Measure = (Integer / Float) Identifier Identifier = [@a-zA-Z0-9_\,-:\[\]]+ _ = [ \t] EOF = !. |
+| `query` | string |  | Global search query. |
+| `related` | string |  | Related config direction. |
 | `select` | array |  | a list of columns to return. |
+| `soft` | boolean |  | Include soft relationships in related config traversal. |
 
 ### `search_health_checks`
 

--- a/mcp/catalog.go
+++ b/mcp/catalog.go
@@ -129,12 +129,47 @@ func describeConfigHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*m
 }
 
 func searchConfigChangesHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	q, err := req.RequireString("query")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+	q := strings.TrimSpace(req.GetString("query", ""))
+	configID := strings.TrimSpace(req.GetString("config_id", ""))
+	if q == "" && configID == "" {
+		return mcp.NewToolResultError("query or config_id is required"), nil
+	}
+	if q != "" && configID != "" {
+		return mcp.NewToolResultError("query and config_id cannot be used together"), nil
+	}
+
+	args := req.GetArguments()
+	if configID == "" {
+		if _, ok := args["related"]; ok {
+			return mcp.NewToolResultError("related, depth, and soft require config_id"), nil
+		}
+		if _, ok := args["depth"]; ok {
+			return mcp.NewToolResultError("related, depth, and soft require config_id"), nil
+		}
+		if _, ok := args["soft"]; ok {
+			return mcp.NewToolResultError("related, depth, and soft require config_id"), nil
+		}
 	}
 
 	limit := req.GetInt("limit", defaultQueryLimit)
+	related := query.ChangeRelationDirection(req.GetString("related", string(query.CatalogChangeRecursiveNone)))
+	switch related {
+	case query.CatalogChangeRecursiveNone,
+		query.CatalogChangeRecursiveDownstream,
+		query.CatalogChangeRecursiveUpstream,
+		query.CatalogChangeRecursiveAll:
+	default:
+		return mcp.NewToolResultError("related must be one of none, downstream, upstream, or all"), nil
+	}
+
+	depth := req.GetInt("depth", 5)
+	if depth <= 0 {
+		return mcp.NewToolResultError("depth must be greater than zero"), nil
+	}
+	soft := req.GetBool("soft", false)
+	if related == query.CatalogChangeRecursiveNone && soft {
+		return mcp.NewToolResultError("soft requires related to be downstream, upstream, or all"), nil
+	}
 
 	ctx, err := getDutyCtx(goctx)
 	if err != nil {
@@ -143,8 +178,31 @@ func searchConfigChangesHandler(goctx gocontext.Context, req mcp.CallToolRequest
 
 	selectCols := req.GetStringSlice("select", defaultSelectConfigChangesView)
 
-	var cis []map[string]any
+	var cis any
 	err = auth.WithRLS(ctx, func(rlsCtx context.Context) error {
+		if configID != "" {
+			if _, err := uuid.Parse(configID); err != nil {
+				return fmt.Errorf("invalid config_id: %w", err)
+			}
+
+			response, err := query.FindCatalogChanges(rlsCtx, query.CatalogChangesSearchRequest{
+				BaseCatalogSearch: query.BaseCatalogSearch{
+					CatalogID: configID,
+					Depth:     depth,
+					PageSize:  limit,
+					Recursive: related,
+					Soft:      soft,
+					SortBy:    "-created_at",
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			cis, err = selectConfigChangeColumns(response.Changes, selectCols)
+			return err
+		}
+
 		// NOTE: we're reading QueryTableColumnsWithResourceSelectors into map[string]any instead of []models.CatalogChange
 		// because, with a select clause with few columns, we only want to print those fields as columns in the markdown table.
 		//
@@ -161,6 +219,30 @@ func searchConfigChangesHandler(goctx gocontext.Context, req mcp.CallToolRequest
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return structToMCPResponse(req, cis), nil
+}
+
+func selectConfigChangeColumns(changes []query.ConfigChangeRow, columns []string) ([]map[string]any, error) {
+	data, err := json.Marshal(changes)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, err
+	}
+
+	selected := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		item := make(map[string]any, len(columns))
+		for _, column := range columns {
+			if value, ok := row[column]; ok {
+				item[column] = value
+			}
+		}
+		selected = append(selected, item)
+	}
+	return selected, nil
 }
 
 func relatedCatalogHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -455,6 +537,13 @@ func registerCatalog(s *server.MCPServer) {
 	`
 
 	catalogChangesDescription := `
+	Related config changes:
+	- For a global search, provide query.
+	- To fetch changes for one config, omit query and provide config_id.
+	- Set related to downstream, upstream, or all to include related configs. The default is none.
+	- Set soft=true to include soft relationships during related traversal. The default is false.
+	- depth controls the maximum relationship traversal depth and defaults to 5.
+
 	IMPORTANT - Column Selection for Token Efficiency:
 	ALWAYS specify the "select" parameter with only the columns you need to minimize token usage.
 	Default columns (id,config_id,name,type,change_type,severity,summary,created_at,first_observed,count) provide essential change metadata.
@@ -462,20 +551,43 @@ func registerCatalog(s *server.MCPServer) {
 	Available columns for CatalogChange:
 	- Lightweight: id, config_id, name, type, change_type, severity, summary, created_at, first_observed, count, external_created_by, created_by, source, deleted_at, agent_id, tags
 	- Heavy (avoid unless needed): config, details, diff - these are large JSON fields containing full configuration data, change details, and diffs
+	- Config-scoped searches return lightweight columns only.
 
 	Examples:
 	- For basic change listing: "id,config_id,name,type,change_type,severity,created_at"
 	- For change analysis: "id,config_id,change_type,severity,summary,first_observed,count"
 	- For critical changes: "id,config_id,name,change_type,severity,summary,source"
 	- Only when full details needed: "id,config_id,change_type,severity,summary,details"
+	- For downstream changes including soft relationships: config_id=<uuid>, related=downstream, soft=true, depth=5
 	`
 
 	searchCatalogChangesTool := mcp.NewTool(toolSearchCatalogChanges,
-		mcp.WithDescription("Search and find configuration change events across catalog items."+catalogChangesDescription),
+		mcp.WithDescription("Search configuration change events globally or for a config and its related configs."+catalogChangesDescription),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("query",
-			mcp.Required(),
-			mcp.Description("Search query"+configChangeQueryDescription),
+			mcp.Description("Global search query. Required unless config_id is provided."+configChangeQueryDescription),
+		),
+		mcp.WithString("config_id",
+			mcp.Description("Config UUID whose changes should be returned. Use instead of query."),
+		),
+		mcp.WithString("related",
+			mcp.Description("Related config direction. Requires config_id. Default: none."),
+			mcp.Enum(
+				string(query.CatalogChangeRecursiveNone),
+				string(query.CatalogChangeRecursiveDownstream),
+				string(query.CatalogChangeRecursiveUpstream),
+				string(query.CatalogChangeRecursiveAll),
+			),
+			mcp.DefaultString(string(query.CatalogChangeRecursiveNone)),
+		),
+		mcp.WithInteger("depth",
+			mcp.Description("Maximum related config traversal depth. Requires config_id and related traversal. Default: 5."),
+			mcp.DefaultNumber(5),
+			mcp.Min(1),
+		),
+		mcp.WithBoolean("soft",
+			mcp.Description("Include soft relationships in related config traversal. Requires config_id and related traversal. Default: false."),
+			mcp.DefaultBool(false),
 		),
 		mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Number of results to return. Default: %d", defaultQueryLimit))),
 		mcp.WithArray("select",

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/flanksource/duty/models"
 	dutyRBAC "github.com/flanksource/duty/rbac"
@@ -181,6 +182,113 @@ var _ = ginkgo.Describe("MCP Tools", ginkgo.FlakeAttempts(3), func() {
 
 			ids := []string{dummy.EKSClusterCreateChange.ID, dummy.KubernetesNodeAChange.ID}
 			checkResultInMCPResponse(result.Content, ids)
+		})
+
+		ginkgo.It("should search changes for hard and soft related configs", func() {
+			createdAt := time.Now()
+			hardRootID := uuid.New()
+			hardRelatedID := uuid.New()
+			softRootID := uuid.New()
+			softRelatedID := uuid.New()
+			configs := []models.ConfigItem{
+				{
+					ID:          hardRootID,
+					Name:        lo.ToPtr("mcp-hard-root"),
+					Type:        lo.ToPtr("Test::Root"),
+					ConfigClass: "Root",
+				},
+				{
+					ID:          hardRelatedID,
+					Name:        lo.ToPtr("mcp-hard-related"),
+					Type:        lo.ToPtr("Test::Child"),
+					ConfigClass: "Child",
+					ParentID:    &hardRootID,
+					Path:        hardRootID.String(),
+				},
+				{
+					ID:          softRootID,
+					Name:        lo.ToPtr("mcp-soft-root"),
+					Type:        lo.ToPtr("Test::Root"),
+					ConfigClass: "Root",
+				},
+				{
+					ID:          softRelatedID,
+					Name:        lo.ToPtr("mcp-soft-related"),
+					Type:        lo.ToPtr("Test::Related"),
+					ConfigClass: "Related",
+				},
+			}
+			softRelationship := models.ConfigRelationship{
+				ConfigID:  softRootID.String(),
+				RelatedID: softRelatedID.String(),
+				Relation:  "mcp-test",
+			}
+			hardRelatedChange := models.ConfigChange{
+				ID:         uuid.New().String(),
+				ConfigID:   hardRelatedID.String(),
+				ChangeType: "mcp-related-hard",
+				CreatedAt:  &createdAt,
+				Severity:   models.SeverityInfo,
+				Source:     "mcp-test",
+			}
+			softRelatedChange := models.ConfigChange{
+				ID:         uuid.New().String(),
+				ConfigID:   softRelatedID.String(),
+				ChangeType: "mcp-related-soft",
+				CreatedAt:  &createdAt,
+				Severity:   models.SeverityInfo,
+				Source:     "mcp-test",
+			}
+			Expect(DefaultContext.DB().Create(&configs).Error).To(Succeed())
+			Expect(DefaultContext.DB().Create(&softRelationship).Error).To(Succeed())
+			Expect(DefaultContext.DB().Create([]models.ConfigChange{hardRelatedChange, softRelatedChange}).Error).To(Succeed())
+			defer func() {
+				Expect(DefaultContext.DB().Where("id IN ?", []string{hardRelatedChange.ID, softRelatedChange.ID}).Delete(&models.ConfigChange{}).Error).To(Succeed())
+				Expect(DefaultContext.DB().Where("config_id = ? AND related_id = ? AND relation = ?", softRelationship.ConfigID, softRelationship.RelatedID, softRelationship.Relation).Delete(&models.ConfigRelationship{}).Error).To(Succeed())
+				Expect(DefaultContext.DB().Where("id IN ?", []uuid.UUID{hardRootID, hardRelatedID, softRootID, softRelatedID}).Delete(&models.ConfigItem{}).Error).To(Succeed())
+			}()
+
+			hardResult, err := mcpClient.CallTool(DefaultContext, mcp.CallToolRequest{
+				Header: jsonHeader,
+				Params: mcp.CallToolParams{
+					Name: toolSearchCatalogChanges,
+					Arguments: map[string]any{
+						"config_id": hardRootID.String(),
+						"related":   "downstream",
+						"depth":     5,
+						"select":    []string{"id", "config_id", "change_type"},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			checkResultInMCPResponse(hardResult.Content, []string{hardRelatedChange.ID})
+
+			withoutSoft, err := mcpClient.CallTool(DefaultContext, mcp.CallToolRequest{
+				Header: jsonHeader,
+				Params: mcp.CallToolParams{
+					Name: toolSearchCatalogChanges,
+					Arguments: map[string]any{
+						"config_id": softRootID.String(),
+						"related":   "downstream",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			checkResultNotInMCPResponse(withoutSoft.Content, []string{softRelatedChange.ID})
+
+			withSoft, err := mcpClient.CallTool(DefaultContext, mcp.CallToolRequest{
+				Header: jsonHeader,
+				Params: mcp.CallToolParams{
+					Name: toolSearchCatalogChanges,
+					Arguments: map[string]any{
+						"config_id": softRootID.String(),
+						"related":   "downstream",
+						"soft":      true,
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			checkResultInMCPResponse(withSoft.Content, []string{softRelatedChange.ID})
 		})
 
 		ginkgo.It("should get related configs", func() {


### PR DESCRIPTION
Adds config-scoped related change searches to the `search_catalog_changes` MCP tool, including relationship direction, traversal depth, and soft relationships, while preserving existing global searches and RLS behavior.