### PR TITLE
fix(ui): let Rollup determine safe chunk boundaries

### DIFF
--- a/ui/frontend/vite.config.ts
+++ b/ui/frontend/vite.config.ts
@@ -6,56 +6,6 @@ import { defineConfig } from "vite";
 // Proxy API calls during `vite dev` to a running mission-control backend.
 const apiTarget = process.env.INCIDENT_COMMANDER_API_URL || "http://localhost:8080";
 
-// Vendor chunk groups — each maps a friendly chunk name to a list of
-// substrings matched against the module path. Each group must be a complete
-// dependency-closed unit; any shared transitive dep falls back to the
-// catch-all `vendor` chunk, which Rollup warns about with circular-chunk
-// errors when the split isn't clean.
-const vendorChunks: Record<string, string[]> = {
-  "vendor-react": ["/react/", "/react-dom/", "/scheduler/"],
-  "vendor-query": ["/@tanstack/"],
-  "vendor-clicky": ["/@flanksource/clicky-ui/", "/@flanksource/icons/"],
-  "vendor-iconify": ["/@iconify/", "/iconify-icon/"],
-  "vendor-radix": ["/@radix-ui/"],
-  // Scalar's API reference + everything it transitively imports (Vue,
-  // CodeMirror, Lezer grammars, floating-ui, headless-ui, ai-sdk, vueuse,
-  // markdown/HAST pipeline, shiki + grammars). These all share utility
-  // packages, so splitting them produces circular chunks. Keep the whole
-  // graph in one bucket — the routes that need any of it pull in everything.
-  "vendor-scalar": [
-    "/shiki/",
-    "/@shikijs/",
-    "/@scalar/",
-    "/@codemirror/",
-    "/@lezer/",
-    "/@marijn/",
-    "/@floating-ui/",
-    "/@headlessui/",
-    "/@vue/",
-    "/vue/",
-    "/@vueuse/",
-    "/@unhead/",
-    "/@ai-sdk/",
-    "/@replit/",
-    "/@ungap/",
-    "/remark-",
-    "/rehype-",
-    "/hast-util-",
-    "/mdast-util-",
-    "/micromark",
-    "/unified/",
-    "/unist-util-",
-    "/property-information/",
-    "/stringify-entities/",
-    "/character-entities",
-    "/space-separated-tokens/",
-    "/comma-separated-tokens/",
-    "/zwitch/",
-    "/html-void-elements/",
-    "/ccount/",
-  ],
-};
-
 export default defineConfig({
   base: "/ui/",
   plugins: [tailwindcss(), react()],
@@ -89,20 +39,5 @@ export default defineConfig({
     // Cap inline-asset size at 4KB; anything larger gets a separate file
     // (the Go server embeds the whole dist tree, so extra files are free).
     assetsInlineLimit: 4096,
-    rollupOptions: {
-      output: {
-        // Heaviest groups first so the explicit match wins. Anything in
-        // node_modules that doesn't match falls into vendor-scalar — almost
-        // every leftover dep is a scalar transitive (ai-sdk, vfile, radix-vue,
-        // etc) and bundling them together avoids circular-chunk warnings.
-        manualChunks(id) {
-          if (!id.includes("node_modules")) return undefined;
-          for (const [chunkName, patterns] of Object.entries(vendorChunks)) {
-            if (patterns.some((p) => id.includes(p))) return chunkName;
-          }
-          return "vendor-scalar";
-        },
-      },
-    },
   },
 });


### PR DESCRIPTION
Fixes flanksource/flanksource-ui#3096.

## Root cause

- Mission Control commit [`f664fbb8`](https://github.com/flanksource/mission-control/commit/f664fbb8eeacb9054727a4c34e17e2cddacf7f71) upgraded `@flanksource/clicky-ui` from `0.2.3` to `0.3.20`, making Floating UI, Monaco, and related dependencies reachable by the production bundle.
- The custom `/react/` matcher unintentionally assigned `@floating-ui/react`, `@floating-ui/react-dom`, and `@monaco-editor/react` to `vendor-react`.
- Their dependencies—including `@floating-ui/dom`, `@floating-ui/core`, `@floating-ui/utils`, `tabbable`, and `@monaco-editor/loader`—were assigned to the catch-all `vendor-scalar`.
- Vite also placed `__vitePreload` in `vendor-clicky`, producing the initialization cycle `vendor-react → vendor-scalar → vendor-clicky → vendor-query → vendor-react`.
- React Query evaluated `React.createContext()` before the unfinished `vendor-react` chunk initialized its React export, leaving `React` undefined and crashing `/ui`.

## Fix

Remove the path-based `manualChunks` policy and let Rollup preserve dependency-safe module ordering.

Dynamic imports, shared modules, workers, minification, tree-shaking, and automatic chunking remain enabled. Static dependencies may be combined into a larger entry chunk, but application functionality and dependencies are unchanged.