### PR TITLE
fix(mcp): return view rows by default

### DIFF
--- a/mcp/views.go
+++ b/mcp/views.go
@@ -205,7 +205,7 @@ func viewRunHandler(goctx gocontext.Context, req mcp.CallToolRequest) (*mcp.Call
 	// We send rows, then (panel meta, panel rows) as args to clicky.
 	// It produces a markdown table for each item.
 	contents := make([]any, 0, 1+len(panels)*2)
-	if args.Bool("withRows", false) {
+	if args.Bool("withRows", true) {
 		contents = append(contents, rows)
 	}
 	if args.Bool("withPanels", false) {


### PR DESCRIPTION
View row handling evolved across two commits with conflicting assumptions.

[`1cd0b204`](https://github.com/flanksource/mission-control/commit/1cd0b204e608e6423e026c59c2b0cc5b7bce6c86) made response formatting default `withRows` to `false`, matching the opt-in schema at the time. [`bd5ae6b0`](https://github.com/flanksource/mission-control/commit/bd5ae6b0f85cfb989be02b2225c379cd3c659c1e) later changed the schema, fetch behavior, and tool description to make rows enabled by default, but left the response guard unchanged.

Calls explicitly sending `withRows=true` still returned rows. The bug affected callers that omitted the argument and relied on the advertised default: JSON Schema defaults do not populate `req.Params.Arguments`, so rows were fetched using the `true` fallback and then discarded by response assembly’s `false` fallback.

Align response assembly with the current `true` default while preserving explicit `withRows=false` as an opt-out.

Fixes #3433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table rows are now included in MCP tool responses by default, matching the documented behavior.
  * Callers can still exclude rows by explicitly setting `withRows=false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->