### PR TITLE
fix(db): postgrest query parsing error

### DIFF
--- a/db/middleware.go
+++ b/db/middleware.go
@@ -152,7 +152,7 @@ func postgrestMatchItemTerms(field string, values []string) ([]string, error) {
 
 	terms := make([]string, 0, len(negative)+1)
 	if len(positive) > 0 {
-		terms = append(terms, "or=("+strings.Join(positive, ",")+")")
+		terms = append(terms, "or("+strings.Join(positive, ",")+")")
 	}
 	return append(terms, negative...), nil
 }

--- a/db/middleware_test.go
+++ b/db/middleware_test.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe("Transform Query to postgREST", ginkgo.Ordered, func() {
 			},
 			output: url.Values{
 				"change_type": []string{"eq=diff"},
-				"and":         []string{"(or=(config_type.ilike.Kubernetes::Pod,config_type.ilike.kubernetes::Deployment))"},
+				"and":         []string{"(or(config_type.ilike.Kubernetes::Pod,config_type.ilike.kubernetes::Deployment))"},
 			},
 		},
 		{
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("Transform Query to postgREST", ginkgo.Ordered, func() {
 				"role.filter": []string{"Owner*,*Reader,!Legacy*"},
 			},
 			output: url.Values{
-				"and": []string{"(or=(role.ilike.Owner*,role.ilike.*Reader),role.not.ilike.Legacy*)"},
+				"and": []string{"(or(role.ilike.Owner*,role.ilike.*Reader),role.not.ilike.Legacy*)"},
 			},
 		},
 		{
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("Transform Query to postgREST", ginkgo.Ordered, func() {
 				"user_type.filter": []string{"!Service*"},
 			},
 			output: url.Values{
-				"and": []string{"(or=(role.ilike.Owner,role.ilike.Reader),user_type.not.ilike.Service*)"},
+				"and": []string{"(or(role.ilike.Owner,role.ilike.Reader),user_type.not.ilike.Service*)"},
 			},
 		},
 		{


### PR DESCRIPTION
```json
{
    "code": "PGRST100",
    "details": "unexpected \"=\" expecting \"(\"",
    "hint": null,
    "message": "\"failed to parse logic tree ((or=(name.ilike.Scraper)))\" (line 1, column 7)"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the query syntax generated for positive OR filters.
  * Improved compatibility with PostgREST filtering for grouped match terms.
* **Tests**
  * Updated filter transformation checks to validate the corrected OR syntax across multiple matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->