### PR TITLE
test(oidc): stabilize browser login flow

### DIFF
--- a/tests/e2e/oidc/oidc_login_test.go
+++ b/tests/e2e/oidc/oidc_login_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = ginkgo.XDescribe("OIDC Browser Login Flow", ginkgo.Label("slow"), ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("OIDC Browser Login Flow", ginkgo.Label("slow"), ginkgo.Ordered, func() {
 	var tokens *oidcclient.Tokens
 	var endpoints *oidcclient.Discovery
 

--- a/tests/e2e/oidc/suite_test.go
+++ b/tests/e2e/oidc/suite_test.go
@@ -100,6 +100,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	allocCtx, _ := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.NoSandbox,
+			chromedp.WSURLReadTimeout(60*time.Second),
 		)...,
 	)
 	chromectx, chromeCanc = chromedp.NewContext(allocCtx)


### PR DESCRIPTION
The OIDC browser login flow was disabled after Chrome repeatedly exceeded Chromedp's 20-second DevTools WebSocket startup deadline on loaded CI runners.

Raise the browser startup deadline to 60 seconds and re-enable the ordered login and refresh flow, preserving its existing assertions while accommodating slower runner startup.

Closes #3121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enabled end-to-end coverage for the OIDC browser login authorization flow and token refresh scenarios.
  - Extended the browser automation connection timeout to improve reliability when running OIDC tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->