### PR TITLE
test(upstream): enable check status sync assertion

### DIFF
--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -55,9 +55,7 @@ var _ = ginkgo.Describe("Upstream Push", ginkgo.Ordered, func() {
 		})
 
 		ginkgo.It("should have transferred all the check statuses", func() {
-			ginkgo.Skip("Skipping. Check statuses are not synced to upstream yet because of foreign key issues.")
-
-			compareAgentEntities[models.CheckStatus]("check_statuses", pushUpstream.DB(), pushAgent)
+			compareAgentEntities[models.CheckStatus]("check_statuses", pushUpstream.DB(), pushAgent, cmpopts.IgnoreFields(models.CheckStatus{}, "IsPushed"))
 		})
 
 		ginkgo.It("should have transferred all the canaries", func() {


### PR DESCRIPTION
Check-status verification remained disabled after a foreign-key ordering race in the retired concurrent event consumer.

Current reconciliation sends canaries, checks, and check statuses sequentially, so the historical failure no longer applies. Enable the comparison while excluding `IsPushed`, which is local replication bookkeeping that intentionally differs after a successful push.

Closes #3443.