### PR TITLE
feat(oidc): support client ID metadata documents

### DIFF
--- a/auth/oidc/cimd.go
+++ b/auth/oidc/cimd.go
@@ -303,27 +303,33 @@ func dialClientMetadata(ctx gocontext.Context, network, address string) (net.Con
 	return nil, fmt.Errorf("connect to client metadata host: %w", lastErr)
 }
 
+// blockedClientMetadataPrefixes contains special-purpose ranges that cannot
+// safely host public CIMD endpoints. This complements IsGlobalUnicast, which
+// describes an address type rather than whether it is publicly reachable.
 var blockedClientMetadataPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("0.0.0.0/8"),
 	netip.MustParsePrefix("10.0.0.0/8"),
-	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("100.64.0.0/10"), // Shared address space (CGNAT).
 	netip.MustParsePrefix("127.0.0.0/8"),
 	netip.MustParsePrefix("169.254.0.0/16"),
 	netip.MustParsePrefix("172.16.0.0/12"),
-	netip.MustParsePrefix("192.0.0.0/24"),
-	netip.MustParsePrefix("192.0.2.0/24"),
-	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("192.0.0.0/24"),   // IETF protocol assignments.
+	netip.MustParsePrefix("192.0.2.0/24"),   // Documentation.
+	netip.MustParsePrefix("192.88.99.0/24"), // Deprecated 6to4 relay anycast.
 	netip.MustParsePrefix("192.168.0.0/16"),
-	netip.MustParsePrefix("198.18.0.0/15"),
-	netip.MustParsePrefix("198.51.100.0/24"),
-	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),   // Benchmarking.
+	netip.MustParsePrefix("198.51.100.0/24"), // Documentation.
+	netip.MustParsePrefix("203.0.113.0/24"),  // Documentation.
 	netip.MustParsePrefix("224.0.0.0/4"),
 	netip.MustParsePrefix("240.0.0.0/4"),
-	netip.MustParsePrefix("64:ff9b::/96"),
-	netip.MustParsePrefix("64:ff9b:1::/48"),
-	netip.MustParsePrefix("100::/64"),
-	netip.MustParsePrefix("2001::/23"),
-	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("64:ff9b::/96"),   // IPv4/IPv6 translation.
+	netip.MustParsePrefix("64:ff9b:1::/48"), // Local-use IPv4/IPv6 translation.
+	netip.MustParsePrefix("100::/64"),       // Discard-only.
+	netip.MustParsePrefix("100:0:0:1::/64"), // Dummy IPv6 prefix.
+	netip.MustParsePrefix("2001::/23"),      // IETF protocol assignments.
+	netip.MustParsePrefix("2001:db8::/32"),  // Documentation.
+	netip.MustParsePrefix("2002::/16"),      // 6to4.
+	netip.MustParsePrefix("3fff::/20"),      // Documentation.
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 	netip.MustParsePrefix("ff00::/8"),

--- a/auth/oidc/cimd.go
+++ b/auth/oidc/cimd.go
@@ -1,0 +1,408 @@
+package oidc
+
+import (
+	gocontext "context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+const (
+	maxClientIDMetadataSize    = 5 << 10
+	maxClientIDMetadataCache   = 128
+	defaultClientMetadataTTL   = 5 * time.Minute
+	maxClientMetadataTTL       = time.Hour
+	clientMetadataFetchTimeout = 5 * time.Second
+)
+
+type clientIDMetadataDocument struct {
+	ClientID                string          `json:"client_id"`
+	ClientName              string          `json:"client_name"`
+	RedirectURIs            []string        `json:"redirect_uris"`
+	GrantTypes              []string        `json:"grant_types"`
+	ResponseTypes           []string        `json:"response_types"`
+	TokenEndpointAuthMethod string          `json:"token_endpoint_auth_method"`
+	ClientSecret            json.RawMessage `json:"client_secret"`
+	ClientSecretExpiresAt   json.RawMessage `json:"client_secret_expires_at"`
+}
+
+type cachedClientMetadata struct {
+	metadata  clientMetadata
+	expiresAt time.Time
+}
+
+// clientIDMetadataResolver fetches untrusted CIMD documents through an
+// SSRF-resistant transport and retains only valid documents in a bounded cache.
+type clientIDMetadataResolver struct {
+	client *http.Client
+	cache  *lru.Cache[string, cachedClientMetadata]
+}
+
+func newClientIDMetadataResolver() *clientIDMetadataResolver {
+	metadataCache, err := lru.New[string, cachedClientMetadata](maxClientIDMetadataCache)
+	if err != nil {
+		panic(fmt.Sprintf("create client metadata cache: %v", err))
+	}
+
+	transport := &http.Transport{
+		DialContext:            dialClientMetadata,
+		ForceAttemptHTTP2:      true,
+		MaxIdleConns:           16,
+		MaxIdleConnsPerHost:    2,
+		MaxConnsPerHost:        4,
+		IdleConnTimeout:        30 * time.Second,
+		ResponseHeaderTimeout:  3 * time.Second,
+		TLSHandshakeTimeout:    3 * time.Second,
+		ExpectContinueTimeout:  1 * time.Second,
+		MaxResponseHeaderBytes: 16 << 10,
+	}
+
+	return &clientIDMetadataResolver{
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   clientMetadataFetchTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		cache: metadataCache,
+	}
+}
+
+func (r *clientIDMetadataResolver) resolve(ctx gocontext.Context, clientID string) (*clientMetadata, error) {
+	if cached, ok := r.cache.Get(clientID); ok {
+		if time.Now().Before(cached.expiresAt) {
+			metadata := cached.metadata
+			metadata.RedirectURIs = append([]string(nil), metadata.RedirectURIs...)
+			return &metadata, nil
+		}
+		r.cache.Remove(clientID)
+	}
+
+	metadata, ttl, err := r.fetch(ctx, clientID)
+	if err != nil {
+		return nil, err
+	}
+	if ttl > 0 {
+		cachedMetadata := *metadata
+		cachedMetadata.RedirectURIs = append([]string(nil), metadata.RedirectURIs...)
+		r.cache.Add(clientID, cachedClientMetadata{metadata: cachedMetadata, expiresAt: time.Now().Add(ttl)})
+	}
+	return metadata, nil
+}
+
+func (r *clientIDMetadataResolver) fetch(ctx gocontext.Context, clientID string) (*clientMetadata, time.Duration, error) {
+	if _, err := parseClientIDMetadataURL(clientID); err != nil {
+		return nil, 0, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create client metadata request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json, application/*+json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("fetch client metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("client metadata returned HTTP %d", resp.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	isJSON := mediaType == "application/json" ||
+		strings.HasPrefix(mediaType, "application/") && strings.HasSuffix(mediaType, "+json")
+	if err != nil || !isJSON {
+		return nil, 0, fmt.Errorf("client metadata response is not JSON")
+	}
+	if resp.ContentLength > maxClientIDMetadataSize {
+		return nil, 0, fmt.Errorf("client metadata exceeds %d bytes", maxClientIDMetadataSize)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClientIDMetadataSize+1))
+	if err != nil {
+		return nil, 0, fmt.Errorf("read client metadata: %w", err)
+	}
+	if len(body) > maxClientIDMetadataSize {
+		return nil, 0, fmt.Errorf("client metadata exceeds %d bytes", maxClientIDMetadataSize)
+	}
+
+	var document clientIDMetadataDocument
+	if err := json.Unmarshal(body, &document); err != nil {
+		return nil, 0, fmt.Errorf("client metadata is not valid JSON: %w", err)
+	}
+	metadata, err := validateClientIDMetadataDocument(clientID, document)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return metadata, clientIDMetadataCacheTTL(resp.Header, time.Now()), nil
+}
+
+func validateClientIDMetadataDocument(clientID string, document clientIDMetadataDocument) (*clientMetadata, error) {
+	if document.ClientID == "" || document.ClientID != clientID {
+		return nil, fmt.Errorf("client metadata client_id must exactly match its document URL")
+	}
+
+	name := strings.TrimSpace(document.ClientName)
+	if name == "" {
+		return nil, fmt.Errorf("client metadata client_name is required")
+	}
+	redirectURIs, err := validateRedirectURIs(document.RedirectURIs)
+	if err != nil {
+		return nil, fmt.Errorf("client metadata: %w", err)
+	}
+
+	if method := document.TokenEndpointAuthMethod; method != "" && method != string(oidc.AuthMethodNone) {
+		return nil, fmt.Errorf("client metadata must describe a public client")
+	}
+	if len(document.ClientSecret) > 0 || len(document.ClientSecretExpiresAt) > 0 {
+		return nil, fmt.Errorf("client metadata must not contain a client secret")
+	}
+
+	grantTypes := []oidc.GrantType{oidc.GrantTypeCode}
+	if len(document.GrantTypes) > 0 {
+		grantTypes = make([]oidc.GrantType, 0, len(document.GrantTypes))
+	}
+	hasAuthorizationCode := false
+	for _, grantType := range document.GrantTypes {
+		switch grantType {
+		case string(oidc.GrantTypeCode):
+			hasAuthorizationCode = true
+		case string(oidc.GrantTypeRefreshToken):
+		default:
+			return nil, fmt.Errorf("client metadata contains unsupported grant_type %q", grantType)
+		}
+		grantTypes = append(grantTypes, oidc.GrantType(grantType))
+	}
+	if len(document.GrantTypes) > 0 && !hasAuthorizationCode {
+		return nil, fmt.Errorf("client metadata must support the authorization_code grant")
+	}
+
+	hasCodeResponse := len(document.ResponseTypes) == 0
+	for _, responseType := range document.ResponseTypes {
+		if responseType != string(oidc.ResponseTypeCode) {
+			return nil, fmt.Errorf("client metadata contains unsupported response_type %q", responseType)
+		}
+		hasCodeResponse = true
+	}
+	if !hasCodeResponse {
+		return nil, fmt.Errorf("client metadata must support the code response type")
+	}
+
+	return &clientMetadata{Name: name, RedirectURIs: redirectURIs, GrantTypes: grantTypes}, nil
+}
+
+func isClientIDMetadataDocument(clientID string) bool {
+	_, err := parseClientIDMetadataURL(clientID)
+	return err == nil
+}
+
+// parseClientIDMetadataURL applies URL-level CIMD and SSRF checks. DNS results
+// are checked and pinned later by dialClientMetadata.
+func parseClientIDMetadataURL(rawURL string) (*url.URL, error) {
+	if len(rawURL) > maxClientIDLength {
+		return nil, fmt.Errorf("client_id exceeds %d characters", maxClientIDLength)
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("client_id is not a valid URL: %w", err)
+	}
+	if parsed.Scheme != "https" || parsed.Host == "" || parsed.Path == "" || parsed.Opaque != "" {
+		return nil, fmt.Errorf("client_id must be an HTTPS URL with a path")
+	}
+	if parsed.User != nil {
+		return nil, fmt.Errorf("client_id must not contain a username or password")
+	}
+	if parsed.Fragment != "" || strings.Contains(rawURL, "#") {
+		return nil, fmt.Errorf("client_id must not contain a fragment")
+	}
+	if parsed.Hostname() == "" || isSpecialMetadataHostname(parsed.Hostname()) {
+		return nil, fmt.Errorf("client_id must use a public hostname")
+	}
+	if literal, err := netip.ParseAddr(parsed.Hostname()); err == nil && !isPublicMetadataAddress(literal) {
+		return nil, fmt.Errorf("client_id must use a public IP address")
+	}
+
+	for _, segment := range strings.Split(parsed.EscapedPath(), "/") {
+		segment, err = url.PathUnescape(segment)
+		if err != nil {
+			return nil, fmt.Errorf("client_id contains an invalid path")
+		}
+		if segment == "." || segment == ".." {
+			return nil, fmt.Errorf("client_id must not contain dot path segments")
+		}
+	}
+
+	return parsed, nil
+}
+
+func isSpecialMetadataHostname(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	for _, suffix := range []string{"localhost", "local", "home.arpa", "internal"} {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// dialClientMetadata prevents DNS rebinding by validating every resolved
+// address and connecting to a validated IP literal rather than resolving again.
+func dialClientMetadata(ctx gocontext.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client metadata address: %w", err)
+	}
+
+	var addresses []netip.Addr
+	if literal, err := netip.ParseAddr(host); err == nil {
+		addresses = []netip.Addr{literal}
+	} else {
+		addresses, err = net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve client metadata host: %w", err)
+		}
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("client metadata host has no IP addresses")
+	}
+
+	for _, address := range addresses {
+		if !isPublicMetadataAddress(address) {
+			return nil, fmt.Errorf("client metadata host resolves to a non-public address")
+		}
+	}
+
+	dialer := net.Dialer{Timeout: 3 * time.Second, KeepAlive: 30 * time.Second}
+	var lastErr error
+	for i, ip := range addresses {
+		if i == 8 {
+			break
+		}
+		connection, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return connection, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("connect to client metadata host: %w", lastErr)
+}
+
+var blockedClientMetadataPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
+
+func isPublicMetadataAddress(address netip.Addr) bool {
+	if !address.IsValid() || address.Zone() != "" {
+		return false
+	}
+	address = address.Unmap()
+	if !address.IsGlobalUnicast() {
+		return false
+	}
+	for _, blocked := range blockedClientMetadataPrefixes {
+		if blocked.Contains(address) {
+			return false
+		}
+	}
+	return true
+}
+
+// clientIDMetadataCacheTTL honors explicit freshness while imposing an upper
+// bound; responses without cache policy receive a short local default.
+func clientIDMetadataCacheTTL(header http.Header, now time.Time) time.Duration {
+	var maxAge, sharedMaxAge *time.Duration
+	for _, value := range header.Values("Cache-Control") {
+		for _, directive := range strings.Split(value, ",") {
+			name, rawValue, _ := strings.Cut(strings.TrimSpace(directive), "=")
+			switch strings.ToLower(name) {
+			case "no-cache", "no-store":
+				return 0
+			case "max-age", "s-maxage":
+				seconds, err := strconv.ParseInt(strings.Trim(rawValue, `"`), 10, 64)
+				if err != nil || seconds < 0 {
+					return 0
+				}
+				ttl := time.Duration(seconds) * time.Second
+				if strings.EqualFold(name, "s-maxage") {
+					sharedMaxAge = &ttl
+				} else {
+					maxAge = &ttl
+				}
+			}
+		}
+	}
+
+	selectedMaxAge := sharedMaxAge
+	if selectedMaxAge == nil {
+		selectedMaxAge = maxAge
+	}
+	if selectedMaxAge != nil {
+		age := time.Duration(0)
+		if date, err := http.ParseTime(header.Get("Date")); err == nil && now.After(date) {
+			age = now.Sub(date)
+		}
+		if seconds, err := strconv.ParseInt(header.Get("Age"), 10, 64); err == nil && seconds >= 0 {
+			reportedAge := time.Duration(seconds) * time.Second
+			if reportedAge > age {
+				age = reportedAge
+			}
+		}
+		return boundClientMetadataTTL(*selectedMaxAge - age)
+	}
+
+	if strings.Contains(strings.ToLower(header.Get("Pragma")), "no-cache") || header.Get("Vary") == "*" {
+		return 0
+	}
+	if expires, err := http.ParseTime(header.Get("Expires")); err == nil {
+		return boundClientMetadataTTL(expires.Sub(now))
+	}
+	return defaultClientMetadataTTL
+}
+
+func boundClientMetadataTTL(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return 0
+	}
+	if ttl > maxClientMetadataTTL {
+		return maxClientMetadataTTL
+	}
+	return ttl
+}

--- a/auth/oidc/consent.go
+++ b/auth/oidc/consent.go
@@ -1,12 +1,11 @@
 package oidc
 
-// Consent for dynamically registered clients.
+// Consent for DCR and CIMD clients.
 //
-// Registration is open, so anyone can mint a client_id whose redirect URI points
-// at a host they control and send a victim an authorization link on Mission
-// Control's own domain. PKCE does not help — the attacker is the client and
-// holds the verifier. The consent screen is the only point in the flow where a
-// human sees where the authorization code is about to be sent.
+// Client metadata is caller-controlled, so anyone can name a redirect URI they
+// control and send a victim an authorization link on Mission Control's domain.
+// PKCE does not help — the attacker is the client and holds the verifier. The
+// consent screen is where a human sees where the authorization code will be sent.
 //
 // The built-in mc-cli client skips consent: the user started it from their own
 // terminal and its redirect URIs are fixed at compile time.
@@ -18,6 +17,7 @@ import (
 	"net/url"
 	"strings"
 
+	dutyAPI "github.com/flanksource/duty/api"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/incident-commander/auth/oidc/static"
@@ -57,8 +57,17 @@ func (h *LoginHandler) ShowConsent(c echo.Context) error {
 	}
 
 	clientName := authRequest.ClientID
-	if metadata, err := decodeClientID(authRequest.ClientID); err == nil {
-		clientName = (&metadataClient{id: authRequest.ClientID, metadata: metadata}).DisplayName()
+	if IsMetadataClient(authRequest.ClientID) {
+		client, err := h.storage.GetClientByClientID(c.Request().Context(), authRequest.ClientID)
+		if err != nil {
+			return dutyAPI.WriteError(c, ctx.Oops().Wrap(err))
+		}
+		if err := op.ValidateAuthReqRedirectURI(client, authRequest.RedirectURI, authRequest.GetResponseType()); err != nil {
+			return dutyAPI.WriteError(c, dutyAPI.Errorf(dutyAPI.EINVALID, "redirect URI is no longer registered"))
+		}
+		if namedClient, ok := client.(interface{ DisplayName() string }); ok {
+			clientName = namedClient.DisplayName()
+		}
 	}
 
 	var person models.Person
@@ -152,7 +161,7 @@ func (h *LoginHandler) denialRedirectURL(c echo.Context, authRequest *AuthReques
 }
 
 // completeLogin finishes an authorization once the user's identity is known,
-// diverting through the consent screen for dynamically registered clients.
+// diverting through the consent screen for metadata-backed clients.
 func (h *LoginHandler) completeLogin(c echo.Context, authRequestID, personID string) error {
 	if err := h.storage.SetAuthRequestSubject(authRequestID, personID); err != nil {
 		return err

--- a/auth/oidc/consent.go
+++ b/auth/oidc/consent.go
@@ -58,7 +58,7 @@ func (h *LoginHandler) ShowConsent(c echo.Context) error {
 
 	clientName := authRequest.ClientID
 	if metadata, err := decodeClientID(authRequest.ClientID); err == nil {
-		clientName = (&dynamicClient{id: authRequest.ClientID, metadata: metadata}).DisplayName()
+		clientName = (&metadataClient{id: authRequest.ClientID, metadata: metadata}).DisplayName()
 	}
 
 	var person models.Person

--- a/auth/oidc/dcr.go
+++ b/auth/oidc/dcr.go
@@ -41,8 +41,7 @@ const (
 
 	dynamicClientIDPrefix = "dcr_"
 
-	// maxClientIDLength bounds the work decodeClientID will do for an
-	// unauthenticated caller.
+	// maxClientIDLength bounds metadata client identifiers from unauthenticated callers.
 	maxClientIDLength = 4096
 
 	maxRedirectURIs      = 10
@@ -51,13 +50,13 @@ const (
 	maxRegistrationBody  = 16 << 10
 )
 
-// clientMetadata is the subset of RFC 7591 client metadata that is carried
-// inside the client_id. Field names are kept short because they are encoded into
-// every authorization request.
+// clientMetadata is the normalized public-client metadata used by DCR and CIMD.
+// Its compact field names keep DCR client identifiers short.
 type clientMetadata struct {
-	Name         string   `json:"n,omitempty"`
-	RedirectURIs []string `json:"r"`
-	IssuedAt     int64    `json:"i,omitempty"`
+	Name         string           `json:"n,omitempty"`
+	RedirectURIs []string         `json:"r"`
+	IssuedAt     int64            `json:"i,omitempty"`
+	GrantTypes   []oidc.GrantType `json:"g,omitempty"`
 }
 
 // registrationRequest is the RFC 7591 client metadata document sent by clients.
@@ -259,9 +258,14 @@ func IsDynamicClient(clientID string) bool {
 	return err == nil
 }
 
+// IsMetadataClient reports whether clientID identifies a DCR or CIMD client.
+func IsMetadataClient(clientID string) bool {
+	return IsDynamicClient(clientID) || isClientIDMetadataDocument(clientID)
+}
+
 // IsKnownClient reports whether clientID names a client this provider issues tokens for.
 func IsKnownClient(clientID string) bool {
-	return clientID == ClientID || IsDynamicClient(clientID)
+	return clientID == ClientID || IsMetadataClient(clientID)
 }
 
 // metadataClient is a public client reconstructed from DCR or CIMD metadata.
@@ -284,6 +288,9 @@ func (c *metadataClient) ResponseTypes() []oidc.ResponseType {
 	return []oidc.ResponseType{oidc.ResponseTypeCode}
 }
 func (c *metadataClient) GrantTypes() []oidc.GrantType {
+	if len(c.metadata.GrantTypes) > 0 {
+		return append([]oidc.GrantType(nil), c.metadata.GrantTypes...)
+	}
 	return []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken}
 }
 func (c *metadataClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }

--- a/auth/oidc/dcr.go
+++ b/auth/oidc/dcr.go
@@ -264,47 +264,46 @@ func IsKnownClient(clientID string) bool {
 	return clientID == ClientID || IsDynamicClient(clientID)
 }
 
-// dynamicClient is a public client reconstructed from a dynamically registered
-// client_id. It mirrors cliClient except that redirect URIs come from the
-// client_id itself.
-type dynamicClient struct {
+// metadataClient is a public client reconstructed from DCR or CIMD metadata.
+// It mirrors cliClient except that the metadata supplies its identity and redirects.
+type metadataClient struct {
 	id       string
 	metadata *clientMetadata
 }
 
-var _ op.Client = (*dynamicClient)(nil)
+var _ op.Client = (*metadataClient)(nil)
 
-func (c *dynamicClient) GetID() string                    { return c.id }
-func (c *dynamicClient) RedirectURIs() []string           { return c.metadata.RedirectURIs }
-func (c *dynamicClient) PostLogoutRedirectURIs() []string { return nil }
-func (c *dynamicClient) ApplicationType() op.ApplicationType {
+func (c *metadataClient) GetID() string                    { return c.id }
+func (c *metadataClient) RedirectURIs() []string           { return c.metadata.RedirectURIs }
+func (c *metadataClient) PostLogoutRedirectURIs() []string { return nil }
+func (c *metadataClient) ApplicationType() op.ApplicationType {
 	return op.ApplicationTypeNative
 }
-func (c *dynamicClient) AuthMethod() oidc.AuthMethod { return oidc.AuthMethodNone }
-func (c *dynamicClient) ResponseTypes() []oidc.ResponseType {
+func (c *metadataClient) AuthMethod() oidc.AuthMethod { return oidc.AuthMethodNone }
+func (c *metadataClient) ResponseTypes() []oidc.ResponseType {
 	return []oidc.ResponseType{oidc.ResponseTypeCode}
 }
-func (c *dynamicClient) GrantTypes() []oidc.GrantType {
+func (c *metadataClient) GrantTypes() []oidc.GrantType {
 	return []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken}
 }
-func (c *dynamicClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }
-func (c *dynamicClient) AccessTokenType() op.AccessTokenType {
+func (c *metadataClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }
+func (c *metadataClient) AccessTokenType() op.AccessTokenType {
 	return op.AccessTokenTypeJWT
 }
-func (c *dynamicClient) IDTokenLifetime() time.Duration { return time.Hour }
-func (c *dynamicClient) DevMode() bool                  { return false }
-func (c *dynamicClient) RestrictAdditionalIdTokenScopes() func(scopes []string) []string {
+func (c *metadataClient) IDTokenLifetime() time.Duration { return time.Hour }
+func (c *metadataClient) DevMode() bool                  { return false }
+func (c *metadataClient) RestrictAdditionalIdTokenScopes() func(scopes []string) []string {
 	return func(scopes []string) []string { return scopes }
 }
-func (c *dynamicClient) RestrictAdditionalAccessTokenScopes() func(scopes []string) []string {
+func (c *metadataClient) RestrictAdditionalAccessTokenScopes() func(scopes []string) []string {
 	return func(scopes []string) []string { return scopes }
 }
-func (c *dynamicClient) IsScopeAllowed(scope string) bool     { return true }
-func (c *dynamicClient) IDTokenUserinfoClaimsAssertion() bool { return false }
-func (c *dynamicClient) ClockSkew() time.Duration             { return 0 }
+func (c *metadataClient) IsScopeAllowed(scope string) bool     { return true }
+func (c *metadataClient) IDTokenUserinfoClaimsAssertion() bool { return false }
+func (c *metadataClient) ClockSkew() time.Duration             { return 0 }
 
 // DisplayName returns the name to show on the consent screen.
-func (c *dynamicClient) DisplayName() string {
+func (c *metadataClient) DisplayName() string {
 	if c.metadata.Name != "" {
 		return c.metadata.Name
 	}

--- a/auth/oidc/dcr.go
+++ b/auth/oidc/dcr.go
@@ -25,13 +25,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
-	"github.com/zitadel/oidc/v3/pkg/op"
 )
 
 const (
@@ -40,24 +38,8 @@ const (
 	RegistrationEndpoint = "/oauth/register"
 
 	dynamicClientIDPrefix = "dcr_"
-
-	// maxClientIDLength bounds metadata client identifiers from unauthenticated callers.
-	maxClientIDLength = 4096
-
-	maxRedirectURIs      = 10
-	maxRedirectURILength = 512
-	maxClientNameLength  = 128
-	maxRegistrationBody  = 16 << 10
+	maxRegistrationBody   = 16 << 10
 )
-
-// clientMetadata is the normalized public-client metadata used by DCR and CIMD.
-// Its compact field names keep DCR client identifiers short.
-type clientMetadata struct {
-	Name         string           `json:"n,omitempty"`
-	RedirectURIs []string         `json:"r"`
-	IssuedAt     int64            `json:"i,omitempty"`
-	GrantTypes   []oidc.GrantType `json:"g,omitempty"`
-}
 
 // registrationRequest is the RFC 7591 client metadata document sent by clients.
 type registrationRequest struct {
@@ -157,54 +139,6 @@ func registrationFailure(c echo.Context, code, description string) error {
 	return c.JSON(http.StatusBadRequest, registrationError{Error: code, Description: description})
 }
 
-// validateRedirectURIs enforces the redirect URI rules for public clients:
-// https anywhere, or plain http only on loopback (RFC 8252 §7.3).
-func validateRedirectURIs(uris []string) ([]string, error) {
-	if len(uris) == 0 {
-		return nil, fmt.Errorf("redirect_uris is required")
-	}
-	if len(uris) > maxRedirectURIs {
-		return nil, fmt.Errorf("at most %d redirect_uris are allowed", maxRedirectURIs)
-	}
-
-	validated := make([]string, 0, len(uris))
-	for _, raw := range uris {
-		if len(raw) > maxRedirectURILength {
-			return nil, fmt.Errorf("redirect_uri exceeds %d characters", maxRedirectURILength)
-		}
-
-		u, err := url.Parse(raw)
-		if err != nil {
-			return nil, fmt.Errorf("redirect_uri %q is not a valid URL", raw)
-		}
-		if u.Fragment != "" || strings.Contains(raw, "#") {
-			return nil, fmt.Errorf("redirect_uri %q must not contain a fragment", raw)
-		}
-
-		switch u.Scheme {
-		case "https":
-		case "http":
-			if !isLoopbackHost(u.Hostname()) {
-				return nil, fmt.Errorf("redirect_uri %q must use https unless it is a loopback address", raw)
-			}
-		default:
-			return nil, fmt.Errorf("redirect_uri %q must use the https or http scheme", raw)
-		}
-
-		if u.Host == "" {
-			return nil, fmt.Errorf("redirect_uri %q must include a host", raw)
-		}
-
-		validated = append(validated, raw)
-	}
-
-	return validated, nil
-}
-
-func isLoopbackHost(host string) bool {
-	return host == "127.0.0.1" || host == "::1" || host == "localhost"
-}
-
 func encodeClientID(md clientMetadata) (string, error) {
 	payload, err := json.Marshal(md)
 	if err != nil {
@@ -256,63 +190,4 @@ func decodeClientID(clientID string) (*clientMetadata, error) {
 func IsDynamicClient(clientID string) bool {
 	_, err := decodeClientID(clientID)
 	return err == nil
-}
-
-// IsMetadataClient reports whether clientID identifies a DCR or CIMD client.
-func IsMetadataClient(clientID string) bool {
-	return IsDynamicClient(clientID) || isClientIDMetadataDocument(clientID)
-}
-
-// IsKnownClient reports whether clientID names a client this provider issues tokens for.
-func IsKnownClient(clientID string) bool {
-	return clientID == ClientID || IsMetadataClient(clientID)
-}
-
-// metadataClient is a public client reconstructed from DCR or CIMD metadata.
-// It mirrors cliClient except that the metadata supplies its identity and redirects.
-type metadataClient struct {
-	id       string
-	metadata *clientMetadata
-}
-
-var _ op.Client = (*metadataClient)(nil)
-
-func (c *metadataClient) GetID() string                    { return c.id }
-func (c *metadataClient) RedirectURIs() []string           { return c.metadata.RedirectURIs }
-func (c *metadataClient) PostLogoutRedirectURIs() []string { return nil }
-func (c *metadataClient) ApplicationType() op.ApplicationType {
-	return op.ApplicationTypeNative
-}
-func (c *metadataClient) AuthMethod() oidc.AuthMethod { return oidc.AuthMethodNone }
-func (c *metadataClient) ResponseTypes() []oidc.ResponseType {
-	return []oidc.ResponseType{oidc.ResponseTypeCode}
-}
-func (c *metadataClient) GrantTypes() []oidc.GrantType {
-	if len(c.metadata.GrantTypes) > 0 {
-		return append([]oidc.GrantType(nil), c.metadata.GrantTypes...)
-	}
-	return []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken}
-}
-func (c *metadataClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }
-func (c *metadataClient) AccessTokenType() op.AccessTokenType {
-	return op.AccessTokenTypeJWT
-}
-func (c *metadataClient) IDTokenLifetime() time.Duration { return time.Hour }
-func (c *metadataClient) DevMode() bool                  { return false }
-func (c *metadataClient) RestrictAdditionalIdTokenScopes() func(scopes []string) []string {
-	return func(scopes []string) []string { return scopes }
-}
-func (c *metadataClient) RestrictAdditionalAccessTokenScopes() func(scopes []string) []string {
-	return func(scopes []string) []string { return scopes }
-}
-func (c *metadataClient) IsScopeAllowed(scope string) bool     { return true }
-func (c *metadataClient) IDTokenUserinfoClaimsAssertion() bool { return false }
-func (c *metadataClient) ClockSkew() time.Duration             { return 0 }
-
-// DisplayName returns the name to show on the consent screen.
-func (c *metadataClient) DisplayName() string {
-	if c.metadata.Name != "" {
-		return c.metadata.Name
-	}
-	return "An unnamed application"
 }

--- a/auth/oidc/metadata_client.go
+++ b/auth/oidc/metadata_client.go
@@ -1,0 +1,136 @@
+package oidc
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/oidc/v3/pkg/op"
+)
+
+const (
+	// maxClientIDLength bounds metadata client identifiers from unauthenticated callers.
+	maxClientIDLength = 4096
+
+	maxRedirectURIs      = 10
+	maxRedirectURILength = 512
+	maxClientNameLength  = 128
+)
+
+// clientMetadata is the normalized public-client metadata used by DCR and CIMD.
+// Its compact field names keep DCR client identifiers short.
+type clientMetadata struct {
+	Name         string           `json:"n,omitempty"`
+	RedirectURIs []string         `json:"r"`
+	IssuedAt     int64            `json:"i,omitempty"`
+	GrantTypes   []oidc.GrantType `json:"g,omitempty"`
+}
+
+// validateRedirectURIs enforces the redirect URI rules for public clients:
+// https anywhere, or plain http only on loopback (RFC 8252 §7.3).
+func validateRedirectURIs(uris []string) ([]string, error) {
+	if len(uris) == 0 {
+		return nil, fmt.Errorf("redirect_uris is required")
+	}
+	if len(uris) > maxRedirectURIs {
+		return nil, fmt.Errorf("at most %d redirect_uris are allowed", maxRedirectURIs)
+	}
+
+	validated := make([]string, 0, len(uris))
+	for _, raw := range uris {
+		if len(raw) > maxRedirectURILength {
+			return nil, fmt.Errorf("redirect_uri exceeds %d characters", maxRedirectURILength)
+		}
+
+		u, err := url.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("redirect_uri %q is not a valid URL", raw)
+		}
+		if u.Fragment != "" || strings.Contains(raw, "#") {
+			return nil, fmt.Errorf("redirect_uri %q must not contain a fragment", raw)
+		}
+
+		switch u.Scheme {
+		case "https":
+		case "http":
+			if !isLoopbackHost(u.Hostname()) {
+				return nil, fmt.Errorf("redirect_uri %q must use https unless it is a loopback address", raw)
+			}
+		default:
+			return nil, fmt.Errorf("redirect_uri %q must use the https or http scheme", raw)
+		}
+
+		if u.Host == "" {
+			return nil, fmt.Errorf("redirect_uri %q must include a host", raw)
+		}
+
+		validated = append(validated, raw)
+	}
+
+	return validated, nil
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "127.0.0.1" || host == "::1" || host == "localhost"
+}
+
+// IsMetadataClient reports whether clientID identifies a DCR or CIMD client.
+func IsMetadataClient(clientID string) bool {
+	return IsDynamicClient(clientID) || isClientIDMetadataDocument(clientID)
+}
+
+// IsKnownClient reports whether clientID names a client this provider issues tokens for.
+func IsKnownClient(clientID string) bool {
+	return clientID == ClientID || IsMetadataClient(clientID)
+}
+
+// metadataClient is a public client reconstructed from DCR or CIMD metadata.
+// It mirrors cliClient except that the metadata supplies its identity and redirects.
+type metadataClient struct {
+	id       string
+	metadata *clientMetadata
+}
+
+var _ op.Client = (*metadataClient)(nil)
+
+func (c *metadataClient) GetID() string                    { return c.id }
+func (c *metadataClient) RedirectURIs() []string           { return c.metadata.RedirectURIs }
+func (c *metadataClient) PostLogoutRedirectURIs() []string { return nil }
+func (c *metadataClient) ApplicationType() op.ApplicationType {
+	return op.ApplicationTypeNative
+}
+func (c *metadataClient) AuthMethod() oidc.AuthMethod { return oidc.AuthMethodNone }
+func (c *metadataClient) ResponseTypes() []oidc.ResponseType {
+	return []oidc.ResponseType{oidc.ResponseTypeCode}
+}
+func (c *metadataClient) GrantTypes() []oidc.GrantType {
+	if len(c.metadata.GrantTypes) > 0 {
+		return append([]oidc.GrantType(nil), c.metadata.GrantTypes...)
+	}
+	return []oidc.GrantType{oidc.GrantTypeCode, oidc.GrantTypeRefreshToken}
+}
+func (c *metadataClient) LoginURL(id string) string { return "/oidc/login?auth_request_id=" + id }
+func (c *metadataClient) AccessTokenType() op.AccessTokenType {
+	return op.AccessTokenTypeJWT
+}
+func (c *metadataClient) IDTokenLifetime() time.Duration { return time.Hour }
+func (c *metadataClient) DevMode() bool                  { return false }
+func (c *metadataClient) RestrictAdditionalIdTokenScopes() func(scopes []string) []string {
+	return func(scopes []string) []string { return scopes }
+}
+func (c *metadataClient) RestrictAdditionalAccessTokenScopes() func(scopes []string) []string {
+	return func(scopes []string) []string { return scopes }
+}
+func (c *metadataClient) IsScopeAllowed(scope string) bool     { return true }
+func (c *metadataClient) IDTokenUserinfoClaimsAssertion() bool { return false }
+func (c *metadataClient) ClockSkew() time.Duration             { return 0 }
+
+// DisplayName returns the name to show on the consent screen.
+func (c *metadataClient) DisplayName() string {
+	if c.metadata.Name != "" {
+		return c.metadata.Name
+	}
+	return "An unnamed application"
+}

--- a/auth/oidc/oauth.go
+++ b/auth/oidc/oauth.go
@@ -71,17 +71,16 @@ func mountOAuthRoutes(e *echo.Echo, oidcIssuer string, providerHandler http.Hand
 	e.GET(oauthProtectedResourcePrefix, prmHandler)
 	e.GET(oauthProtectedResourcePrefix+"/*", prmHandler)
 
-	// The zitadel provider builds the discovery document but has no hook for
-	// registration_endpoint, so the response is augmented on the way out. The
-	// same document answers RFC 8414, which zitadel does not serve at all.
+	// The zitadel provider builds the discovery document but has no hook for MCP
+	// client registration capabilities, so the response is augmented on the way
+	// out. The same document answers RFC 8414, which zitadel does not serve at all.
 	metadata := authorizationServerMetadataHandler(providerHandler)
 	e.GET(openIDConfigurationPath, metadata)
 	e.GET(authorizationServerMetadataPath, metadata)
 	e.GET(authorizationServerMetadataPath+"/*", metadata)
 }
 
-// authorizationServerMetadataHandler delegates to the zitadel discovery handler
-// and injects registration_endpoint into the result.
+// authorizationServerMetadataHandler adds CIMD and DCR capabilities to discovery.
 func authorizationServerMetadataHandler(providerHandler http.Handler) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		req := c.Request().Clone(c.Request().Context())
@@ -109,6 +108,7 @@ func authorizationServerMetadataHandler(providerHandler http.Handler) echo.Handl
 			issuer = detectRequestOrigin(c, "")
 		}
 		doc["registration_endpoint"] = strings.TrimRight(issuer, "/") + RegistrationEndpoint
+		doc["client_id_metadata_document_supported"] = true
 
 		// Discovery documents are public and cookie-free; browser-based clients
 		// such as the MCP Inspector fetch them cross-origin.

--- a/auth/oidc/resource.go
+++ b/auth/oidc/resource.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// MCPResourcePath is the only route dynamically registered OAuth clients may access.
+// MCPResourcePath is the only route metadata-backed OAuth clients may access.
 const MCPResourcePath = "/mcp"
 
 type resourceIndicatorContextKey struct{}
@@ -32,7 +32,7 @@ func withMCPResourceIndicator(next http.Handler, issuerURL string) http.Handler 
 			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "authorization request cannot be parsed")
 			return
 		}
-		if !IsDynamicClient(r.Form.Get("client_id")) {
+		if !IsMetadataClient(r.Form.Get("client_id")) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -114,7 +114,7 @@ func (s *Storage) validateTokenResource(r *http.Request, expectedResource string
 		return nil
 	}
 
-	if !IsDynamicClient(clientID) {
+	if !IsMetadataClient(clientID) {
 		return nil
 	}
 	if resource != expectedResource {

--- a/auth/oidc/static/consent.html
+++ b/auth/oidc/static/consent.html
@@ -21,7 +21,7 @@
       </p>
 
       <div class="mt-5 rounded-lg bg-amber-50 ring-1 ring-amber-200 p-3">
-        <p class="text-xs font-medium text-amber-900">This application registered itself and is not verified.</p>
+        <p class="text-xs font-medium text-amber-900">This application is not verified.</p>
         <p class="mt-2 text-xs text-amber-800">If you approve, you will be sent to:</p>
         <p class="mt-1 break-all font-mono text-xs text-amber-900">%s</p>
         <p class="mt-2 text-xs text-amber-800">Only continue if you started this and recognise that address.</p>

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -240,7 +240,7 @@ func (s *Storage) GetClientByClientID(_ gocontext.Context, clientID string) (op.
 	if err != nil {
 		return nil, fmt.Errorf("unknown client: %w", err)
 	}
-	return &dynamicClient{id: clientID, metadata: metadata}, nil
+	return &metadataClient{id: clientID, metadata: metadata}, nil
 }
 
 func (s *Storage) AuthorizeClientIDSecret(_ gocontext.Context, _, _ string) error {

--- a/auth/oidc/storage.go
+++ b/auth/oidc/storage.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/flanksource/duty"
@@ -44,22 +45,28 @@ func (p *publicKey) Key() any                           { return p.key }
 
 // Storage implements op.Storage backed by Postgres.
 type Storage struct {
-	ctx       context.Context
-	signer    *signingKey
-	issuerURL string
+	ctx                      context.Context
+	signer                   *signingKey
+	issuerURL                string
+	clientIDMetadataResolver *clientIDMetadataResolver
 }
 
 var _ op.Storage = (*Storage)(nil)
 
 func NewStorage(ctx context.Context, signer *signingKey, issuerURL string) *Storage {
-	return &Storage{ctx: ctx, signer: signer, issuerURL: issuerURL}
+	return &Storage{
+		ctx:                      ctx,
+		signer:                   signer,
+		issuerURL:                issuerURL,
+		clientIDMetadataResolver: newClientIDMetadataResolver(),
+	}
 }
 
 func (s *Storage) Health(_ gocontext.Context) error { return nil }
 
-// deriveResource reconstructs the fixed MCP audience for stateless dynamic clients.
+// deriveResource reconstructs the fixed MCP audience for metadata-backed clients.
 func (s *Storage) deriveResource(clientID string) string {
-	if IsDynamicClient(clientID) {
+	if IsMetadataClient(clientID) {
 		return MCPResourceURL(s.issuerURL)
 	}
 	return ""
@@ -231,12 +238,20 @@ func (s *Storage) KeySet(_ gocontext.Context) ([]op.Key, error) {
 	return result, nil
 }
 
-func (s *Storage) GetClientByClientID(_ gocontext.Context, clientID string) (op.Client, error) {
+func (s *Storage) GetClientByClientID(ctx gocontext.Context, clientID string) (op.Client, error) {
 	if clientID == ClientID {
 		return &cliClient{}, nil
 	}
 
-	metadata, err := decodeClientID(clientID)
+	if strings.HasPrefix(clientID, dynamicClientIDPrefix) {
+		metadata, err := decodeClientID(clientID)
+		if err != nil {
+			return nil, fmt.Errorf("unknown client: %w", err)
+		}
+		return &metadataClient{id: clientID, metadata: metadata}, nil
+	}
+
+	metadata, err := s.clientIDMetadataResolver.resolve(ctx, clientID)
 	if err != nil {
 		return nil, fmt.Errorf("unknown client: %w", err)
 	}

--- a/auth/oidc_validate.go
+++ b/auth/oidc_validate.go
@@ -82,13 +82,13 @@ func authenticateOIDCToken(c echo.Context, tokenStr string) (bool, error) {
 	return false, nil
 }
 
-// oidcTokenAudienceAllowed confines dynamic-client credentials to the advertised MCP resource.
+// oidcTokenAudienceAllowed confines metadata-backed client credentials to the MCP resource.
 func oidcTokenAudienceAllowed(c echo.Context, claims jwt.MapClaims, issuer string) bool {
 	clientID, _ := claims["client_id"].(string)
 	if clientID == "" || clientID == oidcmodels.ClientID {
 		return audienceEquals(claims["aud"], oidcmodels.ClientID)
 	}
-	if !oidcmodels.IsDynamicClient(clientID) || c.Request().URL.Path != oidcmodels.MCPResourcePath {
+	if !oidcmodels.IsMetadataClient(clientID) || c.Request().URL.Path != oidcmodels.MCPResourcePath {
 		return false
 	}
 	return audienceEquals(claims["aud"], oidcmodels.MCPResourceURL(issuer))


### PR DESCRIPTION
Closes #3434.

MCP clients using URL-based client IDs could not complete OAuth because Mission Control only recognized its built-in client and encoded DCR metadata.

Advertise CIMD support and securely resolve public HTTPS client metadata with exact identity and redirect validation, bounded retrieval/cache behavior, and DNS-rebinding-resistant SSRF protection. Route CIMD clients through the existing public-client consent and MCP resource enforcement path while preserving DCR as a fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Client-Initiated Metadata (CIMD), allowing clients to provide metadata through securely retrieved documents.
  - Advertised CIMD support in OpenID Connect discovery metadata.
  - Unified CIMD and dynamic registration clients across authorization, consent, token, and resource validation flows.

- **Security**
  - Added HTTPS enforcement, SSRF protection, response limits, metadata validation, DNS rebinding safeguards, and bounded caching.
  - Revalidated client redirect URIs before displaying consent.

- **User Experience**
  - Updated the consent warning to state that the application is not verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->