### PR TITLE
fix(playbook): invalidate event subscription cache

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/flanksource/incident-commander/mcp"
 	"github.com/flanksource/incident-commander/metrics"
 	"github.com/flanksource/incident-commander/notification"
+	"github.com/flanksource/incident-commander/playbook"
 	"github.com/flanksource/incident-commander/plugin/machinery"
 	pluginReconciler "github.com/flanksource/incident-commander/plugin/reconciler"
 	"github.com/flanksource/incident-commander/upstream/tunnel"
@@ -41,7 +42,6 @@ import (
 	// register event handlers & echo routers
 	_ "github.com/flanksource/incident-commander/artifacts"
 	_ "github.com/flanksource/incident-commander/catalog"
-	_ "github.com/flanksource/incident-commander/playbook"
 	_ "github.com/flanksource/incident-commander/plugin/gateway"
 	_ "github.com/flanksource/incident-commander/shorturl"
 	_ "github.com/flanksource/incident-commander/snapshot"
@@ -343,6 +343,7 @@ func tableUpdatesHandler(ctx context.Context) {
 		case v := <-playbooksUpdateChan:
 			tgOperation, id := tableActivityPayload(v)
 			query.InvalidateCacheByID[models.Playbook](id)
+			playbook.PurgeEventCache()
 
 			if tgOperation == TGOPUpdate {
 				if err := rbac.ReloadPolicy(); err != nil {

--- a/db/playbooks.go
+++ b/db/playbooks.go
@@ -221,7 +221,7 @@ func FindPlaybooksForComponent(ctx context.Context, component models.Component) 
 
 func FindPlaybooksForEvent(ctx context.Context, eventClass, event string) ([]models.Playbook, error) {
 	var playbooks []models.Playbook
-	query := fmt.Sprintf(`SELECT * FROM playbooks WHERE spec->'on'->'%s' @> '[{"event": "%s"}]'`, eventClass, event)
+	query := fmt.Sprintf(`SELECT * FROM playbooks WHERE deleted_at IS NULL AND spec->'on'->'%s' @> '[{"event": "%s"}]'`, eventClass, event)
 	if err := ctx.DB().Raw(query).Scan(&playbooks).Error; err != nil {
 		return nil, err
 	}

--- a/playbook/events.go
+++ b/playbook/events.go
@@ -53,7 +53,7 @@ var eventToSpecEvent = map[string]PlaybookSpecEvent{
 }
 
 var (
-	eventPlaybooksCache = cache.New(time.Hour*1, time.Hour*1)
+	eventPlaybooksCache = cache.New(5*time.Minute, 10*time.Minute)
 
 	EventRing *events.EventRing
 )
@@ -436,6 +436,7 @@ func FindPlaybooksForEvent(ctx context.Context, eventClass, event string) ([]mod
 	return playbooks, nil
 }
 
-func clearEventPlaybookCache() {
+// PurgeEventCache clears cached event-to-playbook mappings.
+func PurgeEventCache() {
 	eventPlaybooksCache.Flush()
 }

--- a/playbook/events_test.go
+++ b/playbook/events_test.go
@@ -55,6 +55,7 @@ var _ = ginkgo.Describe("Playbook Events", ginkgo.Ordered, func() {
 
 			err = DefaultContext.DB().Clauses(clause.Returning{}).Create(&playbook).Error
 			Expect(err).NotTo(HaveOccurred())
+			PurgeEventCache()
 		})
 
 		ginkgo.AfterAll(func() {
@@ -153,6 +154,7 @@ var _ = ginkgo.Describe("Playbook Events", ginkgo.Ordered, func() {
 
 			err = DefaultContext.DB().Clauses(clause.Returning{}).Create(&playbook).Error
 			Expect(err).NotTo(HaveOccurred())
+			PurgeEventCache()
 		})
 
 		ginkgo.It("update health to something else other than unhealthy", func() {

--- a/playbook/run_consumer.go
+++ b/playbook/run_consumer.go
@@ -36,7 +36,6 @@ func (t *playbookRunError) Error() string {
 
 // Pg Notify channels for run and action updates
 const (
-	pgNotifyPlaybookSpecUpdated   = "playbook_spec_updated"
 	pgNotifyPlaybookRunUpdates    = "playbook_run_updates"
 	pgNotifyPlaybookActionUpdates = "playbook_action_updates"
 )
@@ -129,24 +128,16 @@ func StartPlaybookConsumers(ctx context.Context) error {
 			runUpdatesPGNotifyChannel         = make(chan string)
 			actionUpdatesPGNotifyChannel      = make(chan string)
 			actionAgentUpdatesPGNotifyChannel = make(chan string)
-			playbookSpecUpdatedChannel        = make(chan string)
 		)
 
 		go func() {
 			err := pg.ListenMany(ctx,
-				pg.ChannelListener{Channel: pgNotifyPlaybookSpecUpdated, Receiver: playbookSpecUpdatedChannel},
 				pg.ChannelListener{Channel: pgNotifyPlaybookRunUpdates, Receiver: runUpdatesPGNotifyChannel},
 				pg.ChannelListener{Channel: pgNotifyPlaybookActionUpdates, Receiver: actionUpdatesPGNotifyChannel},
 				pg.ChannelListener{Channel: pgNotifyPlaybookActionUpdates, Receiver: actionAgentUpdatesPGNotifyChannel},
 			)
 			if err != nil {
 				shutdown.ShutdownAndExit(1, fmt.Sprintf("failed to listen for postgres notifications: %v", err))
-			}
-		}()
-
-		go func() {
-			for range playbookSpecUpdatedChannel {
-				clearEventPlaybookCache()
 			}
 		}()
 


### PR DESCRIPTION
Event-triggered playbook subscriptions could stay stale because cache invalidation listened to a PostgreSQL channel that Duty does not emit. This could suppress matching playbook runs until TTL expiry.

Use the existing `table_activity` dispatcher to flush event mappings on playbook mutations, remove the dead listener, and reduce the fallback TTL. Event lookups now also exclude soft-deleted playbooks.

Fixes #3452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleted playbooks are no longer included when matching playbooks to events.
  - Playbook-related updates now refresh event results more reliably.
  - Changes to playbook configurations become visible sooner through improved cache expiration behavior.

- **Performance**
  - Event-based playbook information is refreshed more frequently, reducing the chance of displaying outdated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->