### PR TITLE
fix(mail): load system SMTP from DB on every send

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/flanksource/incident-commander/echo"
 	"github.com/flanksource/incident-commander/events"
 	"github.com/flanksource/incident-commander/jobs"
-	"github.com/flanksource/incident-commander/mail"
 	"github.com/flanksource/incident-commander/mcp"
 	"github.com/flanksource/incident-commander/metrics"
 	"github.com/flanksource/incident-commander/notification"
@@ -317,7 +316,6 @@ func tableUpdatesHandler(ctx context.Context) {
 	permissionGroupUpdateChan := notifyRouter.GetOrCreateChannel("permission_groups")
 	scopeUpdateChan := notifyRouter.GetOrCreateChannel("scopes")
 	teamMembersUpdateChan := notifyRouter.GetOrCreateChannel("team_members")
-	connectionsUpdateChan := notifyRouter.GetOrCreateChannel("connections")
 
 	// use a single job instance to maintain retention
 	pushPlaybookActionsJob := jobs.PushPlaybookActions(ctx)
@@ -446,9 +444,6 @@ func tableUpdatesHandler(ctx context.Context) {
 
 			// Invalidate view scope cache
 			views.FlushScopeCache()
-
-		case <-connectionsUpdateChan:
-			mail.FlushSMTPCache()
 		}
 	}
 }

--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -3,22 +3,15 @@ package mail
 import (
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
-	gocache "github.com/patrickmn/go-cache"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
 )
 
-const smtpCacheKey = "smtp"
-
-var (
-	smtpCache    = gocache.New(15*time.Minute, 10*time.Minute)
-	fallbackSMTP v1.ConnectionSMTP
-)
+var fallbackSMTP v1.ConnectionSMTP
 
 // SetFallbackSMTP is called during startup to set CLI flag values.
 func SetFallbackSMTP(fromAddress, fromName string) {
@@ -26,30 +19,17 @@ func SetFallbackSMTP(fromAddress, fromName string) {
 	fallbackSMTP.FromName = fromName
 }
 
-// FlushSMTPCache clears the cached SMTP connection.
-// Called by pg_notify handler when connections table is updated.
-func FlushSMTPCache() {
-	smtpCache.Flush()
-}
-
 // GetDefaultSMTP returns the system SMTP configuration.
-// Priority: DB connection named "smtp" > env vars > CLI flags
+// Priority: DB connection named "system" with type email, then env vars, then CLI flags.
 func GetDefaultSMTP(ctx context.Context) (v1.ConnectionSMTP, error) {
-	if cached, found := smtpCache.Get(smtpCacheKey); found {
-		return cached.(v1.ConnectionSMTP), nil
-	}
-
 	smtp, err := loadSMTPFromDB(ctx)
 	if err != nil {
 		return v1.ConnectionSMTP{}, err
 	} else if smtp != nil {
-		smtpCache.SetDefault(smtpCacheKey, *smtp)
 		return *smtp, nil
 	}
 
-	result := buildFallbackSMTP()
-	smtpCache.SetDefault(smtpCacheKey, result)
-	return result, nil
+	return buildFallbackSMTP(), nil
 }
 
 func loadSMTPFromDB(ctx context.Context) (*v1.ConnectionSMTP, error) {

--- a/notification/suite_test.go
+++ b/notification/suite_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/db"
 	"github.com/flanksource/incident-commander/events"
-	"github.com/flanksource/incident-commander/mail"
 )
 
 func TestNotifications(t *testing.T) {
@@ -249,7 +248,6 @@ func setupSystemSMTPConnection() {
 	}
 
 	Expect(db.PersistConnectionFromCRD(DefaultContext, systemSMTPConnection)).To(Succeed())
-	mail.FlushSMTPCache()
 }
 
 func cleanupSystemSMTPConnection() error {
@@ -257,7 +255,6 @@ func cleanupSystemSMTPConnection() error {
 		return nil
 	}
 
-	mail.FlushSMTPCache()
 	return DefaultContext.DB().
 		Where("name = ? AND type = ? AND deleted_at IS NULL", "system", models.ConnectionTypeEmail).
 		Delete(&models.Connection{}).

--- a/tests/e2e/setup_handlers_test.go
+++ b/tests/e2e/setup_handlers_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
 	"github.com/flanksource/incident-commander/db"
-	"github.com/flanksource/incident-commander/mail"
 )
 
 type fixtureContext struct {
@@ -157,7 +156,6 @@ func (h *smtpHandler) Handle(fctx *fixtureContext) {
 			},
 		}
 		Expect(db.PersistConnectionFromCRD(DefaultContext, h.conn)).To(Succeed())
-		mail.FlushSMTPCache()
 	})
 
 	h.backend.clear()
@@ -182,7 +180,6 @@ func (h *smtpHandler) Handle(fctx *fixtureContext) {
 }
 
 func (h *smtpHandler) Cleanup() {
-	mail.FlushSMTPCache()
 	if h.srv != nil {
 		_ = h.srv.Close()
 	}


### PR DESCRIPTION
Closes #3455

Updating or deleting the system email connection left Mission Control using the previous SMTP host/credentials for up to 15 minutes.

`GetDefaultSMTP` cached that row in process memory. Flushing depended on a `connections` `table_activity` notify, but Duty never installs that trigger, so the cache never cleared.

Drop the cache and load the current system email connection on each send. Email notifications and invite mail now pick up connection changes immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMTP configuration is now loaded from the database each time it is requested, ensuring current settings are used.
  * Environment variables and command-line settings remain available as fallbacks when no database configuration is found.
  * SMTP settings are no longer served from a potentially stale in-memory cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->