### PR TITLE
fix: prevent pg_notify cache fills from restoring stale values

### DIFF
--- a/auth/rls.go
+++ b/auth/rls.go
@@ -18,6 +18,7 @@ import (
 	"gorm.io/gorm"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/utils"
 	"github.com/flanksource/incident-commander/vars"
 )
 
@@ -26,8 +27,10 @@ func getRLSCacheKey(userID string) string {
 }
 
 func InvalidateRLSCacheForUser(userID string) {
-	cacheKey := getRLSCacheKey(userID)
-	tokenCache.Delete(cacheKey)
+	// RLS entries are keyed as rls-payload-<id> and rls-payload-<id>:<fingerprint>
+	// for impersonation. PostgREST JWTs also embed the RLS payload under a
+	// different key. Flush the shared token cache so none of those can linger.
+	FlushTokenCache()
 }
 
 func GetRLSPayload(ctx context.Context) (*rls.Payload, error) {
@@ -47,43 +50,28 @@ func GetRLSPayload(ctx context.Context) (*rls.Payload, error) {
 		cacheKey = fmt.Sprintf("%s:%s", cacheKey, impersonated.Fingerprint())
 	}
 
-	if cached, ok := tokenCache.Get(cacheKey); ok {
-		return cached.(*rls.Payload), nil
-	}
-
-	if roles, err := dutyRBAC.RolesForUser(ctx.User().ID.String()); err != nil {
-		return nil, err
-	} else if !lo.Contains(roles, policy.RoleGuest) {
-		payload := &rls.Payload{Disable: true}
-		if impersonated != nil {
-			result, err := applyImpersonation(payload, impersonated)
-			if err != nil {
-				return nil, err
-			}
-			tokenCache.SetDefault(cacheKey, result)
-			return result, nil
-		}
-		tokenCache.SetDefault(cacheKey, payload)
-		return payload, nil
-	}
-
-	// Build RLS payload from permissions and scopes
-	payload, err := buildRLSPayloadFromScopes(ctx)
-	if err != nil {
-		return nil, ctx.Oops().Wrap(err)
-	}
-
-	if impersonated != nil {
-		result, err := applyImpersonation(payload, impersonated)
-		if err != nil {
+	return utils.GetOrLoad(tokenCache, cacheKey, func() (*rls.Payload, error) {
+		if roles, err := dutyRBAC.RolesForUser(ctx.User().ID.String()); err != nil {
 			return nil, err
+		} else if !lo.Contains(roles, policy.RoleGuest) {
+			payload := &rls.Payload{Disable: true}
+			if impersonated != nil {
+				return applyImpersonation(payload, impersonated)
+			}
+			return payload, nil
 		}
-		tokenCache.SetDefault(cacheKey, result)
-		return result, nil
-	}
 
-	tokenCache.SetDefault(cacheKey, payload)
-	return payload, nil
+		payload, err := buildRLSPayloadFromScopes(ctx)
+		if err != nil {
+			return nil, ctx.Oops().Wrap(err)
+		}
+
+		if impersonated != nil {
+			return applyImpersonation(payload, impersonated)
+		}
+
+		return payload, nil
+	})
 }
 
 // WithRLS wraps a function with RLS enforcement in a transaction.

--- a/auth/tokens.go
+++ b/auth/tokens.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flanksource/incident-commander/auth/accesstoken"
 	"github.com/flanksource/incident-commander/auth/signing"
 	"github.com/flanksource/incident-commander/db"
+	"github.com/flanksource/incident-commander/utils"
 )
 
 func FlushTokenCache() {
@@ -33,7 +34,7 @@ func FlushTokenCache() {
 // - JWT for postgREST
 // - RLS payloads
 // - access tokens
-var tokenCache = cache.New(1*time.Hour, 1*time.Hour)
+var tokenCache = utils.NewGenCache(1*time.Hour, 1*time.Hour)
 
 // deletedTokensCache maintains a blacklist of deleted token IDs.
 // Required because tokenCache is keyed by the full token string, not the ID,
@@ -64,40 +65,37 @@ func GetOrCreateJWTToken(ctx context.Context, user *models.Person, sessionId str
 	config := api.DefaultConfig
 	key := sessionId + user.ID.String()
 
-	if token, exists := tokenCache.Get(key); exists {
-		return token.(string), nil
-	}
+	return utils.GetOrLoad(tokenCache, key, func() (string, error) {
+		now := time.Now()
 
-	now := time.Now()
+		// Postgrest makes this jwt available as a session parameter inside postgres.
+		// We inject the rls payload here and then access it inside postgres using request.jwt.claims parameter.
+		claims := jwt.MapClaims{
+			"aud":  string(signing.AudiencePostgREST),
+			"iss":  signing.Issuer,
+			"exp":  float64(now.Add(time.Hour).Unix()),
+			"iat":  float64(now.Unix()),
+			"role": config.Postgrest.DBRole,
+			"id":   user.ID.String(),
+		}
 
-	// Postgrest makes this jwt available as a session parameter inside postgres.
-	// We inject the rls payload here and then access it inside postgres using request.jwt.claims parameter.
-	claims := jwt.MapClaims{
-		"aud":  string(signing.AudiencePostgREST),
-		"iss":  signing.Issuer,
-		"exp":  float64(now.Add(time.Hour).Unix()),
-		"iat":  float64(now.Unix()),
-		"role": config.Postgrest.DBRole,
-		"id":   user.ID.String(),
-	}
+		if rlsPayload, err := GetRLSPayload(ctx.WithUser(user)); err != nil {
+			return "", ctx.Oops().Wrap(err)
+		} else if jwtClaim := rlsPayload.JWTClaims(); jwtClaim != nil {
+			claims = collections.MergeMap(claims, jwtClaim)
+		}
 
-	if rlsPayload, err := GetRLSPayload(ctx.WithUser(user)); err != nil {
-		return "", ctx.Oops().Wrap(err)
-	} else if jwtClaim := rlsPayload.JWTClaims(); jwtClaim != nil {
-		claims = collections.MergeMap(claims, jwtClaim)
-	}
+		token, err := newPostgRESTJWT(config.Postgrest, claims)
+		if err != nil {
+			return "", ctx.Oops().Wrap(err)
+		}
 
-	token, err := newPostgRESTJWT(config.Postgrest, claims)
-	if err != nil {
-		return "", ctx.Oops().Wrap(err)
-	}
+		if err := db.UpdateLastLogin(ctx, user.ID.String()); err != nil {
+			ctx.Errorf("Error updating last login for user[%s]: %v", user, err)
+		}
 
-	if err := db.UpdateLastLogin(ctx, user.ID.String()); err != nil {
-		ctx.Errorf("Error updating last login for user[%s]: %v", user, err)
-	}
-
-	tokenCache.SetDefault(key, token)
-	return token, nil
+		return token, nil
+	})
 }
 
 func newPostgRESTJWT(config api.PostgrestConfig, claims jwt.MapClaims) (string, error) {
@@ -137,7 +135,8 @@ func newClerkKeyfunc(jwksURL string) (jwt.Keyfunc, error) {
 }
 
 func getAccessToken(ctx context.Context, token string) (*models.AccessToken, error) {
-	if cachedToken, ok := tokenCache.Get(token); ok {
+	gen := tokenCache.Snapshot(token)
+	if cachedToken, ok := tokenCache.GetWith(gen, token); ok {
 		accessToken := cachedToken.(*models.AccessToken)
 
 		// Check if this token has been deleted (even if still in cache)
@@ -169,7 +168,7 @@ func getAccessToken(ctx context.Context, token string) (*models.AccessToken, err
 
 	expiry := accessToken.ExpiresAt
 	if expiry == nil {
-		tokenCache.Set(token, &accessToken, -1)
+		tokenCache.SetIf(gen, token, &accessToken, -1)
 	} else {
 		if expiry.Before(time.Now()) {
 			return nil, errTokenExpired
@@ -181,7 +180,7 @@ func getAccessToken(ctx context.Context, token string) (*models.AccessToken, err
 			}
 		}
 
-		tokenCache.Set(token, &accessToken, time.Until(*expiry))
+		tokenCache.SetIf(gen, token, &accessToken, time.Until(*expiry))
 	}
 
 	return &accessToken, nil

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -361,9 +361,7 @@ func tableUpdatesHandler(ctx context.Context) {
 		case v := <-teamsUpdateChan:
 			tgOperation, id := tableActivityPayload(v)
 
-			if tgOperation != TGOPInsert {
-				teams.PurgeCache(id)
-			}
+			teams.PurgeCache(id)
 
 			if tgOperation == TGOPDelete {
 				auth.FlushTokenCache()
@@ -390,23 +388,23 @@ func tableUpdatesHandler(ctx context.Context) {
 				if rbac.Enforcer() == nil {
 					break
 				}
-				auth.InvalidateRLSCacheForUser(personID)
 				if err := rbac.DeleteRoleForUser(personID, teamID); err != nil {
 					ctx.Errorf("failed to delete team(%s)->user(%s) rbac policy: %v", teamID, personID, err)
 				} else if err := rbac.ReloadPolicy(); err != nil {
 					ctx.Errorf("failed to reload rbac policy due to team_members updates: %v", err)
 				}
+				auth.InvalidateRLSCacheForUser(personID)
 
 			case TGOPInsert, TGOPUpdate:
 				if rbac.Enforcer() == nil {
 					break
 				}
-				auth.InvalidateRLSCacheForUser(personID)
 				if err := rbac.AddRoleForUser(personID, teamID); err != nil {
 					ctx.Errorf("failed to add team(%s)->user(%s) rbac policy: %v", teamID, personID, err)
 				} else if err := rbac.ReloadPolicy(); err != nil {
 					ctx.Errorf("failed to reload rbac policy due to team_members updates: %v", err)
 				}
+				auth.InvalidateRLSCacheForUser(personID)
 			}
 
 		case <-permissionUpdateChan:

--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -8,15 +8,15 @@ import (
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/google/uuid"
-	gocache "github.com/patrickmn/go-cache"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/utils"
 )
 
 const smtpCacheKey = "smtp"
 
 var (
-	smtpCache    = gocache.New(15*time.Minute, 10*time.Minute)
+	smtpCache    = utils.NewGenCache(15*time.Minute, 10*time.Minute)
 	fallbackSMTP v1.ConnectionSMTP
 )
 
@@ -35,21 +35,15 @@ func FlushSMTPCache() {
 // GetDefaultSMTP returns the system SMTP configuration.
 // Priority: DB connection named "smtp" > env vars > CLI flags
 func GetDefaultSMTP(ctx context.Context) (v1.ConnectionSMTP, error) {
-	if cached, found := smtpCache.Get(smtpCacheKey); found {
-		return cached.(v1.ConnectionSMTP), nil
-	}
-
-	smtp, err := loadSMTPFromDB(ctx)
-	if err != nil {
-		return v1.ConnectionSMTP{}, err
-	} else if smtp != nil {
-		smtpCache.SetDefault(smtpCacheKey, *smtp)
-		return *smtp, nil
-	}
-
-	result := buildFallbackSMTP()
-	smtpCache.SetDefault(smtpCacheKey, result)
-	return result, nil
+	return utils.GetOrLoad(smtpCache, smtpCacheKey, func() (v1.ConnectionSMTP, error) {
+		smtp, err := loadSMTPFromDB(ctx)
+		if err != nil {
+			return v1.ConnectionSMTP{}, err
+		} else if smtp != nil {
+			return *smtp, nil
+		}
+		return buildFallbackSMTP(), nil
+	})
 }
 
 func loadSMTPFromDB(ctx context.Context) (*v1.ConnectionSMTP, error) {

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -10,14 +10,14 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/incident-commander/api"
 	v1 "github.com/flanksource/incident-commander/api/v1"
-	"github.com/patrickmn/go-cache"
+	"github.com/flanksource/incident-commander/utils"
 )
 
 var (
-	notificationByIDCache = cache.New(time.Hour*12, time.Hour*1)
+	notificationByIDCache = utils.NewGenCache(time.Hour*12, time.Hour*1)
 
 	// a separate cache because we purge the caches in two different ways.
-	notificationByEventCache = cache.New(time.Hour*12, time.Hour*1)
+	notificationByEventCache = utils.NewGenCache(time.Hour*12, time.Hour*1)
 )
 
 func PurgeCache(notificationID string) {
@@ -28,17 +28,13 @@ func PurgeCache(notificationID string) {
 // GetNotificationIDsForEvent returns ids of all the notifications
 // that are watching the given event.
 func GetNotificationIDsForEvent(ctx context.Context, eventName string) ([]string, error) {
-	if val, found := notificationByEventCache.Get(eventName); found {
-		return val.([]string), nil
-	}
-
-	var ids []string
-	if err := ctx.DB().Model(&models.Notification{}).Where("deleted_at IS NULL").Where("? = ANY(events)", eventName).Pluck("id", &ids).Error; err != nil {
-		return nil, err
-	}
-	notificationByEventCache.Set(eventName, ids, cache.DefaultExpiration)
-
-	return ids, nil
+	return utils.GetOrLoad(notificationByEventCache, eventName, func() ([]string, error) {
+		var ids []string
+		if err := ctx.DB().Model(&models.Notification{}).Where("deleted_at IS NULL").Where("? = ANY(events)", eventName).Pluck("id", &ids).Error; err != nil {
+			return nil, err
+		}
+		return ids, nil
+	})
 }
 
 // A wrapper around notification that also contains the custom notifications.
@@ -52,32 +48,13 @@ type NotificationWithSpec struct {
 }
 
 func GetNotification(ctx context.Context, id string) (*NotificationWithSpec, error) {
-	if val, found := notificationByIDCache.Get(id); found {
-		return val.(*NotificationWithSpec), nil
-	}
+	return utils.GetOrLoad(notificationByIDCache, id, func() (*NotificationWithSpec, error) {
+		var n models.Notification
+		if err := ctx.DB().Where("id = ?", id).Find(&n).Error; err != nil {
+			return nil, err
+		}
 
-	var n models.Notification
-	if err := ctx.DB().Where("id = ?", id).Find(&n).Error; err != nil {
-		return nil, err
-	}
-
-	b, err := json.Marshal(n.CustomServices)
-	if err != nil {
-		return nil, err
-	}
-
-	var customNotifications []api.NotificationConfig
-	if err := json.Unmarshal(b, &customNotifications); err != nil {
-		return nil, err
-	}
-
-	data := NotificationWithSpec{
-		Notification:        n,
-		CustomNotifications: customNotifications,
-	}
-
-	if len(n.FallbackCustomServices) > 0 {
-		b, err := json.Marshal(n.FallbackCustomServices)
+		b, err := json.Marshal(n.CustomServices)
 		if err != nil {
 			return nil, err
 		}
@@ -87,26 +64,41 @@ func GetNotification(ctx context.Context, id string) (*NotificationWithSpec, err
 			return nil, err
 		}
 
-		if len(customNotifications) > 0 {
-			data.FallbackCustomNotification = &customNotifications[0]
+		data := NotificationWithSpec{
+			Notification:        n,
+			CustomNotifications: customNotifications,
 		}
-	}
 
-	if n.RepeatInterval != "" {
-		interval, err := text.ParseDuration(n.RepeatInterval)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing repeat interval[%s] to time.Duration: %w", n.RepeatInterval, err)
+		if len(n.FallbackCustomServices) > 0 {
+			b, err := json.Marshal(n.FallbackCustomServices)
+			if err != nil {
+				return nil, err
+			}
+
+			var customNotifications []api.NotificationConfig
+			if err := json.Unmarshal(b, &customNotifications); err != nil {
+				return nil, err
+			}
+
+			if len(customNotifications) > 0 {
+				data.FallbackCustomNotification = &customNotifications[0]
+			}
 		}
-		data.RepeatInterval = interval
-	}
 
-	if len(n.Inhibitions) > 0 {
-		if err := json.Unmarshal(n.Inhibitions, &data.Inhibitions); err != nil {
-			return nil, fmt.Errorf("error parsing inhibitions[%s] to NotificationInihibition: %w", n.Inhibitions, err)
+		if n.RepeatInterval != "" {
+			interval, err := text.ParseDuration(n.RepeatInterval)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing repeat interval[%s] to time.Duration: %w", n.RepeatInterval, err)
+			}
+			data.RepeatInterval = interval
 		}
-	}
 
-	notificationByIDCache.Set(id, &data, cache.DefaultExpiration)
+		if len(n.Inhibitions) > 0 {
+			if err := json.Unmarshal(n.Inhibitions, &data.Inhibitions); err != nil {
+				return nil, fmt.Errorf("error parsing inhibitions[%s] to NotificationInihibition: %w", n.Inhibitions, err)
+			}
+		}
 
-	return &data, nil
+		return &data, nil
+	})
 }

--- a/playbook/events.go
+++ b/playbook/events.go
@@ -14,7 +14,6 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/gomplate/v3"
 	"github.com/google/uuid"
-	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 
 	"github.com/flanksource/incident-commander/api"
@@ -53,7 +52,7 @@ var eventToSpecEvent = map[string]PlaybookSpecEvent{
 }
 
 var (
-	eventPlaybooksCache = cache.New(5*time.Minute, 10*time.Minute)
+	eventPlaybooksCache = utils.NewGenCache(5*time.Minute, 10*time.Minute)
 
 	EventRing *events.EventRing
 )
@@ -423,17 +422,9 @@ func onPlaybookRunNewApproval(ctx context.Context, event models.Event) error {
 }
 
 func FindPlaybooksForEvent(ctx context.Context, eventClass, event string) ([]models.Playbook, error) {
-	if playbooks, found := eventPlaybooksCache.Get(eventPlaybookCacheKey(eventClass, event)); found {
-		return playbooks.([]models.Playbook), nil
-	}
-
-	playbooks, err := db.FindPlaybooksForEvent(ctx, eventClass, event)
-	if err != nil {
-		return nil, err
-	}
-
-	eventPlaybooksCache.SetDefault(eventPlaybookCacheKey(eventClass, event), playbooks)
-	return playbooks, nil
+	return utils.GetOrLoad(eventPlaybooksCache, eventPlaybookCacheKey(eventClass, event), func() ([]models.Playbook, error) {
+		return db.FindPlaybooksForEvent(ctx, eventClass, event)
+	})
 }
 
 // PurgeEventCache clears cached event-to-playbook mappings.

--- a/teams/teams.go
+++ b/teams/teams.go
@@ -10,11 +10,11 @@ import (
 	"github.com/flanksource/duty/types"
 	"github.com/flanksource/incident-commander/api"
 	"github.com/flanksource/incident-commander/db/models"
+	"github.com/flanksource/incident-commander/utils"
 	"github.com/google/uuid"
-	"github.com/patrickmn/go-cache"
 )
 
-var teamSpecCache = cache.New(time.Hour*1, time.Hour*1)
+var teamSpecCache = utils.NewGenCache(time.Hour*1, time.Hour*1)
 
 func GetTeamComponentsFromSelectors(ctx context.Context, teamID uuid.UUID, componentSelectors []types.ResourceSelector) ([]api.TeamComponent, error) {
 	var selectedComponents = make(map[string][]uuid.UUID)
@@ -45,28 +45,24 @@ func GetTeamComponentsFromSelectors(ctx context.Context, teamID uuid.UUID, compo
 }
 
 func GetTeamSpec(ctx context.Context, id string) (*api.TeamSpec, error) {
-	if val, found := teamSpecCache.Get(id); found {
-		return val.(*api.TeamSpec), nil
-	}
+	return utils.GetOrLoad(teamSpecCache, id, func() (*api.TeamSpec, error) {
+		var team models.Team
+		if err := ctx.DB().Where("id = ?", id).Find(&team).Error; err != nil {
+			return nil, err
+		}
 
-	var team models.Team
-	if err := ctx.DB().Where("id = ?", id).Find(&team).Error; err != nil {
-		return nil, err
-	}
+		b, err := json.Marshal(team.Spec)
+		if err != nil {
+			return nil, err
+		}
 
-	b, err := json.Marshal(team.Spec)
-	if err != nil {
-		return nil, err
-	}
+		var teamSpec api.TeamSpec
+		if err := json.Unmarshal(b, &teamSpec); err != nil {
+			return nil, err
+		}
 
-	var teamSpec api.TeamSpec
-	if err := json.Unmarshal(b, &teamSpec); err != nil {
-		return nil, err
-	}
-
-	teamSpecCache.Set(id, &teamSpec, cache.DefaultExpiration)
-
-	return &teamSpec, nil
+		return &teamSpec, nil
+	})
 }
 
 func PurgeCache(id string) {

--- a/utils/gencache.go
+++ b/utils/gencache.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+// CacheGen is a snapshot of a GenCache's generation for a key.
+// Fillers capture it before reading the database and pass it to SetIf so a
+// concurrent invalidation cannot be overwritten by a stale result.
+type CacheGen struct {
+	global uint64
+	local  uint64
+}
+
+// GenCache is an in-process TTL cache that folds a generation counter into keys.
+// Flush increments a cache-wide generation; Delete increments a per-key generation.
+// Lookups always use the current generation, so a fill that raced with invalidation
+// cannot store a value later reads will see.
+type GenCache struct {
+	cache *gocache.Cache
+
+	mu   sync.Mutex
+	gen  uint64
+	keys map[string]uint64
+}
+
+// NewGenCache creates a generation-aware cache with the given default TTL and
+// expired-entry cleanup interval.
+func NewGenCache(defaultExpiration, cleanupInterval time.Duration) *GenCache {
+	return &GenCache{
+		cache: gocache.New(defaultExpiration, cleanupInterval),
+		keys:  make(map[string]uint64),
+	}
+}
+
+func (c *GenCache) stampedKey(gen CacheGen, key string) string {
+	return fmt.Sprintf("%d:%d:%s", gen.global, gen.local, key)
+}
+
+func (c *GenCache) snapshotLocked(key string) CacheGen {
+	return CacheGen{global: c.gen, local: c.keys[key]}
+}
+
+// Snapshot returns the current generation for key. Capture it before a cache-fill
+// database read and pass it to SetIf.
+func (c *GenCache) Snapshot(key string) CacheGen {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.snapshotLocked(key)
+}
+
+// Get returns the cached value for key at the current generation.
+func (c *GenCache) Get(key string) (any, bool) {
+	return c.GetWith(c.Snapshot(key), key)
+}
+
+// GetWith returns the cached value for key at gen.
+func (c *GenCache) GetWith(gen CacheGen, key string) (any, bool) {
+	return c.cache.Get(c.stampedKey(gen, key))
+}
+
+// SetIf stores value under key only if gen is still current.
+func (c *GenCache) SetIf(gen CacheGen, key string, value any, d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.gen != gen.global || c.keys[key] != gen.local {
+		return
+	}
+	c.cache.Set(c.stampedKey(gen, key), value, d)
+}
+
+// Delete invalidates a single key so in-flight fills for that key cannot restore it.
+func (c *GenCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache.Delete(c.stampedKey(c.snapshotLocked(key), key))
+	c.keys[key]++
+}
+
+// Flush invalidates every entry so in-flight fills cannot restore purged values.
+func (c *GenCache) Flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gen++
+	c.cache.Flush()
+	c.keys = make(map[string]uint64)
+}
+
+// GetOrLoad returns the cached value for key, or calls load on a miss.
+// If the cache is invalidated while load runs, the result is returned but not stored.
+func GetOrLoad[T any](c *GenCache, key string, load func() (T, error)) (T, error) {
+	return GetOrLoadExpire(c, key, gocache.DefaultExpiration, load)
+}
+
+// GetOrLoadExpire is GetOrLoad with an explicit TTL.
+func GetOrLoadExpire[T any](c *GenCache, key string, expire time.Duration, load func() (T, error)) (T, error) {
+	gen := c.Snapshot(key)
+	if v, ok := c.GetWith(gen, key); ok {
+		return v.(T), nil
+	}
+
+	v, err := load()
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	c.SetIf(gen, key, v, expire)
+	return v, nil
+}

--- a/views/scopes.go
+++ b/views/scopes.go
@@ -10,9 +10,9 @@ import (
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/types"
 	pkgView "github.com/flanksource/duty/view"
-	gocache "github.com/patrickmn/go-cache"
 
 	v1 "github.com/flanksource/incident-commander/api/v1"
+	"github.com/flanksource/incident-commander/utils"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 	scopeConfigsCacheKey = "scope-configs-with-targets"
 )
 
-var scopeCache = gocache.New(defaultScopeCacheTTL, defaultScopeCacheTTL*2)
+var scopeCache = utils.NewGenCache(defaultScopeCacheTTL, defaultScopeCacheTTL*2)
 
 func FlushScopeCache() {
 	scopeCache.Flush()
@@ -33,63 +33,60 @@ type scopeConfig struct {
 
 // getScopeConfigs returns cached scope configs with config/global targets.
 func getScopeConfigs(ctx context.Context) ([]scopeConfig, error) {
-	if cached, found := scopeCache.Get(scopeConfigsCacheKey); found {
-		return cached.([]scopeConfig), nil
-	}
-
-	var scopes []models.Scope
-	if err := ctx.DB().
-		Where("deleted_at IS NULL").
-		Find(&scopes).Error; err != nil {
-		return nil, fmt.Errorf("failed to load scopes: %w", err)
-	}
-
-	var scopeConfigs []scopeConfig
-	for _, scope := range scopes {
-		if len(scope.Targets) == 0 {
-			continue
+	return utils.GetOrLoad(scopeCache, scopeConfigsCacheKey, func() ([]scopeConfig, error) {
+		var scopes []models.Scope
+		if err := ctx.DB().
+			Where("deleted_at IS NULL").
+			Find(&scopes).Error; err != nil {
+			return nil, fmt.Errorf("failed to load scopes: %w", err)
 		}
 
-		var targets []v1.ScopeTarget
-		if err := json.Unmarshal(scope.Targets, &targets); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal targets for scope %s: %w", scope.ID, err)
-		}
+		var scopeConfigs []scopeConfig
+		for _, scope := range scopes {
+			if len(scope.Targets) == 0 {
+				continue
+			}
 
-		var selectors []types.ResourceSelector
-		for _, target := range targets {
-			var selector *types.ResourceSelector
-			switch {
-			case target.Config != nil:
-				selector = &types.ResourceSelector{
-					Agent:       target.Config.Agent,
-					Name:        target.Config.Name,
-					Namespace:   target.Config.Namespace,
-					TagSelector: target.Config.TagSelector,
+			var targets []v1.ScopeTarget
+			if err := json.Unmarshal(scope.Targets, &targets); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal targets for scope %s: %w", scope.ID, err)
+			}
+
+			var selectors []types.ResourceSelector
+			for _, target := range targets {
+				var selector *types.ResourceSelector
+				switch {
+				case target.Config != nil:
+					selector = &types.ResourceSelector{
+						Agent:       target.Config.Agent,
+						Name:        target.Config.Name,
+						Namespace:   target.Config.Namespace,
+						TagSelector: target.Config.TagSelector,
+					}
+				case target.Global != nil:
+					selector = &types.ResourceSelector{
+						Agent:       target.Global.Agent,
+						Name:        target.Global.Name,
+						Namespace:   target.Global.Namespace,
+						TagSelector: target.Global.TagSelector,
+					}
 				}
-			case target.Global != nil:
-				selector = &types.ResourceSelector{
-					Agent:       target.Global.Agent,
-					Name:        target.Global.Name,
-					Namespace:   target.Global.Namespace,
-					TagSelector: target.Global.TagSelector,
+
+				if selector != nil {
+					selectors = append(selectors, *selector)
 				}
 			}
 
-			if selector != nil {
-				selectors = append(selectors, *selector)
+			if len(selectors) > 0 {
+				scopeConfigs = append(scopeConfigs, scopeConfig{
+					scopeID:   scope.ID.String(),
+					selectors: selectors,
+				})
 			}
 		}
 
-		if len(selectors) > 0 {
-			scopeConfigs = append(scopeConfigs, scopeConfig{
-				scopeID:   scope.ID.String(),
-				selectors: selectors,
-			})
-		}
-	}
-
-	scopeCache.SetDefault(scopeConfigsCacheKey, scopeConfigs)
-	return scopeConfigs, nil
+		return scopeConfigs, nil
+	})
 }
 
 // computeGrantsForConfigResults computes scope grants for each row in config query results


### PR DESCRIPTION
`table_activity` invalidation could be undone when a cache miss was already in flight: the handler purged an empty key, then the stale SELECT result was stored until TTL (up to 12 hours for notifications, 1 hour for RLS/JWT). Permission and notification changes could therefore fail to take effect even though the notify was delivered.

Folds a generation counter into cache keys via a shared helper so `Flush` and `Delete` make in-flight `SetIf` writes invisible. Per-user RLS invalidation now flushes the shared token cache (impersonated payloads and PostgREST JWTs share it), team-member invalidation runs after RBAC reload, and team specs are purged on insert as well as update/delete.

Fixes #3454

Duty's `getterCache` still has this race inside `query.findEntityByField`; that needs a Duty-side change and a dependency bump.